### PR TITLE
Benchmarking scaledown strategies

### DIFF
--- a/pkg/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
+++ b/pkg/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+	testprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	cacontext "sigs.k8s.io/cluster-autoscaler/pkg/context"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/bench/scaledown/efficiency/metrics"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/budgets"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/planner"
+	. "sigs.k8s.io/cluster-autoscaler/pkg/core/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/processors"
+	processorstest "sigs.k8s.io/cluster-autoscaler/pkg/processors/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/resourcequotas"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/options"
+	kubeutil "sigs.k8s.io/cluster-autoscaler/pkg/utils/kubernetes"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+// scaleDownScenario packs initialClusterState, metricsTracker, and optional config.AutoscalingOptions into one struct for individual scaledown run execution.
+type scaleDownScenario struct {
+	Name                 string
+	InitialClusterState  *initialClusterState
+	MetricsTracker       *metrics.Tracker
+	AutoscalingOptsSetup func(opts *config.AutoscalingOptions)
+}
+
+type scaleDownDependencies struct {
+	AutoscalingCtx *cacontext.AutoscalingContext
+	Processors     *processors.AutoscalingProcessors
+	Planner        *planner.Planner
+	Actuator       *fakeActuator
+	MetricsTracker *metrics.Tracker
+}
+
+func defaultAutoscalingOptions() config.AutoscalingOptions {
+	return config.AutoscalingOptions{
+		ScaleDownEnabled:           true,
+		MaxScaleDownParallelism:    1,
+		MaxDrainParallelism:        1,
+		ScaleDownSimulationTimeout: 10 * time.Second,
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			ScaleDownUtilizationThreshold: 1.0,
+			ScaleDownUnneededTime:         0,
+		},
+	}
+}
+
+func buildScaleDownDependencies(b *testing.B, cs *initialClusterState, autoscalingOpts config.AutoscalingOptions) scaleDownDependencies {
+	b.Helper()
+	var allNodes []*apiv1.Node
+	var allPods []*apiv1.Pod
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+
+	for _, ng := range cs.NodeGroups {
+		allNodes = append(allNodes, ng.Nodes...)
+		allPods = append(allPods, ng.Pods...)
+		provider.AddNodeGroupWithCustomOptions(ng.Name, ng.MinSize, ng.MaxSize, len(ng.Nodes), ng.NodeGroupOptions)
+		for _, node := range ng.Nodes {
+			provider.AddNode(ng.Name, node)
+		}
+	}
+
+	procs, templateRegistry := processorstest.NewTestProcessors(autoscalingOpts)
+	registry := kubeutil.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(autoscalingOpts, &fake.Clientset{}, registry, provider, nil, nil, templateRegistry)
+	if err != nil {
+		b.Fatalf("failed to instantiate AutoscalingContext: %v", err)
+	}
+	clustersnapshot.InitializeClusterSnapshotOrDie(b, autoscalingCtx.ClusterSnapshot, allNodes, allPods)
+
+	a := NewFakeActuator(autoscalingCtx, &fakeActuationStatus{})
+	factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: procs.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+	p := planner.New(&autoscalingCtx, procs, options.NodeDeleteOptions{}, nil, factory)
+
+	return scaleDownDependencies{
+		AutoscalingCtx: &autoscalingCtx,
+		Processors:     procs,
+		Planner:        p,
+		Actuator:       a,
+	}
+}
+
+// Crucial to pass -benchtime=1x to let the Loop know to run scaledown strategy exactly once.
+func (scenario scaleDownScenario) run(b *testing.B) {
+	opts := defaultAutoscalingOptions()
+	if scenario.AutoscalingOptsSetup != nil {
+		scenario.AutoscalingOptsSetup(&opts)
+	}
+	mt := scenario.MetricsTracker
+	sdDeps := buildScaleDownDependencies(b, scenario.InitialClusterState, opts)
+
+	nodeInfos, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	if err != nil {
+		b.Fatalf("failed to list node infos from snapshot: %s", err.Error())
+	}
+
+	mt.ComputeMetrics(metrics.NewClusterState(nil, nodeInfos, time.Now()), b)
+
+	var scaleDownCandidates []*apiv1.Node
+	var podDestinations []*apiv1.Node
+
+	for scaleDownLoop := 0; ; scaleDownLoop++ {
+		infos, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
+		if err != nil {
+			b.Fatalf("error retrieving nodes from cluster snapshot, err %s", err.Error())
+		}
+
+		var nodes []*apiv1.Node
+		for _, nodeInfo := range infos {
+			nodes = append(nodes, nodeInfo.Node())
+		}
+
+		if sdDeps.Processors == nil || sdDeps.Processors.ScaleDownNodeProcessor == nil {
+			scaleDownCandidates = nodes
+			podDestinations = nodes
+		} else {
+			scaleDownCandidates, err = sdDeps.Processors.ScaleDownNodeProcessor.GetScaleDownCandidates(
+				sdDeps.AutoscalingCtx, nodes)
+			if err != nil {
+				b.Fatalf("error getting scale-down candidates: %s", err.Error())
+			}
+			podDestinations, err = sdDeps.Processors.ScaleDownNodeProcessor.GetPodDestinationCandidates(sdDeps.AutoscalingCtx, nodes)
+			if err != nil {
+				b.Fatalf("error getting pod destination candidates: %s", err.Error())
+			}
+		}
+
+		currentTime := time.Now()
+		err = sdDeps.Planner.UpdateClusterState(podDestinations, scaleDownCandidates, sdDeps.Actuator.actuationStatus, currentTime)
+		if err != nil {
+			b.Fatalf("error updating cluster state: %s", err.Error())
+		}
+
+		empty, needDrain := sdDeps.Planner.NodesToDelete(currentTime)
+
+		budgetProcessor := budgets.NewScaleDownBudgetProcessor(sdDeps.AutoscalingCtx)
+		emptyGrouped, drainGrouped := budgetProcessor.CropNodes(sdDeps.Actuator.actuationStatus, empty, needDrain)
+
+		empty = []*apiv1.Node{}
+		for _, group := range emptyGrouped {
+			empty = append(empty, group.Nodes...)
+		}
+
+		needDrain = []*apiv1.Node{}
+		for _, group := range drainGrouped {
+			needDrain = append(needDrain, group.Nodes...)
+		}
+
+		// No more nodes to delete, final state reached.
+		if len(empty) == 0 && len(needDrain) == 0 {
+			b.ReportMetric(float64(scaleDownLoop), "loops")
+			break
+		}
+		_, scaledDownNodes, typedErr := sdDeps.Actuator.startDeletion(empty, needDrain)
+		if typedErr != nil {
+			b.Fatalf("error processing nodes in fake actuator, err %s", typedErr.Error())
+		}
+		ni, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
+		if err != nil {
+			b.Fatalf("error listing node infos: %s", err.Error())
+		}
+
+		mt.ComputeMetrics(metrics.NewClusterState(scaledDownNodes, ni, currentTime), b)
+	}
+	mt.ReportToBenchmark(b)
+}
+
+func BenchmarkScaledownEfficiency(b *testing.B) {
+	s := scaleDownScenario{
+		Name:                "three ng, basic setup",
+		InitialClusterState: differentNodeSizesMemIrrelevant(),
+		MetricsTracker: metrics.NewTracker(
+			metrics.NewResourceUtilizationMetric(apiv1.ResourceCPU),
+			metrics.NewResourceUtilizationMetric(apiv1.ResourceMemory),
+		),
+		AutoscalingOptsSetup: func(opts *config.AutoscalingOptions) {
+			opts.NodeGroupDefaults.ScaleDownUtilizationThreshold = 0.75
+		},
+	}
+	s.run(b)
+}

