### PR TITLE
Add sig-autoscaling-leads to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+- sig-autoscaling-leads
 - aleksandra-malinowska
 - BigDarkClown
 - towca

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,6 @@
+aliases:
+  sig-autoscaling-leads:
+    - adrianmoisey
+    - jackfrancis
+    - omerap12
+    - towca


### PR DESCRIPTION
All SIG Autoscaling projects should have sig-autoscaling-leads in the OWNERS. I accidentally removed it when I changed the OWNERS in this repo to point to the cluster-autoscaler/OWNERS file from kubernetes/autoscaler.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```