### PR TITLE
Add Choraden to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
 reviewers:
 - aleksandra-malinowska
 - BigDarkClown
+- Choraden
 - x13n
 - elmiko
 - mtrqq


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Self-nominate Choraden to the reviewers as per https://github.com/kubernetes/community/blob/main/community-membership.md#requirements-1


#### Requirements 

- [x] Member for at least 3 months (Since [March 2026](https://github.com/kubernetes/org/issues/6157))
- [x] Primary reviewer for at least 5 PRs to the codebase
    - https://github.com/kubernetes/autoscaler/pull/9661
    - https://github.com/kubernetes/autoscaler/pull/9543
    - https://github.com/kubernetes/autoscaler/pull/9376  
    - https://github.com/kubernetes/autoscaler/pull/9887
    - https://github.com/kubernetes/autoscaler/pull/9640
- [x] Reviewed or merged at least 20 substantial PRs to the codebase
    - reviewed (old repo): https://github.com/kubernetes/autoscaler/pulls?q=is%3Amerged+is%3Apr+assignee%3AChoraden+-label%3Asize%2FXS+-label%3Asize%2FS
    - authored (old repo): https://github.com/kubernetes/autoscaler/pulls?q=is%3Amerged+is%3Apr+author%3AChoraden+-label%3Asize%2FXS+-label%3Asize%2FS
    - authored (new repo) https://github.com/kubernetes-sigs/cluster-autoscaler/pulls?q=is%3Apr+is%3Amerged+author%3AChoraden+-label%3Asize%2FXS+-label%3Asize%2FS

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