--- a/pkg/core/bench/scaledown/efficiency/clusterstate_factory.go
+++ b/pkg/core/bench/scaledown/efficiency/clusterstate_factory.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	testutils "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+// cloudProviderMockOptions overrides constraints enforced by the cloud provider infrastructure.
+type cloudProviderMockOptions struct {
+	NodeToNodeGroup   map[string]string
+	NodeGroupMinSizes map[string]int
+}
+
+// nodeGroup represents a named node group with Nodes and Pods.
+type nodeGroup struct {
+	Name    string
+	MinSize int
+	MaxSize int
+	Nodes   []*apiv1.Node
+	Pods    []*apiv1.Pod
+
+	// Optional node group overrides to customize autoscaling of a given nodeGroup.
+	NodeGroupOptions *config.NodeGroupAutoscalingOptions
+}
+
+type initialClusterState struct {
+	Name                 string
+	NodeGroups           []*nodeGroup
+	CloudProviderOptions *cloudProviderMockOptions
+}
+
+func differentNodeSizesMemIrrelevant() *initialClusterState {
+	return &initialClusterState{
+		Name: "different node sizes, memory irrelevant",
+		NodeGroups: []*nodeGroup{
+			{
+				Name:    "ng-small",
+				MinSize: 0,
+				MaxSize: 10,
+				Nodes: []*apiv1.Node{
+					testutils.BuildTestNode("small-node-1", 1000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "s-class"})),
+					testutils.BuildTestNode("small-node-2", 1000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "s-class"})),
+				},
+				Pods: []*apiv1.Pod{
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-s1", 1000, 100, "small-node-1"), "rs"),
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-s2", 1000, 100, "small-node-2"), "rs"),
+				},
+			},
+			{
+				Name:    "ng-moderate",
+				MinSize: 0,
+				MaxSize: 10,
+				Nodes: []*apiv1.Node{
+					testutils.BuildTestNode("mod-node-1", 4000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "m-class"})),
+					testutils.BuildTestNode("mod-node-2", 4000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "m-class"})),
+					testutils.BuildTestNode("mod-node-3", 4000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "m-class"})),
+				},
+				Pods: []*apiv1.Pod{
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-m1", 1000, 100, "mod-node-1"), "rs"),
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-m2", 1000, 100, "mod-node-2"), "rs"),
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-m3", 1000, 100, "mod-node-3"), "rs"),
+				},
+			},
+			{
+				Name:    "ng-big",
+				MinSize: 0,
+				MaxSize: 10,
+				Nodes: []*apiv1.Node{
+					testutils.BuildTestNode("big-node-1", 9000, 1000, testutils.IsReady(true), testutils.WithNodeLabels(map[string]string{apiv1.LabelInstanceTypeStable: "xl-class"})),
+				},
+				Pods: []*apiv1.Pod{
+					testutils.SetRSPodSpec(testutils.BuildScheduledTestPod("pod-b1", 1000, 100, "big-node-1"), "rs"),
+				},
+			},
+		},
+	}
+}

