### PR TITLE
Update README.md to reflect that the main part of core CA logic migration is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,33 @@
-# [WIP] cluster-autoscaler
+# cluster-autoscaler
 
-This repo is intended to host the provider-agnostic core logic for Kubernetes Cluster Autoscaler, including the cluster snapshot, scale-up/down decision logic, and external/test provider interfaces.
+This repo hosts the provider-agnostic core logic for Kubernetes Cluster Autoscaler, including the cluster snapshot, scale-up/down decision logic, and external/test provider implementations.
 
 Cluster Autoscaler originally started out in [the kubernetes/autoscaler repo](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler), with provider-agnostic core logic
-combined with provider-specific logic. This original repo is intended to keep hosting the provider-specific logic and import the core CA logic from here to form a complete Cluster Autoscaler component.
+combined with provider-specific logic. That original repo keeps hosting the provider-specific logic, and imports the core CA logic from here to form a complete Cluster Autoscaler component.
+
+The core Cluster Autoscaler logic in this repo is essentially a framework - it determines the overall code flow, and
+exposes code hooks that allow injecting custom logic in certain parts of the flow (in particular provider-specific logic).
+
+The eventual goal is for the core CA logic in this repo to form a proper library, exposing only the "building blocks" - without dictating how the code flows
+between them. This change is expected to take significant time, and can be tracked in https://github.com/kubernetes/autoscaler/issues/9264.
 
 ---
-**WARNING:** The migration of core Cluster Autoscaler logic from [kubernetes/autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to this repo is still in progress, and can be tracked
-in the following issues:
-* Full migration - including refactoring the core Cluster Autoscaler logic into a proper library: https://github.com/kubernetes/autoscaler/issues/9264
-* First steps - just a mechanical split of existing Cluster Autoscaler logic between the two repos: https://github.com/kubernetes/autoscaler/issues/9832
+**WARNING: parts of this repo are still WIP** 
 
-Until the first mechanical steps of the migration are completed, some files might be duplicated between the two repositories. This should be very temporary.
+This repo is still in the last steps of being split away from [the kubernetes/autoscaler repo](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
 
-Until the full migration is completed, the core Cluster Autoscaler logic hosted here doesn't really form a proper library - it's more of a framework pattern, with
-years of tech debt from the old repo. The full migration is expected to take considerable time.
+Most of the files/directories have already been split and are in the correct repo, but some are temporarily duplicated between the 2 repos. If you want to modify any of the following paths, you must do so in the other repo - the files here are just mirrors:
+* `pkg/apis`
+* `pkg/cloudprovider/azure`
+* `pkg/cloudprovider/gce`
+* `pkg/proposals` and other files containing documentation
+
+The structure of the files in the repo is still being worked on as well - in particular `pkg/` still contains a bunch of non-Go files. These will be moved to other places soon,
+the intention is for `pkg/` to only contain Go code.
+
+This state should be very temporary, the migration can be tracked in https://github.com/kubernetes/autoscaler/issues/9832.
+
+The repo is otherwise fully functional, further changes to core Cluster Autoscaler logic should happen via PRs here.
 
 ---
 


### PR DESCRIPTION
Further changes to core CA logic should happen as PRs in this repo, changed the README.md wording to reflect that.

There are still some steps to complete for the migration, explained the caveats around this temporary state in the WARNING section.

/kind documentation

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```