--- a/pkg/core/bench/scaledown/efficiency/fake_actuator.go
+++ b/pkg/core/bench/scaledown/efficiency/fake_actuator.go
@@ -1,0 +1,137 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	"context"
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	cacontext "sigs.k8s.io/cluster-autoscaler/pkg/context"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/status"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/scheduling"
+	caerrors "sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
+)
+
+type fakeActuationStatus struct {
+	recentEvictions []*apiv1.Pod
+}
+
+// RecentEvictions implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) RecentEvictions() []*apiv1.Pod {
+	return f.recentEvictions
+}
+
+// RegisterEviction implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) RegisterEviction(pod *apiv1.Pod) {
+	f.recentEvictions = append(f.recentEvictions, pod)
+}
+
+// DeletionsInProgress implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) DeletionsInProgress() ([]string, []string) {
+	return nil, nil
+}
+
+// DeletionsCount implements the scaledown.ActuationStatus interface, demanded by UpdateClusterState.
+func (f *fakeActuationStatus) DeletionsCount(nodeGroup string) int {
+	return 0
+}
+
+type fakeActuator struct {
+	autoscalingCtx  cacontext.AutoscalingContext
+	actuationStatus *fakeActuationStatus
+}
+
+// NewFakeActuator returns new instance of fakeActuator.
+func NewFakeActuator(ctx cacontext.AutoscalingContext, status *fakeActuationStatus) *fakeActuator {
+	return &fakeActuator{
+		autoscalingCtx:  ctx,
+		actuationStatus: status,
+	}
+}
+
+// startDeletion "manually" removes nodes and ensures pods rescheduling.
+// Clustersnapshot.fork/commit/revert not present as Pod rescheduling should succeed if nodes were marked as candidates (consistent with planner's decisions on candidate nodes).
+func (f *fakeActuator) startDeletion(empty, needDrain []*apiv1.Node) (status.ScaleDownResult, []*status.ScaleDownNode, caerrors.AutoscalerError) {
+	if len(empty) == 0 && len(needDrain) == 0 {
+		return status.ScaleDownNoNodeDeleted, nil, nil
+	}
+
+	var scaledDownNodes []*status.ScaleDownNode
+	for _, node := range empty {
+		err := f.autoscalingCtx.ClusterSnapshot.RemoveNodeInfo(node.Name)
+		if err != nil {
+			return status.ScaleDownError, nil, nil
+		}
+		scaledDownNodes = append(scaledDownNodes, &status.ScaleDownNode{
+			Node:        node,
+			EvictedPods: nil,
+		})
+	}
+
+	schedSimulator := scheduling.NewHintingSimulator()
+
+	for _, n := range needDrain {
+		nodeInfo, err := f.autoscalingCtx.ClusterSnapshot.GetNodeInfo(n.Name)
+		if err != nil {
+			return status.ScaleDownError, nil, caerrors.ToAutoscalerError(caerrors.TransientError, err)
+		}
+
+		var podsToReschedule []*apiv1.Pod
+		for _, podInfo := range nodeInfo.Pods() {
+			podInfo.Pod.Spec.NodeName = ""
+			podsToReschedule = append(podsToReschedule, podInfo.Pod)
+		}
+
+		err = f.autoscalingCtx.ClusterSnapshot.RemoveNodeInfo(n.Name)
+		if err != nil {
+			return status.ScaleDownError, nil, caerrors.ToAutoscalerError(caerrors.TransientError, err)
+		}
+
+		// If there are Pods to be rescheduled, try rescheduling them.
+		if len(podsToReschedule) > 0 {
+			schedulingResult, err := schedSimulator.TrySchedulePods(context.Background(), f.autoscalingCtx.ClusterSnapshot, podsToReschedule, false,
+				clustersnapshot.SchedulingOptions{
+					// Currently evaluated node to drain is not considered as scheduling target as it was already removed from cluster snapshot.
+					IsNodeAcceptable: scheduling.ScheduleAnywhere,
+				})
+			if err != nil {
+				return status.ScaleDownError, nil, caerrors.ToAutoscalerError(caerrors.TransientError, err)
+			}
+
+			scheduledPods := sets.Set[string]{}
+			for _, s := range schedulingResult.Statuses {
+				scheduledPods.Insert(fmt.Sprintf("%s/%s", s.Pod.Namespace, s.Pod.Name))
+			}
+
+			// If Pod is not present in scheduledPods, it was not successfully rescheduled.
+			// This is an error because Planner's decision on nodes to drain should be successful in static cluster snapshot.
+			for _, pod := range podsToReschedule {
+				if !scheduledPods.Has(fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)) {
+					return status.ScaleDownError, nil, caerrors.NewAutoscalerError(caerrors.InternalError, "failed to reschedule all Pods in actuator")
+				}
+			}
+		}
+		scaledDownNodes = append(scaledDownNodes, &status.ScaleDownNode{
+			Node:        n,
+			EvictedPods: podsToReschedule,
+		})
+	}
+	return status.ScaleDownNodeDeleteStarted, scaledDownNodes, nil
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efficiency
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/status"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
+)
+
+type clusterState struct {
+	scaledDownNodes []*status.ScaleDownNode
+	nodeInfos       []*framework.NodeInfo
+	currentTime     time.Time
+}
+
+// scaleDownMetric is the unified interface all metrics implement.
+type scaleDownMetric interface {
+	// Name returns name of the scaleDownMetric.
+	Name() string
+	// Compute calculates single cluster-level metric value using clusterState.
+	Compute(clusterState clusterState) (float64, error)
+	// Summarize processes metric recorded timeline and derives final benchmarking values returned in a map.
+	Summarize(metricValues []float64) map[string]float64
+}
+
+// metricsTracker orchestrates the computation, storing, and reporting of multiple scaleDownMetric.
+type metricsTracker struct {
+	metrics         []scaleDownMetric
+	metricsTimeline map[string][]float64
+}
+
+// NewMetricsTracker creates a new instance of metricsTracker with given list of scaleDownMetrics.
+func NewMetricsTracker(metrics ...scaleDownMetric) *metricsTracker {
+	return &metricsTracker{
+		metrics:         metrics,
+		metricsTimeline: make(map[string][]float64),
+	}
+}
+
+// ReportToBenchmark registers final benchmark values to benchmark runner across a set of configured scaleDownMetrics.
+func (mt *metricsTracker) ReportToBenchmark(b *testing.B) {
+	for _, m := range mt.metrics {
+		metricValues := mt.metricsTimeline[m.Name()]
+		benchVals := m.Summarize(metricValues)
+		for name, val := range benchVals {
+			b.ReportMetric(val, name)
+		}
+	}
+}
+
+// ComputeMetrics computes metric value across a set of configured scaleDownMetrics.
+func (mt *metricsTracker) ComputeMetrics(clusterState clusterState, t testing.TB) {
+	for _, m := range mt.metrics {
+		val, err := m.Compute(clusterState)
+		if err != nil {
+			t.Errorf("failed to compute metric %s, err %v", m.Name(), err)
+			continue
+		}
+		mt.metricsTimeline[m.Name()] = append(mt.metricsTimeline[m.Name()], val)
+	}
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics.go
@@ -80,3 +80,89 @@ func (mt *metricsTracker) ComputeMetrics(clusterState clusterState, t testing.TB
 		mt.metricsTimeline[m.Name()] = append(mt.metricsTimeline[m.Name()], val)
 	}
 }
+
+// resource struct holds two values:
+// 1) node allocatable value of given resource (whole number)
+// 2) node utilization of a given resource (float in range <0,1>)
+type resource struct {
+	allocatable float64
+	utilization float64
+}
+
+func resourceAllocatableRequested(resourceName apiv1.ResourceName, nodeInfo *framework.NodeInfo, nodeName string, currentTime time.Time) (resource, error) {
+	var r resource
+	util, err := utilization.CalculateUtilizationOfResource(nodeInfo, resourceName, true, true, currentTime)
+	if err != nil {
+		return r, err
+	}
+	r.utilization = util
+	allocatable, found := nodeInfo.Node().Status.Allocatable[resourceName]
+	if !found {
+		return r, fmt.Errorf("failed to get allocatable %v from %s", resourceName, nodeName)
+	}
+	if resourceName == apiv1.ResourceCPU {
+		r.allocatable = float64(allocatable.MilliValue())
+	} else {
+		r.allocatable = float64(allocatable.Value())
+	}
+	return r, nil
+}
+
+func computeResourceUtilization(metricName string, resourceName apiv1.ResourceName, clusterState clusterState) (float64, error) {
+	var totalRequested, totalAllocatable, ratio float64
+	for _, nodeInfo := range clusterState.nodeInfos {
+		if nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		nodeName := nodeInfo.Node().Name
+		res, err := resourceAllocatableRequested(resourceName, nodeInfo, nodeName, clusterState.currentTime)
+		if err != nil {
+			return 0, err
+		}
+		nodeRequested := res.utilization * res.allocatable
+		totalRequested += nodeRequested
+		totalAllocatable += res.allocatable
+	}
+
+	if totalAllocatable > 0 {
+		ratio = totalRequested / totalAllocatable
+	}
+
+	klog.V(5).Infof("Metric: %s, Allocated: %.2f, Allocatable: %.2f, Ratio: %.2f",
+		metricName, totalRequested, totalAllocatable, ratio)
+	return ratio, nil
+}
+
+// resourceUtilizationMetric computes utilization ratio for given resource of generic ResourceName.
+type resourceUtilizationMetric struct {
+	resourceName apiv1.ResourceName
+}
+
+// NewResourceUtilizationMetric creates a new instance of resourceUtilizationMetric.
+func NewResourceUtilizationMetric(rn apiv1.ResourceName) *resourceUtilizationMetric {
+	return &resourceUtilizationMetric{resourceName: rn}
+}
+
+func (m *resourceUtilizationMetric) Name() string {
+	return fmt.Sprintf("%s_utilization", m.resourceName.String())
+}
+
+func (m *resourceUtilizationMetric) Compute(clusterState clusterState) (float64, error) {
+	ratio, err := computeResourceUtilization(m.Name(), m.resourceName, clusterState)
+	if err != nil {
+		return 0, err
+	}
+	return ratio, nil
+}
+
+func (m *resourceUtilizationMetric) Summarize(metricValues []float64) map[string]float64 {
+	first := metricValues[0]
+	last := metricValues[len(metricValues)-1]
+	diff := last - first
+	r := map[string]float64{
+		fmt.Sprintf("%s_%%_init", m.Name()):     first * 100,
+		fmt.Sprintf("%s_%%_final", m.Name()):    last * 100,
+		fmt.Sprintf("%s_%%_improved", m.Name()): diff * 100,
+	}
+	return r
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics/interface.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/interface.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/status"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+)
+
+// ClusterState holds cluster state scaleDownMetric use for computing the values.
+type ClusterState struct {
+	scaledDownNodes []*status.ScaleDownNode
+	nodeInfos       []*framework.NodeInfo
+	currentTime     time.Time
+}
+
+// NewClusterState returns a new instance of ClusterState.
+func NewClusterState(scaledDownNodes []*status.ScaleDownNode, nodeInfos []*framework.NodeInfo, currentTime time.Time) ClusterState {
+	return ClusterState{
+		scaledDownNodes: scaledDownNodes,
+		nodeInfos:       nodeInfos,
+		currentTime:     currentTime,
+	}
+}
+
+// scaleDownMetric is the unified interface all metrics implement.
+type scaleDownMetric interface {
+	// Name returns name of the scaleDownMetric.
+	Name() string
+	// Compute calculates single cluster-level metric value using clusterState.
+	Compute(clusterState ClusterState) (float64, error)
+	// Summarize processes metric recorded timeline and derives final benchmarking values returned in a map.
+	Summarize(metricValues []float64) map[string]float64
+}
+
+// Tracker orchestrates the computation, storing, and reporting of multiple scaleDownMetric.
+type Tracker struct {
+	metrics         []scaleDownMetric
+	metricsTimeline map[string][]float64
+}
+
+// NewTracker creates a new instance of Tracker with given list of scaleDownMetrics.
+func NewTracker(metrics ...scaleDownMetric) *Tracker {
+	return &Tracker{
+		metrics:         metrics,
+		metricsTimeline: make(map[string][]float64),
+	}
+}
+
+// ReportToBenchmark registers final benchmark values to benchmark runner across a set of configured scaleDownMetrics.
+func (mt *Tracker) ReportToBenchmark(b *testing.B) {
+	for _, m := range mt.metrics {
+		metricValues := mt.metricsTimeline[m.Name()]
+		benchVals := m.Summarize(metricValues)
+		for name, val := range benchVals {
+			b.ReportMetric(val, name)
+		}
+	}
+}
+
+// ComputeMetrics computes metric value across a set of configured scaleDownMetrics.
+// Watch out: If a metric fails to be computed, final metricsTimeline for each configured scaleDownMetric will diverge in length.
+func (mt *Tracker) ComputeMetrics(clusterState ClusterState, t testing.TB) {
+	for _, m := range mt.metrics {
+		val, err := m.Compute(clusterState)
+		if err != nil {
+			t.Errorf("failed to compute metric %s, err %v", m.Name(), err)
+			continue
+		}
+		mt.metricsTimeline[m.Name()] = append(mt.metricsTimeline[m.Name()], val)
+	}
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics/utilization.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/utilization.go
@@ -14,72 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package efficiency
+package metrics
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/status"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
 )
-
-type clusterState struct {
-	scaledDownNodes []*status.ScaleDownNode
-	nodeInfos       []*framework.NodeInfo
-	currentTime     time.Time
-}
-
-// scaleDownMetric is the unified interface all metrics implement.
-type scaleDownMetric interface {
-	// Name returns name of the scaleDownMetric.
-	Name() string
-	// Compute calculates single cluster-level metric value using clusterState.
-	Compute(clusterState clusterState) (float64, error)
-	// Summarize processes metric recorded timeline and derives final benchmarking values returned in a map.
-	Summarize(metricValues []float64) map[string]float64
-}
-
-// metricsTracker orchestrates the computation, storing, and reporting of multiple scaleDownMetric.
-type metricsTracker struct {
-	metrics         []scaleDownMetric
-	metricsTimeline map[string][]float64
-}
-
-// NewMetricsTracker creates a new instance of metricsTracker with given list of scaleDownMetrics.
-func NewMetricsTracker(metrics ...scaleDownMetric) *metricsTracker {
-	return &metricsTracker{
-		metrics:         metrics,
-		metricsTimeline: make(map[string][]float64),
-	}
-}
-
-// ReportToBenchmark registers final benchmark values to benchmark runner across a set of configured scaleDownMetrics.
-func (mt *metricsTracker) ReportToBenchmark(b *testing.B) {
-	for _, m := range mt.metrics {
-		metricValues := mt.metricsTimeline[m.Name()]
-		benchVals := m.Summarize(metricValues)
-		for name, val := range benchVals {
-			b.ReportMetric(val, name)
-		}
-	}
-}
-
-// ComputeMetrics computes metric value across a set of configured scaleDownMetrics.
-func (mt *metricsTracker) ComputeMetrics(clusterState clusterState, t testing.TB) {
-	for _, m := range mt.metrics {
-		val, err := m.Compute(clusterState)
-		if err != nil {
-			t.Errorf("failed to compute metric %s, err %v", m.Name(), err)
-			continue
-		}
-		mt.metricsTimeline[m.Name()] = append(mt.metricsTimeline[m.Name()], val)
-	}
-}
 
 // resource struct holds two values:
 // 1) node allocatable value of given resource (whole number)
@@ -89,7 +34,7 @@ type resource struct {
 	utilization float64
 }
 
-func resourceAllocatableRequested(resourceName apiv1.ResourceName, nodeInfo *framework.NodeInfo, nodeName string, currentTime time.Time) (resource, error) {
+func resourceAllocatableRequested(resourceName apiv1.ResourceName, nodeInfo *framework.NodeInfo, currentTime time.Time) (resource, error) {
 	var r resource
 	util, err := utilization.CalculateUtilizationOfResource(nodeInfo, resourceName, true, true, currentTime)
 	if err != nil {
@@ -98,7 +43,7 @@ func resourceAllocatableRequested(resourceName apiv1.ResourceName, nodeInfo *fra
 	r.utilization = util
 	allocatable, found := nodeInfo.Node().Status.Allocatable[resourceName]
 	if !found {
-		return r, fmt.Errorf("failed to get allocatable %v from %s", resourceName, nodeName)
+		return r, fmt.Errorf("failed to get allocatable %v from %s", resourceName, nodeInfo.Node().Name)
 	}
 	if resourceName == apiv1.ResourceCPU {
 		r.allocatable = float64(allocatable.MilliValue())
@@ -108,14 +53,13 @@ func resourceAllocatableRequested(resourceName apiv1.ResourceName, nodeInfo *fra
 	return r, nil
 }
 
-func computeResourceUtilization(metricName string, resourceName apiv1.ResourceName, clusterState clusterState) (float64, error) {
+func (m *resourceUtilizationMetric) computeResourceUtilization(clusterState ClusterState) (float64, error) {
 	var totalRequested, totalAllocatable, ratio float64
 	for _, nodeInfo := range clusterState.nodeInfos {
 		if nodeInfo == nil || nodeInfo.Node() == nil {
 			continue
 		}
-		nodeName := nodeInfo.Node().Name
-		res, err := resourceAllocatableRequested(resourceName, nodeInfo, nodeName, clusterState.currentTime)
+		res, err := resourceAllocatableRequested(m.resourceName, nodeInfo, clusterState.currentTime)
 		if err != nil {
 			return 0, err
 		}
@@ -129,7 +73,7 @@ func computeResourceUtilization(metricName string, resourceName apiv1.ResourceNa
 	}
 
 	klog.V(5).Infof("Metric: %s, Allocated: %.2f, Allocatable: %.2f, Ratio: %.2f",
-		metricName, totalRequested, totalAllocatable, ratio)
+		m.Name(), totalRequested, totalAllocatable, ratio)
 	return ratio, nil
 }
 
@@ -147,8 +91,8 @@ func (m *resourceUtilizationMetric) Name() string {
 	return fmt.Sprintf("%s_utilization", m.resourceName.String())
 }
 
-func (m *resourceUtilizationMetric) Compute(clusterState clusterState) (float64, error) {
-	ratio, err := computeResourceUtilization(m.Name(), m.resourceName, clusterState)
+func (m *resourceUtilizationMetric) Compute(clusterState ClusterState) (float64, error) {
+	ratio, err := m.computeResourceUtilization(clusterState)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/simulator/clustersnapshot/test_utils.go
+++ b/pkg/simulator/clustersnapshot/test_utils.go
@@ -32,7 +32,7 @@ import (
 // InitializeClusterSnapshotOrDie clears cluster snapshot and then initializes it with given set of nodes and pods.
 // Both Spec.NodeName and Status.NominatedNodeName are used when simulating scheduling pods.
 func InitializeClusterSnapshotOrDie(
-	t *testing.T,
+	t testing.TB,
 	snapshot ClusterSnapshot,
 	nodes []*apiv1.Node,
 	pods []*apiv1.Pod) {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

This project aims to develop a system for benchmarking various scaledown strategies and evaluating how chosen strategy affects final efficiency. Scaledown strategies may be driven by different algorithms and prioritization logic, therefore it is essential to first develop metrics that will assess the scaledown outcome objectively.

The initial work involves:

- Definition of `scaleDownMetric` interface and `metricsTracker` to orchestrate the computation, storing, and reporting of multiple `scaleDownMetrics`.
- Implementation of  `resourceUtilizationMetric`.
- Implementation of `fakeActuator` which performs node removal from clustersnapshot to simulate scaledown actuation without external cloud provider communication.
- Definition of `scaleDownScenario` which packs initial cluster topology, `metricsTracker` and optional `AutoscalingOptions` into one struct for individual scaledown run execution.
- Implementation of benchmark runner in the form of a simplified scaledown loop which executes until no more nodes to delete are detected.

A small change was introduced to `simulator/clustersnaphot, func InitializeClusterSnapshotOrDie` - parameter `t *testing.T` changed to `t testing.TB` to enable reusing the function from the benchmark.

#### Run 
Benchmark can be run from cmdl e.g. 
```
cd pkg/core/bench/scaledown/efficiency
go test -v -count=5 -benchtime=1x -bench=.  .
```
which will run the scaledown loop until no new scaledown candidates are found 5 times on fresh initial cluster state and report raw metrics for these 5 executions. If the output is redirected to results file, it can be fed to benchstat.

An explanation to why `benchtime=1x` is used is offered in the [comment to the PR in previous CA repository](https://github.com/kubernetes/autoscaler/pull/9986#discussion_r3676034501). 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
This work has been previously tracked in kubernetes/autoscaler repository.
```docs
[PR 9986 in kubernetes/autoscaler]: https://github.com/kubernetes/autoscaler/pull/9986
```
