### PR TITLE
[Scaledown] Partial taint actuation

### DIFF
--- a/pkg/cloudprovider/test/fake_cloud_provider.go
+++ b/pkg/cloudprovider/test/fake_cloud_provider.go
@@ -17,9 +17,9 @@ limitations under the License.
 package test
 
 import (
-	"k8s.io/apimachinery/pkg/types"
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"strings"
 	"sync"
 	"time"
@@ -543,7 +543,7 @@ func (n *NodeGroup) addNodeFromTemplate(nodeName string) *apiv1.Node {
 func cloneNodeForNodeGroup(templateNode *apiv1.Node, ngName, nodeName string) *apiv1.Node {
 	node := templateNode.DeepCopy()
 	node.Name = nodeName
-		node.UID = types.UID(nodeName)
+	node.UID = types.UID(nodeName)
 	node.Spec.ProviderID = fmt.Sprintf("fake-provider/%s/%s", ngName, node.Name)
 	return node
 }

--- a/pkg/cloudprovider/test/fake_cloud_provider.go
+++ b/pkg/cloudprovider/test/fake_cloud_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"context"
 	"fmt"
 	"strings"
@@ -241,6 +242,13 @@ func WithNodeReadinessDelay(delay time.Duration) NodeGroupOption {
 	}
 }
 
+// WithNodeGroupOptions sets the autoscaling options for the node group.
+func WithNodeGroupOptions(opts *config.NodeGroupAutoscalingOptions) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.opts = opts
+	}
+}
+
 // AddNodeGroup is a helper for tests to add a group with its template.
 func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) *NodeGroup {
 	c.Lock()
@@ -320,6 +328,9 @@ type NodeGroup struct {
 	// nodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If unset,
 	// the Nodes will appear as Ready immediately after registration.
 	nodeReadinessDelay time.Duration
+
+	// opts contains the autoscaling options for this node group.
+	opts *config.NodeGroupAutoscalingOptions
 }
 
 // MaxSize returns the maximum size of the node group.
@@ -442,7 +453,7 @@ func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 
 // GetOptions returns autoscaling options specific to this node group.
 func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, nil
+	return n.opts, nil
 }
 
 // TargetSize returns the current target size of the node group.
@@ -532,6 +543,7 @@ func (n *NodeGroup) addNodeFromTemplate(nodeName string) *apiv1.Node {
 func cloneNodeForNodeGroup(templateNode *apiv1.Node, ngName, nodeName string) *apiv1.Node {
 	node := templateNode.DeepCopy()
 	node.Name = nodeName
+		node.UID = types.UID(nodeName)
 	node.Spec.ProviderID = fmt.Sprintf("fake-provider/%s/%s", ngName, node.Name)
 	return node
 }

--- a/pkg/config/autoscaling_options.go
+++ b/pkg/config/autoscaling_options.go
@@ -390,6 +390,8 @@ type AutoscalingOptions struct {
 	PendingPodsBatchingTimeout time.Duration
 	// GracefulDegradationEnabled tells if graceful degradation for unschedulable pods is enabled.
 	GracefulDegradationEnabled bool
+	// PartialTaintActuation determines whether successfully tainted nodes in non-atomic nodegroups will still be deleted if other nodes in the batch fail to taint.
+	PartialTaintActuationEnabled bool
 }
 
 // KubeClientOptions specify options for kube client

--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -211,6 +211,7 @@ func (p *AutoscalingFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&p.o.PendingPodsBatchingTimeout, "pending-pods-batching-timeout", 4*time.Minute, "The maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.")
 	fs.BoolVar(&p.o.GracefulDegradationEnabled, "enable-graceful-degradation", false, "Enables graceful degradation for unschedulable pods. When enabled, scheduling simulations during filter out pod list processor will be stopped after a timeout(specified by scheduling-simulation-timeout) and CA will proceed with a sub set of pods.")
 	fs.BoolVar(&p.o.InterPodAffinityHostnameFastPath, "enable-inter-pod-affinity-hostname-fast-path", false, "Enable the InterPodAffinityHostnameFastPath scheduler feature gate.")
+	fs.BoolVar(&p.o.PartialTaintActuationEnabled, "partial-taint-actuation-enabled", false, "If true, Cluster Autoscaler will proceed with deleting successfully tainted nodes in non-atomic nodegroups even if individual node taints fail in the same batch.")
 
 	// Deprecated flags
 	fs.StringArrayVar(&p.ignoreTaints, "ignore-taint", []string{}, "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")

--- a/pkg/core/scaledown/actuation/actuator.go
+++ b/pkg/core/scaledown/actuation/actuator.go
@@ -235,10 +235,6 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 	nodesToTaint := make([]*apiv1.Node, 0)
 	var updateLatencyTracker *UpdateLatencyTracker
 	nodeDeleteDelayAfterTaint := a.nodeDeleteDelayAfterTaint
-	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-		updateLatencyTracker = NewUpdateLatencyTracker(a.autoscalingCtx.AutoscalingKubeClients.ListerRegistry.AllNodeLister())
-		go updateLatencyTracker.Start(ctx)
-	}
 
 	for _, bucket := range nodeGroupViews {
 		for _, node := range bucket.Nodes {
@@ -252,7 +248,7 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 		for _, node := range nodesToTaint {
 			updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, time.Now()}
 		}
-		go updateLatencyTracker.Start()
+		go updateLatencyTracker.Start(ctx)
 	}
 
 	// Taint nodes concurrently and record failures
@@ -279,7 +275,7 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 			if _, found := failedNodes[taintedNode.UID]; found {
 				continue
 			}
-			_, _ = taints.CleanToBeDeleted(ctx,taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
+			_, _ = taints.CleanToBeDeleted(ctx, taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
 		}
 		// No need to record taint propagation latency, all taints are cleaned up.
 		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
@@ -309,7 +305,7 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 		klog.Infof("couldn't taint %d nodes with ToBeDeleted, proceeding with partial scale down or bucket cleanup", len(failedNodes))
 
 		for _, bucket := range nodeGroupViews {
-			bucketWithSuccessfulNodes, bucketNodesToClean := a.resolveBucketFailures(bucket, failedNodes)
+			bucketWithSuccessfulNodes, bucketNodesToClean := a.resolveBucketFailures(ctx, bucket, failedNodes)
 			if bucketWithSuccessfulNodes != nil {
 				successfulNodeGroupViews = append(successfulNodeGroupViews, bucketWithSuccessfulNodes)
 			}
@@ -334,8 +330,8 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 //   - If the node is from a regular, non-atomic nodegorup, other successfully tainted nodes from this nodegroup can be deleted.
 //
 // Returns a nodegroup view that contains nodes that can be deleted, and a list of nodes from which the taint has to be cleaned up.
-func (a *Actuator) resolveBucketFailures(bucket *budgets.NodeGroupView, failedNodes map[types.UID]struct{}) (*budgets.NodeGroupView, []*apiv1.Node) {
-	opts, err := bucket.Group.GetOptions(a.autoscalingCtx.NodeGroupDefaults)
+func (a *Actuator) resolveBucketFailures(ctx context.Context, bucket *budgets.NodeGroupView, failedNodes map[types.UID]struct{}) (*budgets.NodeGroupView, []*apiv1.Node) {
+	opts, err := bucket.Group.GetOptions(ctx, a.autoscalingCtx.NodeGroupDefaults)
 	isAtomic := false
 	if err != nil {
 		klog.Warningf("Failed to get options for node group %v: %v, assuming atomic node group to be safe", bucket.Group.Id(), err)

--- a/pkg/core/scaledown/actuation/actuator.go
+++ b/pkg/core/scaledown/actuation/actuator.go
@@ -241,13 +241,13 @@ func (a *Actuator) taintNodesSync(ctx context.Context, NodeGroupViews []*budgets
 			_, _ = taints.CleanToBeDeleted(ctx, taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
 		}
 		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-			close(updateLatencyTracker.AwaitOrStopChan)
+			close(updateLatencyTracker.ExpectedNodeCountChan)
 		}
 		return nodeDeleteDelayAfterTaint, errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted", len(failedTaintedNodes))
 	}
 
 	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-		updateLatencyTracker.AwaitOrStopChan <- true
+		updateLatencyTracker.ExpectedNodeCountChan <- len(nodesToTaint)
 		latency, ok := <-updateLatencyTracker.ResultChan
 		if ok {
 			a.pastLatencies.RegisterElement(latency)

--- a/pkg/core/scaledown/actuation/actuator.go
+++ b/pkg/core/scaledown/actuation/actuator.go
@@ -140,7 +140,7 @@ func (a *Actuator) startDeletion(ctx context.Context, empty, drain []*apiv1.Node
 	defer func() {
 		// nodesToClean is populated only if PartialTaintActuationEnabled is true.
 		if len(nodesToClean) > 0 {
-			workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToClean), func(piece int) {
+			workqueue.ParallelizeUntil(ctx, maxConcurrentNodesTainting, len(nodesToClean), func(piece int) {
 				_, _ = taints.CleanToBeDeleted(ctx, nodesToClean[piece], a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
 			})
 		}
@@ -152,18 +152,48 @@ func (a *Actuator) startDeletion(ctx context.Context, empty, drain []*apiv1.Node
 		return status.ScaleDownNoNodeDeleted, nil, nil
 	}
 
+	abortedNodeGroups := make(map[string]bool)
+
 	if len(emptyToDelete) > 0 {
 		// Taint all empty nodes synchronously
 		taintRes, err := a.taintNodesSync(ctx, emptyToDelete)
 		if len(taintRes.nodesToClean) > 0 {
 			nodesToClean = append(nodesToClean, taintRes.nodesToClean...)
 		}
+
+		// Map successfully processed groups
+		successfulGroups := make(map[string]bool)
+		for _, bucket := range taintRes.successfulNodes {
+			successfulGroups[bucket.Group.Id()] = true
+		}
+		// If an original bucket didn't make it to successfulNodes, it was aborted.
+		// If the group is atomic, we must abort its siblings in the drain phase.
+		for _, bucket := range emptyToDelete {
+			if !successfulGroups[bucket.Group.Id()] {
+				opts, err := bucket.Group.GetOptions(ctx, a.autoscalingCtx.NodeGroupDefaults)
+				if err != nil || (opts != nil && opts.ZeroOrMaxNodeScaling) {
+					abortedNodeGroups[bucket.Group.Id()] = true
+				}
+			}
+		}
+
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
 		emptyScaledDown := a.deleteAsyncEmpty(ctx, taintRes.successfulNodes, taintRes.delayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, emptyScaledDown...)
+	}
+
+	if len(drainToDelete) > 0 {
+		var filteredDrainToDelete []*budgets.NodeGroupView
+		for _, bucket := range drainToDelete {
+			if abortedNodeGroups[bucket.Group.Id()] {
+				continue
+			}
+			filteredDrainToDelete = append(filteredDrainToDelete, bucket)
+		}
+		drainToDelete = filteredDrainToDelete
 	}
 
 	if len(drainToDelete) > 0 {
@@ -254,7 +284,7 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 	// Taint nodes concurrently and record failures
 	failedNodesChan := make(chan taintResult, len(nodesToTaint))
 	failedNodes := make(map[types.UID]struct{})
-	workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
+	workqueue.ParallelizeUntil(ctx, maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
 		node := nodesToTaint[piece]
 		err := a.taintNode(ctx, node)
 		if err != nil {
@@ -267,7 +297,7 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 		a.autoscalingCtx.Recorder.Eventf(result.node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", result.err)
 	}
 
-	// Parial taint actualtion disabled: failure mode
+	// Partial taint actuation disabled: failure mode
 	// Clean up all applied taints.
 	if len(failedNodes) > 0 && !a.autoscalingCtx.AutoscalingOptions.PartialTaintActuationEnabled {
 		// Clean up already applied taints in case of issues.
@@ -286,13 +316,13 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 
 	// Compute taint propagation latency for successfully tainted nodes
 	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-		updateLatencyTracker.ExpectedNodeCountChan <- len(nodesToTaint) - len(failedNodes)
+		expectedCount := len(nodesToTaint) - len(failedNodes)
+		updateLatencyTracker.ExpectedNodeCountChan <- expectedCount
 		latency, ok := <-updateLatencyTracker.ResultChan
-		if ok {
+		if ok && expectedCount > 0 {
 			a.pastLatencies.RegisterElement(latency)
 			a.pastLatencies.DropNotNewerThan(time.Now().Add(-1 * pastLatencyExpireDuration))
 			nodeDeleteDelayAfterTaint = 2 * maxLatency(a.pastLatencies.ToSlice())
-
 		}
 	}
 
@@ -327,7 +357,7 @@ func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets
 //
 // When actuator fails to apply a taint to a node:
 //   - If the node is from an atomic nodegroup, actuator must clean up all successfully applied taints in this nodegroup. The group won't be scaled down.
-//   - If the node is from a regular, non-atomic nodegorup, other successfully tainted nodes from this nodegroup can be deleted.
+//   - If the node is from a regular, non-atomic nodegroup, other successfully tainted nodes from this nodegroup can be deleted.
 //
 // Returns a nodegroup view that contains nodes that can be deleted, and a list of nodes from which the taint has to be cleaned up.
 func (a *Actuator) resolveBucketFailures(ctx context.Context, bucket *budgets.NodeGroupView, failedNodes map[types.UID]struct{}) (*budgets.NodeGroupView, []*apiv1.Node) {
@@ -370,7 +400,6 @@ func (a *Actuator) resolveBucketFailures(ctx context.Context, bucket *budgets.No
 	for _, node := range bucket.Nodes {
 		if _, found := failedNodes[node.UID]; !found {
 			successfulNodes = append(successfulNodes, node)
-		} else {
 		}
 	}
 	if len(successfulNodes) == 0 {

--- a/pkg/core/scaledown/actuation/actuator.go
+++ b/pkg/core/scaledown/actuation/actuator.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown"
@@ -135,6 +136,16 @@ func (a *Actuator) startDeletion(ctx context.Context, empty, drain []*apiv1.Node
 	deletionStartTime := time.Now()
 	defer func() { metrics.UpdateDuration(ctx, metrics.ScaleDownNodeDeletion, time.Since(deletionStartTime)) }()
 
+	var nodesToClean []*apiv1.Node
+	defer func() {
+		// nodesToClean is populated only if PartialTaintActuationEnabled is true.
+		if len(nodesToClean) > 0 {
+			workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToClean), func(piece int) {
+				_, _ = taints.CleanToBeDeleted(ctx, nodesToClean[piece], a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
+			})
+		}
+	}()
+
 	scaledDownNodes := make([]*status.ScaleDownNode, 0)
 	emptyToDelete, drainToDelete := a.budgetProcessor.CropNodes(ctx, a.nodeDeletionTracker, empty, drain)
 	if len(emptyToDelete) == 0 && len(drainToDelete) == 0 {
@@ -143,25 +154,31 @@ func (a *Actuator) startDeletion(ctx context.Context, empty, drain []*apiv1.Node
 
 	if len(emptyToDelete) > 0 {
 		// Taint all empty nodes synchronously
-		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(ctx, emptyToDelete)
+		taintRes, err := a.taintNodesSync(ctx, emptyToDelete)
+		if len(taintRes.nodesToClean) > 0 {
+			nodesToClean = append(nodesToClean, taintRes.nodesToClean...)
+		}
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
-		emptyScaledDown := a.deleteAsyncEmpty(ctx, emptyToDelete, nodeDeleteDelayAfterTaint, force)
+		emptyScaledDown := a.deleteAsyncEmpty(ctx, taintRes.successfulNodes, taintRes.delayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, emptyScaledDown...)
 	}
 
 	if len(drainToDelete) > 0 {
 		// Taint all nodes that need drain synchronously, but don't start any drain/deletion yet. Otherwise, pods evicted from one to-be-deleted node
 		// could get recreated on another.
-		nodeDeleteDelayAfterTaint, err := a.taintNodesSync(ctx, drainToDelete)
+		taintRes, err := a.taintNodesSync(ctx, drainToDelete)
+		if len(taintRes.nodesToClean) > 0 {
+			nodesToClean = append(nodesToClean, taintRes.nodesToClean...)
+		}
 		if err != nil {
 			return status.ScaleDownError, scaledDownNodes, err
 		}
 
 		// All nodes involved in the scale-down should be tainted now - start draining and deleting nodes asynchronously.
-		drainScaledDown := a.deleteAsyncDrain(ctx, drainToDelete, nodeDeleteDelayAfterTaint, force)
+		drainScaledDown := a.deleteAsyncDrain(ctx, taintRes.successfulNodes, taintRes.delayAfterTaint, force)
 		scaledDownNodes = append(scaledDownNodes, drainScaledDown...)
 	}
 
@@ -194,9 +211,27 @@ func (a *Actuator) deleteAsyncEmpty(ctx context.Context, NodeGroupViews []*budge
 	return reportedSDNodes
 }
 
-// taintNodesSync synchronously taints all provided nodes with NoSchedule. If tainting fails for any of the nodes, already
-// applied taints are cleaned up.
-func (a *Actuator) taintNodesSync(ctx context.Context, NodeGroupViews []*budgets.NodeGroupView) (time.Duration, errors.AutoscalerError) {
+type taintNodesResult struct {
+	delayAfterTaint time.Duration
+	successfulNodes []*budgets.NodeGroupView
+	nodesToClean    []*apiv1.Node
+}
+
+// taintNodesSync synchronously taints all provided nodes with NoSchedule.
+// When PartialTaintActuationEnabled is false, if tainting fails for any of the nodes, already applied taints are cleaned up.
+// When PartialTaintActuationEnabled is true:
+//   - if tainting fails in any of the nodes in a non-atomic nodegroup, successfully tainted nodes remain tainted and can proceed to scaledown.
+//   - if tainting fails in any of the nodes in an atomic nodegroup, already taints that were applied to nodes in this group are added to nodesToClean in the result.
+//
+// Returns:
+//   - delayAfterTaint how much time actuator needs to wait before draining nodes from pods
+//   - successfulNodes nodes that can be scaled down.
+//   - nodesToClean nodes that need to be cleaned up from taints. This is only populated if PartialTaintActuationEnabled is true.
+func (a *Actuator) taintNodesSync(ctx context.Context, nodeGroupViews []*budgets.NodeGroupView) (taintNodesResult, errors.AutoscalerError) {
+	type taintResult struct {
+		node *apiv1.Node
+		err  error
+	}
 	nodesToTaint := make([]*apiv1.Node, 0)
 	var updateLatencyTracker *UpdateLatencyTracker
 	nodeDeleteDelayAfterTaint := a.nodeDeleteDelayAfterTaint
@@ -205,60 +240,153 @@ func (a *Actuator) taintNodesSync(ctx context.Context, NodeGroupViews []*budgets
 		go updateLatencyTracker.Start(ctx)
 	}
 
-	for _, bucket := range NodeGroupViews {
+	for _, bucket := range nodeGroupViews {
 		for _, node := range bucket.Nodes {
-			if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, time.Now()}
-			}
 			nodesToTaint = append(nodesToTaint, node)
 		}
 	}
-	failedTaintedNodes := make(chan struct {
-		node *apiv1.Node
-		err  error
-	}, len(nodesToTaint))
-	taintedNodes := make(chan *apiv1.Node, len(nodesToTaint))
+
+	// start tracking the node taint latency
+	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
+		updateLatencyTracker = NewUpdateLatencyTracker(a.autoscalingCtx.AutoscalingKubeClients.ListerRegistry.AllNodeLister(), len(nodesToTaint))
+		for _, node := range nodesToTaint {
+			updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, time.Now()}
+		}
+		go updateLatencyTracker.Start()
+	}
+
+	// Taint nodes concurrently and record failures
+	failedNodesChan := make(chan taintResult, len(nodesToTaint))
+	failedNodes := make(map[types.UID]struct{})
 	workqueue.ParallelizeUntil(context.Background(), maxConcurrentNodesTainting, len(nodesToTaint), func(piece int) {
 		node := nodesToTaint[piece]
 		err := a.taintNode(ctx, node)
 		if err != nil {
-			failedTaintedNodes <- struct {
-				node *apiv1.Node
-				err  error
-			}{node: node, err: err}
-		} else {
-			taintedNodes <- node
+			failedNodesChan <- taintResult{node: node, err: err}
 		}
 	})
-	close(failedTaintedNodes)
-	close(taintedNodes)
-	if len(failedTaintedNodes) > 0 {
-		for nodeWithError := range failedTaintedNodes {
-			a.autoscalingCtx.Recorder.Eventf(nodeWithError.node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", nodeWithError.err)
-		}
+	close(failedNodesChan)
+	for result := range failedNodesChan {
+		failedNodes[result.node.UID] = struct{}{}
+		a.autoscalingCtx.Recorder.Eventf(result.node, apiv1.EventTypeWarning, "ScaleDownFailed", "failed to mark the node as toBeDeleted/unschedulable: %v", result.err)
+	}
+
+	// Parial taint actualtion disabled: failure mode
+	// Clean up all applied taints.
+	if len(failedNodes) > 0 && !a.autoscalingCtx.AutoscalingOptions.PartialTaintActuationEnabled {
 		// Clean up already applied taints in case of issues.
-		for taintedNode := range taintedNodes {
-			_, _ = taints.CleanToBeDeleted(ctx, taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
+		for _, taintedNode := range nodesToTaint {
+			if _, found := failedNodes[taintedNode.UID]; found {
+				continue
+			}
+			_, _ = taints.CleanToBeDeleted(ctx,taintedNode, a.autoscalingCtx.ClientSet, a.autoscalingCtx.CordonNodeBeforeTerminate)
 		}
+		// No need to record taint propagation latency, all taints are cleaned up.
 		if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
 			close(updateLatencyTracker.ExpectedNodeCountChan)
 		}
-		return nodeDeleteDelayAfterTaint, errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted", len(failedTaintedNodes))
+		return taintNodesResult{delayAfterTaint: nodeDeleteDelayAfterTaint, successfulNodes: nil, nodesToClean: nil}, errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted", len(failedNodes))
 	}
 
+	// Compute taint propagation latency for successfully tainted nodes
 	if a.autoscalingCtx.AutoscalingOptions.DynamicNodeDeleteDelayAfterTaintEnabled {
-		updateLatencyTracker.ExpectedNodeCountChan <- len(nodesToTaint)
+		updateLatencyTracker.ExpectedNodeCountChan <- len(nodesToTaint) - len(failedNodes)
 		latency, ok := <-updateLatencyTracker.ResultChan
 		if ok {
 			a.pastLatencies.RegisterElement(latency)
 			a.pastLatencies.DropNotNewerThan(time.Now().Add(-1 * pastLatencyExpireDuration))
-			// CA is expected to wait 3 times the round-trip time between CA and the api-server.
-			// At this point, we have already tainted all the nodes.
-			// Therefore, the nodeDeleteDelayAfterTaint is set 2 times the maximum latency observed during the last hour.
 			nodeDeleteDelayAfterTaint = 2 * maxLatency(a.pastLatencies.ToSlice())
+
 		}
 	}
-	return nodeDeleteDelayAfterTaint, nil
+
+	// Partial taint actuation enabled: failure mode
+	// Compute which taints need to be cleaned up and which nodes can be scaled down
+	if len(failedNodes) > 0 && a.autoscalingCtx.AutoscalingOptions.PartialTaintActuationEnabled {
+		var retErr errors.AutoscalerError
+		var successfulNodeGroupViews []*budgets.NodeGroupView
+		var nodesToClean []*apiv1.Node
+		klog.Infof("couldn't taint %d nodes with ToBeDeleted, proceeding with partial scale down or bucket cleanup", len(failedNodes))
+
+		for _, bucket := range nodeGroupViews {
+			bucketWithSuccessfulNodes, bucketNodesToClean := a.resolveBucketFailures(bucket, failedNodes)
+			if bucketWithSuccessfulNodes != nil {
+				successfulNodeGroupViews = append(successfulNodeGroupViews, bucketWithSuccessfulNodes)
+			}
+			nodesToClean = append(nodesToClean, bucketNodesToClean...)
+		}
+		if len(successfulNodeGroupViews) == 0 {
+			retErr = errors.NewAutoscalerErrorf(errors.ApiCallError, "couldn't taint %d nodes with ToBeDeleted and no nodes can be scaled down", len(failedNodes))
+		}
+		return taintNodesResult{delayAfterTaint: nodeDeleteDelayAfterTaint, successfulNodes: successfulNodeGroupViews, nodesToClean: nodesToClean}, retErr
+
+	}
+
+	// No failed nodes
+	return taintNodesResult{delayAfterTaint: nodeDeleteDelayAfterTaint, successfulNodes: nodeGroupViews, nodesToClean: nil}, nil
+
+}
+
+// resolveTaintFailures evaluates how to handle taint failures in a nodegroup.
+//
+// When actuator fails to apply a taint to a node:
+//   - If the node is from an atomic nodegroup, actuator must clean up all successfully applied taints in this nodegroup. The group won't be scaled down.
+//   - If the node is from a regular, non-atomic nodegorup, other successfully tainted nodes from this nodegroup can be deleted.
+//
+// Returns a nodegroup view that contains nodes that can be deleted, and a list of nodes from which the taint has to be cleaned up.
+func (a *Actuator) resolveBucketFailures(bucket *budgets.NodeGroupView, failedNodes map[types.UID]struct{}) (*budgets.NodeGroupView, []*apiv1.Node) {
+	opts, err := bucket.Group.GetOptions(a.autoscalingCtx.NodeGroupDefaults)
+	isAtomic := false
+	if err != nil {
+		klog.Warningf("Failed to get options for node group %v: %v, assuming atomic node group to be safe", bucket.Group.Id(), err)
+		isAtomic = true
+	} else if opts != nil && opts.ZeroOrMaxNodeScaling {
+		isAtomic = true
+	}
+
+	// If any nodes in an atomic nodegroup failed to taint, we cannot scale it down and need to clean up all applied taints.
+	if isAtomic {
+		failedBucket := false
+		for _, node := range bucket.Nodes {
+			if _, found := failedNodes[node.UID]; found {
+				failedBucket = true
+				break
+			}
+		}
+
+		if !failedBucket {
+			return bucket, nil
+		}
+
+		var toClean []*apiv1.Node
+		for _, node := range bucket.Nodes {
+			if _, found := failedNodes[node.UID]; !found {
+				toClean = append(toClean, node)
+			}
+		}
+
+		return nil, toClean
+	}
+
+	// In a non-atomic nodegroup, any successfully tainted nodes can be scaled down.
+	successfulNodes := make([]*apiv1.Node, 0, len(bucket.Nodes))
+
+	for _, node := range bucket.Nodes {
+		if _, found := failedNodes[node.UID]; !found {
+			successfulNodes = append(successfulNodes, node)
+		} else {
+		}
+	}
+	if len(successfulNodes) == 0 {
+		return nil, nil
+	}
+	if len(successfulNodes) == len(bucket.Nodes) {
+		return bucket, nil
+	}
+	newBucket := *bucket
+	newBucket.Nodes = successfulNodes
+	return &newBucket, nil
+
 }
 
 // deleteAsyncDrain asynchronously starts deletions with drain for all provided nodes. scaledDownNodes return value contains all nodes for which
@@ -367,25 +495,25 @@ func (a *Actuator) deleteNodesAsync(ctx context.Context, nodes []*apiv1.Node, no
 func (a *Actuator) scaleDownNodeToReport(ctx context.Context, node *apiv1.Node, drain bool) (*status.ScaleDownNode, error) {
 	nodeGroup, err := a.autoscalingCtx.CloudProvider.NodeGroupForNode(ctx, node)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to get node group for node %s: %v", node.Name, err)
 	}
 	if nodeGroup == nil {
 		return nil, errors.NewAutoscalerErrorf(errors.NodeGroupDoesNotExistError, "no node group for node %s", node.Name)
 	}
 	nodeInfo, err := a.autoscalingCtx.ClusterSnapshot.GetNodeInfo(node.Name)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to get node info for %s: %v", node.Name, err)
 	}
 
 	ignoreDaemonSetsUtilization, err := a.configGetter.GetIgnoreDaemonSetsUtilization(ctx, nodeGroup)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to get ignoreDaemonSetsUtilization for node group %s: %v", nodeGroup.Id(), err)
 	}
 
 	gpuConfig := a.autoscalingCtx.CloudProvider.GetNodeGpuConfig(ctx, node)
 	utilInfo, err := utilization.Calculate(ctx, nodeInfo, ignoreDaemonSetsUtilization, a.autoscalingCtx.IgnoreMirrorPodsUtilization, a.autoscalingCtx.DynamicResourceAllocationEnabled, gpuConfig, time.Now())
 	if err != nil {
-		return nil, err
+		return nil, errors.NewAutoscalerErrorf(errors.InternalError, "failed to calculate utilization for %s: %v", node.Name, err)
 	}
 	var evictedPods []*apiv1.Pod
 	if drain {

--- a/pkg/core/scaledown/actuation/actuator_test.go
+++ b/pkg/core/scaledown/actuation/actuator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package actuation
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -1382,6 +1381,7 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 }
 
 func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
+	ctx := GetTestContext(t)
 	// Insert all nodes into a map to support live node updates and GETs.
 	emptyNodeGroupViews, drainNodeGroupViews := []*budgets.NodeGroupView{}, []*budgets.NodeGroupView{}
 	allEmptyNodes, allDrainNodes := []*apiv1.Node{}, []*apiv1.Node{}
@@ -1594,9 +1594,9 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 	var gotScaleDownNodes []*status.ScaleDownNode
 	var gotErr error
 	if force {
-		gotResult, gotScaleDownNodes, gotErr = actuator.StartForceDeletion(context.TODO(), allEmptyNodes, allDrainNodes)
+		gotResult, gotScaleDownNodes, gotErr = actuator.StartForceDeletion(ctx, allEmptyNodes, allDrainNodes)
 	} else {
-		gotResult, gotScaleDownNodes, gotErr = actuator.StartDeletion(context.TODO(), allEmptyNodes, allDrainNodes)
+		gotResult, gotScaleDownNodes, gotErr = actuator.StartDeletion(ctx, allEmptyNodes, allDrainNodes)
 	}
 
 	if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
@@ -1833,6 +1833,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := GetTestContext(t)
 			test := test
 			gotFailedRequest := func(nodeGroupId string) bool {
 				val, _ := test.failedRequests[nodeGroupId]
@@ -1903,7 +1904,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			}
 
 			for _, nodes := range deleteNodes {
-				actuator.StartDeletion(context.TODO(), nodes, []*apiv1.Node{})
+				actuator.StartDeletion(ctx, nodes, []*apiv1.Node{})
 				time.Sleep(deleteInterval)
 			}
 			wantDeletedNodes := 0

--- a/pkg/core/scaledown/actuation/actuator_test.go
+++ b/pkg/core/scaledown/actuation/actuator_test.go
@@ -2080,6 +2080,8 @@ type partialTaintingTestCase struct {
 	nodeGroupName   string
 	nodeGroups      map[string]*testprovider.TestNodeGroup
 	emptyNodes      []nodeGroupViewInfo
+	drainNodes      []nodeGroupViewInfo
+	pods            map[string][]*apiv1.Pod
 	failedNodeTaint map[string]bool
 	enabled         expectedActuationResult
 	disabled        expectedActuationResult
@@ -2136,6 +2138,39 @@ func TestStartDeletion_PartialTaintActuation(t *testing.T) {
 				deletedNodes: nil,
 			},
 		},
+		{
+			description:   "atomic node group: empty node fails taint, non-empty node is not scaled down",
+			nodeGroupName: "atomic-2",
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-2": sizedNodeGroup("atomic-2", 2, true, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"atomic-2", 0, 1},
+			},
+			drainNodes: []nodeGroupViewInfo{
+				{"atomic-2", 1, 2},
+			},
+			pods: map[string][]*apiv1.Pod{
+				"atomic-2-node-1": {
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default", UID: "uid"},
+					},
+				},
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-2-node-0": true,
+			},
+			disabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+				deletedNodes: nil,
+			},
+			enabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted and no nodes can be scaled down"),
+				deletedNodes: nil,
+			},
+		},
 	}
 
 	buildExpected := func(wantResult status.ScaleDownResult, wantDeleted []string, nodeGroupName string) (scaleDownStatusInfo, map[string]status.NodeDeleteResult, map[string][][]apiv1.Taint) {
@@ -2167,6 +2202,8 @@ func TestStartDeletion_PartialTaintActuation(t *testing.T) {
 				baseTC := startDeletionTestCase{
 					nodeGroups:                    tc.nodeGroups,
 					emptyNodes:                    tc.emptyNodes,
+					drainNodes:                    tc.drainNodes,
+					pods:                          tc.pods,
 					failedNodeTaint:               tc.failedNodeTaint,
 					wantStatus:                    statusInfo,
 					wantErr:                       tc.disabled.err,
@@ -2184,6 +2221,8 @@ func TestStartDeletion_PartialTaintActuation(t *testing.T) {
 				baseTC := startDeletionTestCase{
 					nodeGroups:                    tc.nodeGroups,
 					emptyNodes:                    tc.emptyNodes,
+					drainNodes:                    tc.drainNodes,
+					pods:                          tc.pods,
 					failedNodeTaint:               tc.failedNodeTaint,
 					wantStatus:                    statusInfo,
 					wantErr:                       tc.enabled.err,

--- a/pkg/core/scaledown/actuation/actuator_test.go
+++ b/pkg/core/scaledown/actuation/actuator_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
@@ -48,6 +49,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroupconfig"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
+	caerrors "sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/expiring"
 	kube_util "sigs.k8s.io/cluster-autoscaler/pkg/utils/kubernetes"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/taints"
@@ -73,21 +75,23 @@ type scaleDownStatusInfo struct {
 }
 
 type startDeletionTestCase struct {
-	defaultOnly           bool // Set to true to only run default deletion logic tests.
-	forcedOnly            bool // Set to true to only run forced deletion logic tests.
-	nodeGroups            map[string]*testprovider.TestNodeGroup
-	emptyNodes            []nodeGroupViewInfo
-	drainNodes            []nodeGroupViewInfo
-	pods                  map[string][]*apiv1.Pod
-	failedPodDrain        map[string]bool
-	failedNodeDeletion    map[string]bool
-	failedNodeTaint       map[string]bool
-	wantStatus            scaleDownStatusInfo
-	wantErr               error
-	wantDeletedPods       []string
-	wantDeletedNodes      []string
-	wantTaintUpdates      map[string][][]apiv1.Taint
-	wantNodeDeleteResults map[string]status.NodeDeleteResult
+	defaultOnly                   bool // Set to true to only run default deletion logic tests.
+	forcedOnly                    bool // Set to true to only run forced deletion logic tests.
+	nodeGroups                    map[string]*testprovider.TestNodeGroup
+	emptyNodes                    []nodeGroupViewInfo
+	drainNodes                    []nodeGroupViewInfo
+	pods                          map[string][]*apiv1.Pod
+	failedPodDrain                map[string]bool
+	failedNodeDeletion            map[string]bool
+	failedNodeTaint               map[string]bool
+	partialTaintActuationEnabled  bool
+	dynamicNodeDeleteDelayEnabled bool
+	wantStatus                    scaleDownStatusInfo
+	wantErr                       error
+	wantDeletedPods               []string
+	wantDeletedNodes              []string
+	wantTaintUpdates              map[string][][]apiv1.Taint
+	wantNodeDeleteResults         map[string]status.NodeDeleteResult
 }
 
 func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suffix string) map[string]startDeletionTestCase {
@@ -180,6 +184,274 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
 				"atomic-2-node-0": {ResultType: status.NodeDeleteOk},
 				"atomic-2-node-1": {ResultType: status.NodeDeleteOk},
+			},
+		},
+		"empty node deletion with failed taint": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-4": sizedNodeGroup("test-4", 4, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-4-node-1": true,
+			},
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"test-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"test-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"test-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+			},
+		},
+
+		"empty node deletion with all taints failing, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-3": sizedNodeGroup("test-3", 3, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-3", 0, 3},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-3-node-0": true,
+				"test-3-node-1": true,
+				"test-3-node-2": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 3 nodes with ToBeDeleted and no nodes can be scaled down"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{},
+		},
+		"drain node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-4": sizedNodeGroup("test-4", 4, false, ignoreDaemonSetsUtilization),
+			},
+			drainNodes: []nodeGroupViewInfo{
+				{"test-4", 0, 4},
+			},
+			pods: map[string][]*apiv1.Pod{
+				"test-4-node-0": removablePods(1, "test-4-node-0"),
+				"test-4-node-1": removablePods(1, "test-4-node-1"),
+				"test-4-node-2": removablePods(1, "test-4-node-2"),
+				"test-4-node-3": removablePods(1, "test-4-node-3"),
+			},
+			failedNodeTaint: map[string]bool{
+				"test-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownNodeDeleteStarted,
+				scaledDownNodes: []scaleDownNodeInfo{
+					{
+						name:        "test-4-node-0",
+						nodeGroup:   "test-4",
+						utilInfo:    generateUtilInfo(0.125, 0.125),
+						evictedPods: removablePods(1, "test-4-node-0"),
+					},
+					{
+						name:        "test-4-node-2",
+						nodeGroup:   "test-4",
+						utilInfo:    generateUtilInfo(0.125, 0.125),
+						evictedPods: removablePods(1, "test-4-node-2"),
+					},
+					{
+						name:        "test-4-node-3",
+						nodeGroup:   "test-4",
+						utilInfo:    generateUtilInfo(0.125, 0.125),
+						evictedPods: removablePods(1, "test-4-node-3"),
+					},
+				},
+			},
+			wantErr: nil,
+			wantDeletedNodes: []string{
+				"test-4-node-0",
+				"test-4-node-2",
+				"test-4-node-3",
+			},
+			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
+				"test-4-node-0": {ResultType: status.NodeDeleteOk},
+				"test-4-node-2": {ResultType: status.NodeDeleteOk},
+				"test-4-node-3": {ResultType: status.NodeDeleteOk},
+			},
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"test-4-node-0": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-2": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-3": {
+					{toBeDeletedTaint},
+				},
+			},
+		},
+
+		"drain atomic node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-4": sizedNodeGroup("atomic-4", 4, true, ignoreDaemonSetsUtilization),
+			},
+			drainNodes: []nodeGroupViewInfo{
+				{"atomic-4", 0, 4},
+			},
+			pods: map[string][]*apiv1.Pod{
+				"atomic-4-node-0": removablePods(1, "atomic-4-node-0"),
+				"atomic-4-node-1": removablePods(1, "atomic-4-node-1"),
+				"atomic-4-node-2": removablePods(1, "atomic-4-node-2"),
+				"atomic-4-node-3": removablePods(1, "atomic-4-node-3"),
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result:          status.ScaleDownError,
+				scaledDownNodes: nil,
+			},
+			wantErr:               cmpopts.AnyError,
+			wantDeletedNodes:      nil,
+			wantNodeDeleteResults: map[string]status.NodeDeleteResult{},
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"atomic-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+			},
+		},
+		"empty node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-4": sizedNodeGroup("test-4", 4, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownNodeDeleteStarted,
+				scaledDownNodes: []scaleDownNodeInfo{
+					{
+						name:      "test-4-node-0",
+						nodeGroup: "test-4",
+						utilInfo:  generateUtilInfo(0, 0),
+					},
+					{
+						name:      "test-4-node-2",
+						nodeGroup: "test-4",
+						utilInfo:  generateUtilInfo(0, 0),
+					},
+					{
+						name:      "test-4-node-3",
+						nodeGroup: "test-4",
+						utilInfo:  generateUtilInfo(0, 0),
+					},
+				},
+			},
+			wantDeletedNodes: []string{
+				"test-4-node-0",
+				"test-4-node-2",
+				"test-4-node-3",
+			},
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"test-4-node-0": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-2": {
+					{toBeDeletedTaint},
+				},
+				"test-4-node-3": {
+					{toBeDeletedTaint},
+				},
+			},
+			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
+				"test-4-node-0": {ResultType: status.NodeDeleteOk},
+				"test-4-node-2": {ResultType: status.NodeDeleteOk},
+				"test-4-node-3": {ResultType: status.NodeDeleteOk},
+			},
+		},
+		"empty atomic node deletion with failed taint": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-4": sizedNodeGroup("atomic-4", 4, true, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"atomic-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-4-node-1": true,
+			},
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"atomic-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+			},
+		},
+		"empty atomic node deletion with failed taint, throughput optimized": {
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"atomic-4": sizedNodeGroup("atomic-4", 4, true, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"atomic-4", 0, 4},
+			},
+			failedNodeTaint: map[string]bool{
+				"atomic-4-node-1": true,
+			},
+			partialTaintActuationEnabled: true,
+			wantStatus: scaleDownStatusInfo{
+				result: status.ScaleDownError,
+			},
+			wantErr:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted and no nodes can be scaled down"),
+			wantDeletedNodes: nil,
+			wantTaintUpdates: map[string][][]apiv1.Taint{
+				"atomic-4-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-2": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-4-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
 			},
 		},
 		"deletion with drain": {
@@ -571,6 +843,26 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 				},
 				"test-node-1": {
 					{toBeDeletedTaint},
+				},
+				"atomic-6-node-0": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-1": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-3": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-4": {
+					{toBeDeletedTaint},
+					{},
+				},
+				"atomic-6-node-5": {
+					{toBeDeletedTaint},
+					{},
 				},
 			},
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
@@ -998,11 +1290,9 @@ func getStartDeletionTestCases(ignoreDaemonSetsUtilization bool, force bool, suf
 			wantTaintUpdates: map[string][][]apiv1.Taint{
 				"test-node-0": {
 					{toBeDeletedTaint},
-					{},
 				},
 				"test-node-1": {
 					{toBeDeletedTaint},
-					{},
 				},
 			},
 			wantNodeDeleteResults: map[string]status.NodeDeleteResult{
@@ -1162,7 +1452,14 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 			defer nodesLock.Unlock()
 			update := action.(core.UpdateAction)
 			obj := update.GetObject().(*apiv1.Node)
-			if tc.failedNodeTaint[obj.Name] {
+			hasToBeDeletedTaint := false
+			for _, taint := range obj.Spec.Taints {
+				if taint.Key == taints.ToBeDeletedTaint {
+					hasToBeDeletedTaint = true
+					break
+				}
+			}
+			if tc.failedNodeTaint[obj.Name] && hasToBeDeletedTaint {
 				return true, nil, fmt.Errorf("SIMULATED ERROR: won't taint")
 			}
 			nt := nodeTaints{
@@ -1219,10 +1516,12 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 
 	// Set up other needed structures and options.
 	opts := config.AutoscalingOptions{
-		MaxScaleDownParallelism:        10,
-		MaxDrainParallelism:            5,
-		MaxPodEvictionTime:             0,
-		DaemonSetEvictionForEmptyNodes: true,
+		MaxScaleDownParallelism:                 10,
+		MaxDrainParallelism:                     5,
+		MaxPodEvictionTime:                      0,
+		DaemonSetEvictionForEmptyNodes:          true,
+		PartialTaintActuationEnabled:            tc.partialTaintActuationEnabled,
+		DynamicNodeDeleteDelayAfterTaintEnabled: tc.dynamicNodeDeleteDelayEnabled,
 	}
 
 	allPods := []*apiv1.Pod{}
@@ -1235,14 +1534,14 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 	pdbLister := kube_util.NewTestPodDisruptionBudgetLister([]*policyv1.PodDisruptionBudget{})
 	dsLister, err := kube_util.NewTestDaemonSetLister([]*appsv1.DaemonSet{ds})
 	if err != nil {
-		t.Fatalf("Couldn't create daemonset lister")
+		t.Fatalf("couldn't create daemonset lister")
 	}
 
 	nodeLister := kube_util.NewDynamicTestNodeLister(fakeClient)
 	registry := kube_util.NewListerRegistry(nodeLister, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
 	autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
 	if err != nil {
-		t.Fatalf("Couldn't set up autoscaling context: %v", err)
+		t.Fatalf("couldn't set up autoscaling context: %v", err)
 	}
 	scaleStateNotifier := nodegroupchange.NewNodeGroupChangeObserversList()
 	_ = clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(scaleStateNotifier))
@@ -1250,7 +1549,7 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 		for _, node := range bucket.Nodes {
 			err := autoscalingCtx.ClusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node, tc.pods[node.Name]...))
 			if err != nil {
-				t.Fatalf("Couldn't add node %q to snapshot: %v", node.Name, err)
+				t.Fatalf("couldn't add node %q to snapshot: %v", node.Name, err)
 			}
 		}
 	}
@@ -1262,7 +1561,7 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 			}
 			err := autoscalingCtx.ClusterSnapshot.AddNodeInfo(framework.NewTestNodeInfo(node, pods...))
 			if err != nil {
-				t.Fatalf("Couldn't add node %q to snapshot: %v", node.Name, err)
+				t.Fatalf("couldn't add node %q to snapshot: %v", node.Name, err)
 			}
 		}
 	}
@@ -1389,34 +1688,68 @@ taintsLoop:
 
 func TestStartDeletion(t *testing.T) {
 	testSets := []map[string]startDeletionTestCase{
-		// IgnoreDaemonSetsUtilization is false
 		getStartDeletionTestCases(false, false, "testNg1"),
-		// IgnoreDaemonSetsUtilization is true
 		getStartDeletionTestCases(true, false, "testNg2"),
 	}
 
 	for _, testSet := range testSets {
 		for tn, tc := range testSet {
-			t.Run(tn, func(t *testing.T) {
-				runStartDeletionTest(t, tc, false)
-			})
+			if !tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:false", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, false)
+				})
+			}
+		}
+	}
+}
+
+func TestStartDeletionThroughputOptimized(t *testing.T) {
+	testSets := []map[string]startDeletionTestCase{
+		getStartDeletionTestCases(false, false, "testNg1"),
+		getStartDeletionTestCases(true, false, "testNg2"),
+	}
+
+	for _, testSet := range testSets {
+		for tn, tc := range testSet {
+			if tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:true", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, false)
+				})
+			}
 		}
 	}
 }
 
 func TestStartForceDeletion(t *testing.T) {
 	testSets := []map[string]startDeletionTestCase{
-		// IgnoreDaemonSetsUtilization is false
 		getStartDeletionTestCases(false, true, "testNg1"),
-		// IgnoreDaemonSetsUtilization is true
 		getStartDeletionTestCases(true, true, "testNg2"),
 	}
 
 	for _, testSet := range testSets {
 		for tn, tc := range testSet {
-			t.Run(tn, func(t *testing.T) {
-				runStartDeletionTest(t, tc, true)
-			})
+			if !tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:false", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, true)
+				})
+			}
+		}
+	}
+}
+
+func TestStartForceDeletionThroughputOptimized(t *testing.T) {
+	testSets := []map[string]startDeletionTestCase{
+		getStartDeletionTestCases(false, true, "testNg1"),
+		getStartDeletionTestCases(true, true, "testNg2"),
+	}
+
+	for _, testSet := range testSets {
+		for tn, tc := range testSet {
+			if tc.partialTaintActuationEnabled {
+				t.Run(fmt.Sprintf("%s-partialActuationEnabled:true", tn), func(t *testing.T) {
+					runStartDeletionTest(t, tc, true)
+				})
+			}
 		}
 	}
 }
@@ -1554,7 +1887,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			registry := kube_util.NewListerRegistry(nil, nil, podLister, pdbLister, nil, nil, nil, nil, nil)
 			autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
 			if err != nil {
-				t.Fatalf("Couldn't set up autoscaling context: %v", err)
+				t.Fatalf("couldn't set up autoscaling context: %v", err)
 			}
 			scaleStateNotifier := nodegroupchange.NewNodeGroupChangeObserversList()
 			_ = clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(scaleStateNotifier))
@@ -1630,7 +1963,7 @@ func generateNodeGroupViewList(ng cloudprovider.NodeGroup, from, to int) []*budg
 
 func generateNode(name string) *apiv1.Node {
 	return &apiv1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name)},
 		Status: apiv1.NodeStatus{
 			Allocatable: apiv1.ResourceList{
 				apiv1.ResourceCPU:    resource.MustParse("8"),
@@ -1733,4 +2066,134 @@ func waitForDeletionResultsCount(ndt *deletiontracker.NodeDeletionTracker, resul
 		}
 	}
 	return fmt.Errorf("timed out while waiting for node deletion results")
+}
+
+type expectedActuationResult struct {
+	status       status.ScaleDownResult
+	err          error
+	deletedNodes []string
+}
+
+type partialTaintingTestCase struct {
+	description     string
+	nodeGroupName   string
+	nodeGroups      map[string]*testprovider.TestNodeGroup
+	emptyNodes      []nodeGroupViewInfo
+	failedNodeTaint map[string]bool
+	enabled         expectedActuationResult
+	disabled        expectedActuationResult
+}
+
+func TestStartDeletion_PartialTaintActuation(t *testing.T) {
+	ignoreDaemonSetsUtilization := false
+	cases := []partialTaintingTestCase{
+		{
+			description:   "empty node deletion with partial taint failure",
+			nodeGroupName: "test-3",
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-3": sizedNodeGroup("test-3", 3, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-3", 0, 3},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-3-node-1": true,
+			},
+			disabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 1 nodes with ToBeDeleted"),
+				deletedNodes: nil,
+			},
+			enabled: expectedActuationResult{
+				status:       status.ScaleDownNodeDeleteStarted,
+				err:          nil,
+				deletedNodes: []string{"test-3-node-0", "test-3-node-2"},
+			},
+		},
+		{
+			description:   "empty node deletion with all taints failing",
+			nodeGroupName: "test-3",
+			nodeGroups: map[string]*testprovider.TestNodeGroup{
+				"test-3": sizedNodeGroup("test-3", 3, false, ignoreDaemonSetsUtilization),
+			},
+			emptyNodes: []nodeGroupViewInfo{
+				{"test-3", 0, 3},
+			},
+			failedNodeTaint: map[string]bool{
+				"test-3-node-0": true,
+				"test-3-node-1": true,
+				"test-3-node-2": true,
+			},
+			disabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 3 nodes with ToBeDeleted"),
+				deletedNodes: nil,
+			},
+			enabled: expectedActuationResult{
+				status:       status.ScaleDownError,
+				err:          caerrors.NewAutoscalerErrorf(caerrors.ApiCallError, "couldn't taint 3 nodes with ToBeDeleted and no nodes can be scaled down"),
+				deletedNodes: nil,
+			},
+		},
+	}
+
+	buildExpected := func(wantResult status.ScaleDownResult, wantDeleted []string, nodeGroupName string) (scaleDownStatusInfo, map[string]status.NodeDeleteResult, map[string][][]apiv1.Taint) {
+		statusInfo := scaleDownStatusInfo{result: wantResult}
+		var deleteResults map[string]status.NodeDeleteResult
+		var taintUpdates map[string][][]apiv1.Taint
+		toBeDeletedTaint := apiv1.Taint{Key: taints.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
+
+		if len(wantDeleted) > 0 {
+			deleteResults = make(map[string]status.NodeDeleteResult)
+			taintUpdates = make(map[string][][]apiv1.Taint)
+			for _, node := range wantDeleted {
+				statusInfo.scaledDownNodes = append(statusInfo.scaledDownNodes, scaleDownNodeInfo{
+					name:      node,
+					nodeGroup: nodeGroupName,
+					utilInfo:  generateUtilInfo(0, 0),
+				})
+				deleteResults[node] = status.NodeDeleteResult{ResultType: status.NodeDeleteOk}
+				taintUpdates[node] = [][]apiv1.Taint{{toBeDeletedTaint}}
+			}
+		}
+		return statusInfo, deleteResults, taintUpdates
+	}
+
+	for _, tc := range cases {
+		for _, dynamicDelayEnabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s-PartialTaintActuationEnabled:false-DynamicDelay:%v", tc.description, dynamicDelayEnabled), func(t *testing.T) {
+				statusInfo, deleteResults, taintUpdates := buildExpected(tc.disabled.status, tc.disabled.deletedNodes, tc.nodeGroupName)
+				baseTC := startDeletionTestCase{
+					nodeGroups:                    tc.nodeGroups,
+					emptyNodes:                    tc.emptyNodes,
+					failedNodeTaint:               tc.failedNodeTaint,
+					wantStatus:                    statusInfo,
+					wantErr:                       tc.disabled.err,
+					wantDeletedNodes:              tc.disabled.deletedNodes,
+					wantNodeDeleteResults:         deleteResults,
+					wantTaintUpdates:              taintUpdates,
+					partialTaintActuationEnabled:  false,
+					dynamicNodeDeleteDelayEnabled: dynamicDelayEnabled,
+				}
+				runStartDeletionTest(t, baseTC, false)
+			})
+
+			t.Run(fmt.Sprintf("%s-PartialTaintActuationEnabled:true-DynamicDelay:%v", tc.description, dynamicDelayEnabled), func(t *testing.T) {
+				statusInfo, deleteResults, taintUpdates := buildExpected(tc.enabled.status, tc.enabled.deletedNodes, tc.nodeGroupName)
+				baseTC := startDeletionTestCase{
+					nodeGroups:                    tc.nodeGroups,
+					emptyNodes:                    tc.emptyNodes,
+					failedNodeTaint:               tc.failedNodeTaint,
+					wantStatus:                    statusInfo,
+					wantErr:                       tc.enabled.err,
+					wantDeletedNodes:              tc.enabled.deletedNodes,
+					wantNodeDeleteResults:         deleteResults,
+					wantTaintUpdates:              taintUpdates,
+					partialTaintActuationEnabled:  true,
+					dynamicNodeDeleteDelayEnabled: dynamicDelayEnabled,
+				}
+				runStartDeletionTest(t, baseTC, false)
+			})
+		}
+	}
 }

--- a/pkg/core/scaledown/actuation/actuator_test.go
+++ b/pkg/core/scaledown/actuation/actuator_test.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroupconfig"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/expiring"
 	kube_util "sigs.k8s.io/cluster-autoscaler/pkg/utils/kubernetes"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/taints"
 	. "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
@@ -1141,6 +1142,15 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 		}
 		return true, node, nil
 	})
+	fakeClient.Fake.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		nodesLock.Lock()
+		defer nodesLock.Unlock()
+		nodeList := &apiv1.NodeList{}
+		for _, node := range nodesByName {
+			nodeList.Items = append(nodeList.Items, *node)
+		}
+		return true, nodeList, nil
+	})
 	fakeClient.Fake.AddReactor("get", "pods",
 		func(action core.Action) (bool, runtime.Object, error) {
 			return true, nil, errors.NewNotFound(apiv1.Resource("pod"), "whatever")
@@ -1228,7 +1238,8 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 		t.Fatalf("Couldn't create daemonset lister")
 	}
 
-	registry := kube_util.NewListerRegistry(nil, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
+	nodeLister := kube_util.NewDynamicTestNodeLister(fakeClient)
+	registry := kube_util.NewListerRegistry(nodeLister, nil, podLister, pdbLister, dsLister, nil, nil, nil, nil)
 	autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, fakeClient, registry, provider, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Couldn't set up autoscaling context: %v", err)
@@ -1275,6 +1286,7 @@ func runStartDeletionTest(t *testing.T, tc startDeletionTestCase, force bool) {
 	actuator := Actuator{
 		autoscalingCtx: &autoscalingCtx, nodeDeletionTracker: ndt,
 		nodeDeletionScheduler: NewGroupDeletionScheduler(&autoscalingCtx, ndt, ndb, evictor),
+		pastLatencies:         expiring.NewList(),
 		budgetProcessor:       budgets.NewScaleDownBudgetProcessor(&autoscalingCtx),
 		configGetter:          nodegroupconfig.NewDefaultNodeGroupConfigProcessor(autoscalingCtx.NodeGroupDefaults),
 	}
@@ -1553,6 +1565,7 @@ func TestStartDeletionInBatchBasic(t *testing.T) {
 			actuator := Actuator{
 				autoscalingCtx: &autoscalingCtx, nodeDeletionTracker: ndt,
 				nodeDeletionScheduler: NewGroupDeletionScheduler(&autoscalingCtx, ndt, ndb, evictor),
+				pastLatencies:         expiring.NewList(),
 				budgetProcessor:       budgets.NewScaleDownBudgetProcessor(&autoscalingCtx),
 			}
 

--- a/pkg/core/scaledown/actuation/group_deletion_scheduler_test.go
+++ b/pkg/core/scaledown/actuation/group_deletion_scheduler_test.go
@@ -168,16 +168,17 @@ func TestScheduleDeletion(t *testing.T) {
 				scheduler.ResetAndReportMetrics()
 				tracker.ClearResultsNotNewerThan(time.Now())
 
-				if err := scheduleAll(ti.toSchedule, scheduler); err != nil {
+				if err := scheduleAll(ti.toSchedule, scheduler, tracker); err != nil {
 					t.Fatal(err)
 				}
 				for _, bucket := range ti.toAbort {
 					for _, node := range bucket.Nodes {
+						tracker.StartDeletion(bucket.Group.Id(), node.Name)
 						nodeDeleteResult := status.NodeDeleteResult{ResultType: status.NodeDeleteErrorFailedToDelete, Err: cmpopts.AnyError}
 						scheduler.AbortNodeDeletionDueToError(context.TODO(), node, bucket.Group.Id(), false, "simulated abort", nodeDeleteResult)
 					}
 				}
-				if err := scheduleAll(ti.toScheduleAfterAbort, scheduler); err != nil {
+				if err := scheduleAll(ti.toScheduleAfterAbort, scheduler, tracker); err != nil {
 					t.Fatal(err)
 				}
 
@@ -208,13 +209,14 @@ func (b *countingBatcher) AddNodes(ctx context.Context, nodes []*apiv1.Node, nod
 	b.addedNodes += len(nodes)
 }
 
-func scheduleAll(toSchedule []*budgets.NodeGroupView, scheduler *GroupDeletionScheduler) error {
+func scheduleAll(toSchedule []*budgets.NodeGroupView, scheduler *GroupDeletionScheduler, tracker *deletiontracker.NodeDeletionTracker) error {
 	for _, bucket := range toSchedule {
 		bucketSize, err := bucket.Group.TargetSize(context.TODO())
 		if err != nil {
 			return fmt.Errorf("failed to get target size for node group %q: %s", bucket.Group.Id(), err)
 		}
 		for _, node := range bucket.Nodes {
+			tracker.StartDeletion(bucket.Group.Id(), node.Name)
 			scheduler.ScheduleDeletion(context.TODO(), framework.NewTestNodeInfo(node), bucket.Group, bucketSize, false)
 		}
 	}

--- a/pkg/core/scaledown/actuation/update_latency_tracker.go
+++ b/pkg/core/scaledown/actuation/update_latency_tracker.go
@@ -26,7 +26,8 @@ import (
 )
 
 const sleepDurationWhenPolling = 50 * time.Millisecond
-const waitForTaintingTimeoutDuration = 30 * time.Second
+
+var waitForTaintingTimeoutDuration = 30 * time.Second
 
 type nodeTaintStartTime struct {
 	nodeName  string
@@ -43,16 +44,15 @@ type UpdateLatencyTracker struct {
 	// Sends node tainting start timestamps to the tracker
 	StartTimeChan            chan nodeTaintStartTime
 	sleepDurationWhenPolling time.Duration
-	// Passing a bool will wait for all the started nodes to get tainted and calculate
-	// latency based on latencies observed. (If all the nodes did not get tained within
-	// waitForTaintingTimeoutDuration after passing a bool, latency calculation will be
-	// aborted and the ResultChan will be closed without returning a value) Closing the
-	// AwaitOrStopChan without passing any bool will abort the latency calculation.
-	AwaitOrStopChan chan bool
+	// ExpectedNodeCountChan receives the capacity limit seeded precisely to the count
+	// of successfully tainted nodes. This instructs the tracker to discard start stamps
+	// of any node that failed its API request to bypass the hang.
+	ExpectedNodeCountChan chan int
 	// Communicate back the measured latency
 	ResultChan chan time.Duration
 	// now is used only to make the testing easier
-	now func() time.Time
+	now   func() time.Time
+	sleep func(time.Duration)
 }
 
 // NewUpdateLatencyTracker returns a new NewUpdateLatencyTracker object
@@ -62,21 +62,27 @@ func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister) *UpdateLatencyTra
 		finishTimestamp:          map[string]time.Time{},
 		remainingNodeCount:       0,
 		nodeLister:               nodeLister,
-		StartTimeChan:            make(chan nodeTaintStartTime),
+		StartTimeChan:            make(chan nodeTaintStartTime, 10000),
 		sleepDurationWhenPolling: sleepDurationWhenPolling,
-		AwaitOrStopChan:          make(chan bool),
+		ExpectedNodeCountChan:    make(chan int, 1),
 		ResultChan:               make(chan time.Duration),
 		now:                      time.Now,
+		sleep:                    time.Sleep,
 	}
 }
 
 // Start starts listening for node tainting start timestamps and update the timestamps that
-// the taint appears for the first time for a particular node. Listen AwaitOrStopChan for stop/await signals
+// the taint appears for the first time for a particular node. Listen ExpectedNodeCountChan for stop/await signals
 func (u *UpdateLatencyTracker) Start(ctx context.Context) {
 	for {
 		select {
-		case _, ok := <-u.AwaitOrStopChan:
+		case expectedCount, ok := <-u.ExpectedNodeCountChan:
 			if ok {
+				u.drainStartTimeChan()
+				u.remainingNodeCount = expectedCount - len(u.finishTimestamp)
+				if u.remainingNodeCount < 0 {
+					u.remainingNodeCount = 0
+				}
 				u.await(ctx)
 			}
 			return
@@ -87,7 +93,22 @@ func (u *UpdateLatencyTracker) Start(ctx context.Context) {
 		default:
 		}
 		u.updateFinishTime(ctx)
-		time.Sleep(u.sleepDurationWhenPolling)
+		u.sleep(u.sleepDurationWhenPolling)
+	}
+}
+
+// drainStartTimeChan safely and non-blockingly pulls all pending items out
+// of StartTimeChan until it's completely empty. It uses a select-default idiom
+// to avoid deadlocking, which is a risk when using `len(chan) > 0` checks
+// due to concurrent race conditions.
+func (u *UpdateLatencyTracker) drainStartTimeChan() {
+	for {
+		select {
+		case ntst := <-u.StartTimeChan:
+			u.startTimestamp[ntst.nodeName] = ntst.startTime
+		default:
+			return // Channel is empty, safely exit without blocking.
+		}
 	}
 }
 
@@ -112,7 +133,10 @@ func (u *UpdateLatencyTracker) updateFinishTime(ctx context.Context) {
 func (u *UpdateLatencyTracker) calculateLatency() time.Duration {
 	var maxLatency time.Duration = 0
 	for node, startTime := range u.startTimestamp {
-		endTime, _ := u.finishTimestamp[node]
+		endTime, ok := u.finishTimestamp[node]
+		if !ok {
+			continue
+		}
 		currentLatency := endTime.Sub(startTime)
 		if currentLatency > maxLatency {
 			maxLatency = currentLatency
@@ -123,20 +147,20 @@ func (u *UpdateLatencyTracker) calculateLatency() time.Duration {
 
 func (u *UpdateLatencyTracker) await(ctx context.Context) {
 	logger := klog.FromContext(ctx)
-	waitingForTaintingStartTime := time.Now()
+	waitingForTaintingStartTime := u.now()
 	for {
 		switch {
-		case u.remainingNodeCount == 0:
+		case u.remainingNodeCount <= 0:
 			latency := u.calculateLatency()
 			u.ResultChan <- latency
 			return
-		case time.Now().After(waitingForTaintingStartTime.Add(waitForTaintingTimeoutDuration)):
+		case u.now().After(waitingForTaintingStartTime.Add(waitForTaintingTimeoutDuration)):
 			logger.Error(nil, "Timeout before tainting all nodes, latency measurement will be stale")
 
 			close(u.ResultChan)
 			return
 		default:
-			time.Sleep(u.sleepDurationWhenPolling)
+			u.sleep(u.sleepDurationWhenPolling)
 			u.updateFinishTime(ctx)
 		}
 	}

--- a/pkg/core/scaledown/actuation/update_latency_tracker.go
+++ b/pkg/core/scaledown/actuation/update_latency_tracker.go
@@ -74,8 +74,11 @@ func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister, maxNodes int) *Up
 // Start starts listening for node tainting start timestamps and update the timestamps that
 // the taint appears for the first time for a particular node. Listen ExpectedNodeCountChan for stop/await signals
 func (u *UpdateLatencyTracker) Start(ctx context.Context) {
+	defer close(u.ResultChan)
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case expectedCount, ok := <-u.ExpectedNodeCountChan:
 			if ok {
 				u.drainStartTimeChan()
@@ -91,6 +94,7 @@ func (u *UpdateLatencyTracker) Start(ctx context.Context) {
 			u.remainingNodeCount += 1
 			continue
 		default:
+			u.drainStartTimeChan()
 		}
 		u.updateFinishTime(ctx)
 		u.sleep(u.sleepDurationWhenPolling)
@@ -151,15 +155,22 @@ func (u *UpdateLatencyTracker) await(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	waitingForTaintingStartTime := u.now()
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		switch {
 		case u.remainingNodeCount <= 0:
 			latency := u.calculateLatency()
-			u.ResultChan <- latency
+			select {
+			case u.ResultChan <- latency:
+			case <-ctx.Done():
+			}
 			return
 		case u.now().After(waitingForTaintingStartTime.Add(waitForTaintingTimeoutDuration)):
 			logger.Error(nil, "Timeout before tainting all nodes, latency measurement will be stale")
-
-			close(u.ResultChan)
 			return
 		default:
 			u.sleep(u.sleepDurationWhenPolling)

--- a/pkg/core/scaledown/actuation/update_latency_tracker.go
+++ b/pkg/core/scaledown/actuation/update_latency_tracker.go
@@ -44,7 +44,7 @@ type UpdateLatencyTracker struct {
 	// Sends node tainting start timestamps to the tracker
 	StartTimeChan            chan nodeTaintStartTime
 	sleepDurationWhenPolling time.Duration
-	// ExpectedNodeCountChan receives the capacity limit seeded precisely to the count
+	// ExpectedNodeCountChan receives the capacity limit needed precisely to the count
 	// of successfully tainted nodes. This instructs the tracker to discard start stamps
 	// of any node that failed its API request to bypass the hang.
 	ExpectedNodeCountChan chan int
@@ -56,13 +56,13 @@ type UpdateLatencyTracker struct {
 }
 
 // NewUpdateLatencyTracker returns a new NewUpdateLatencyTracker object
-func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister) *UpdateLatencyTracker {
+func NewUpdateLatencyTracker(nodeLister kubernetes.NodeLister, maxNodes int) *UpdateLatencyTracker {
 	return &UpdateLatencyTracker{
 		startTimestamp:           map[string]time.Time{},
 		finishTimestamp:          map[string]time.Time{},
 		remainingNodeCount:       0,
 		nodeLister:               nodeLister,
-		StartTimeChan:            make(chan nodeTaintStartTime, 10000),
+		StartTimeChan:            make(chan nodeTaintStartTime, maxNodes),
 		sleepDurationWhenPolling: sleepDurationWhenPolling,
 		ExpectedNodeCountChan:    make(chan int, 1),
 		ResultChan:               make(chan time.Duration),
@@ -97,17 +97,19 @@ func (u *UpdateLatencyTracker) Start(ctx context.Context) {
 	}
 }
 
-// drainStartTimeChan safely and non-blockingly pulls all pending items out
-// of StartTimeChan until it's completely empty. It uses a select-default idiom
-// to avoid deadlocking, which is a risk when using `len(chan) > 0` checks
-// due to concurrent race conditions.
+// drainStartTimeChan pulls all pending items out  of u.StartTimeChan.
+// Returns immediately if u.StartTimeChan is empty.
 func (u *UpdateLatencyTracker) drainStartTimeChan() {
 	for {
 		select {
-		case ntst := <-u.StartTimeChan:
+		case ntst, ok := <-u.StartTimeChan:
+			if !ok {
+				return
+			}
 			u.startTimestamp[ntst.nodeName] = ntst.startTime
 		default:
-			return // Channel is empty, safely exit without blocking.
+			// Channel is empty, safely exit without blocking.
+			return
 		}
 	}
 }
@@ -168,8 +170,8 @@ func (u *UpdateLatencyTracker) await(ctx context.Context) {
 
 // NewUpdateLatencyTrackerForTesting returns a UpdateLatencyTracker object with
 // reduced sleepDurationWhenPolling and mock clock for testing
-func NewUpdateLatencyTrackerForTesting(nodeLister kubernetes.NodeLister, now func() time.Time) *UpdateLatencyTracker {
-	updateLatencyTracker := NewUpdateLatencyTracker(nodeLister)
+func NewUpdateLatencyTrackerForTesting(nodeLister kubernetes.NodeLister, maxNodes int, now func() time.Time) *UpdateLatencyTracker {
+	updateLatencyTracker := NewUpdateLatencyTracker(nodeLister, maxNodes)
 	updateLatencyTracker.now = now
 	updateLatencyTracker.sleepDurationWhenPolling = time.Millisecond
 	return updateLatencyTracker

--- a/pkg/core/scaledown/actuation/update_latency_tracker_test.go
+++ b/pkg/core/scaledown/actuation/update_latency_tracker_test.go
@@ -174,7 +174,7 @@ func TestUpdateLatencyCalculation(t *testing.T) {
 				nodes[name] = node
 			}
 			nodeLister := NewTestCustomNodeLister(nodes, tc.nodeTaintAfterDuration, mc)
-			updateLatencyTracker := NewUpdateLatencyTrackerForTesting(nodeLister, mc.Now)
+			updateLatencyTracker := NewUpdateLatencyTrackerForTesting(nodeLister, len(nodes), mc.Now)
 
 			// Synthetically advance mock clock upon each sleep.
 			updateLatencyTracker.sleep = func(d time.Duration) {
@@ -187,12 +187,18 @@ func TestUpdateLatencyCalculation(t *testing.T) {
 			for _, node := range nodes {
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, tc.startTime}
 			}
-			updateLatencyTracker.ExpectedNodeCountChan <- len(tc.nodes)
+			if tc.simulateZeroExpectedCount {
+				close(updateLatencyTracker.ExpectedNodeCountChan)
+				// Wait slightly to ensure Start() loop processes the closed channel.
+				time.Sleep(50 * time.Millisecond)
+			} else {
+				updateLatencyTracker.ExpectedNodeCountChan <- len(tc.nodes)
 
-			latency, ok := <-updateLatencyTracker.ResultChan
-			assert.Equal(t, tc.wantResultChanOpen, ok)
-			if ok {
-				assert.Equal(t, tc.wantLatency, latency)
+				latency, ok := <-updateLatencyTracker.ResultChan
+				assert.Equal(t, tc.wantResultChanOpen, ok)
+				if ok {
+					assert.Equal(t, tc.wantLatency, latency)
+				}
 			}
 		})
 	}

--- a/pkg/core/scaledown/actuation/update_latency_tracker_test.go
+++ b/pkg/core/scaledown/actuation/update_latency_tracker_test.go
@@ -19,6 +19,7 @@ package actuation
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -29,52 +30,36 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
 )
 
-// mockClock is used to mock time.Now() when testing UpdateLatencyTracker
-// For the n th call to Now() it will return a timestamp after duration[n] to
-// the startTime if n < the length of durations. Otherwise, it will return current time.
 type mockClock struct {
-	startTime time.Time
-	durations []time.Duration
-	index     int
-	mutex     sync.Mutex
+	startTime   time.Time
+	currentTime time.Time
+	mutex       sync.Mutex
 }
 
-// Returns a new NewMockClock object
-func NewMockClock(startTime time.Time, durations []time.Duration) mockClock {
-	return mockClock{
-		startTime: startTime,
-		durations: durations,
-		index:     0,
+func NewMockClock(startTime time.Time) *mockClock {
+	return &mockClock{
+		startTime:   startTime,
+		currentTime: startTime,
 	}
 }
 
-// Returns a time after Nth duration from the start time if N < length of durations.
-// Otherwise, returns the current time
 func (m *mockClock) Now() time.Time {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	var timeToSend time.Time
-	if m.index < len(m.durations) {
-		timeToSend = m.startTime.Add(m.durations[m.index])
-	} else {
-		timeToSend = time.Now()
-	}
-	m.index += 1
-	return timeToSend
+	return m.currentTime
 }
 
-// Returns the number of times that the Now function was called
-func (m *mockClock) getIndex() int {
+func (m *mockClock) SetTime(t time.Time) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return m.index
+	m.currentTime = t
 }
 
-// TestCustomNodeLister can be used to mock nodeLister Get call when testing delayed tainting
 type TestCustomNodeLister struct {
-	nodes                    map[string]*apiv1.Node
-	getCallCount             map[string]int
-	nodeTaintAfterNthGetCall map[string]int
+	nodes                  map[string]*apiv1.Node
+	getCallCount           map[string]int
+	nodeTaintAfterDuration map[string]time.Duration
+	clock                  *mockClock
 }
 
 // List returns all nodes in test lister.
@@ -86,15 +71,15 @@ func (l *TestCustomNodeLister) List() ([]*apiv1.Node, error) {
 	return nodes, nil
 }
 
-// Get returns node from test lister. Add ToBeDeletedTaint to the node
-// during the N th call specified in the nodeTaintAfterNthGetCall
 func (l *TestCustomNodeLister) Get(name string) (*apiv1.Node, error) {
 	for _, node := range l.nodes {
 		if node.Name == name {
 			l.getCallCount[node.Name] += 1
-			if _, ok := l.nodeTaintAfterNthGetCall[node.Name]; ok && l.getCallCount[node.Name] == l.nodeTaintAfterNthGetCall[node.Name] {
-				toBeDeletedTaint := apiv1.Taint{Key: taints.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
-				node.Spec.Taints = append(node.Spec.Taints, toBeDeletedTaint)
+			if expectedDuration, ok := l.nodeTaintAfterDuration[node.Name]; ok {
+				if l.clock.Now().Sub(l.clock.startTime) >= expectedDuration {
+					toBeDeletedTaint := apiv1.Taint{Key: taints.ToBeDeletedTaint, Effect: apiv1.TaintEffectNoSchedule}
+					node.Spec.Taints = append(node.Spec.Taints, toBeDeletedTaint)
+				}
 			}
 			return node, nil
 		}
@@ -103,96 +88,111 @@ func (l *TestCustomNodeLister) Get(name string) (*apiv1.Node, error) {
 }
 
 // Return new TestCustomNodeLister object
-func NewTestCustomNodeLister(nodes map[string]*apiv1.Node, nodeTaintAfterNthGetCall map[string]int) *TestCustomNodeLister {
+func NewTestCustomNodeLister(nodes map[string]*apiv1.Node, nodeTaintAfterDuration map[string]time.Duration, clock *mockClock) *TestCustomNodeLister {
 	getCallCounts := map[string]int{}
 	for name := range nodes {
 		getCallCounts[name] = 0
 	}
 	return &TestCustomNodeLister{
-		nodes:                    nodes,
-		getCallCount:             getCallCounts,
-		nodeTaintAfterNthGetCall: nodeTaintAfterNthGetCall,
+		nodes:                  nodes,
+		getCallCount:           getCallCounts,
+		nodeTaintAfterDuration: nodeTaintAfterDuration,
+		clock:                  clock,
 	}
 }
 
 func TestUpdateLatencyCalculation(t *testing.T) {
+	oldTimeout := waitForTaintingTimeoutDuration
+	waitForTaintingTimeoutDuration = 150 * time.Millisecond
+	defer func() { waitForTaintingTimeoutDuration = oldTimeout }()
 
 	testCases := []struct {
 		description string
 		startTime   time.Time
 		nodes       []string
 		// If an entry is not added for a node, that node will never get tainted
-		nodeTaintAfterNthGetCall map[string]int
-		durations                []time.Duration
-		wantLatency              time.Duration
-		wantResultChanOpen       bool
+		nodeTaintAfterDuration    map[string]time.Duration
+		wantLatency               time.Duration
+		wantResultChanOpen        bool
+		simulateZeroExpectedCount bool
 	}{
 		{
-			description:              "latency when tainting a single node - node is tainted in the first call to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 1},
-			durations:                []time.Duration{100 * time.Millisecond},
-			wantLatency:              100 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting a single node - node is tainted in the first call to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond},
+			wantLatency:            100 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "latency when tainting a single node - node is not tainted in the first call to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 3},
-			durations:                []time.Duration{100 * time.Millisecond},
-			wantLatency:              100 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting a single node - node is not tainted in the first call to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond},
+			wantLatency:            100 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "latency when tainting multiple nodes - nodes are tainted in the first calls to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1", "n2"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 1, "n2": 1},
-			durations:                []time.Duration{100 * time.Millisecond, 150 * time.Millisecond},
-			wantLatency:              150 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting multiple nodes - nodes are tainted in the first calls to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1", "n2"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond, "n2": 150 * time.Millisecond},
+			wantLatency:            150 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "latency when tainting multiple nodes - nodes are not tainted in the first calls to the lister",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1", "n2"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 3, "n2": 5},
-			durations:                []time.Duration{100 * time.Millisecond, 150 * time.Millisecond},
-			wantLatency:              150 * time.Millisecond,
-			wantResultChanOpen:       true,
+			description:            "latency when tainting multiple nodes - nodes are not tainted in the first calls to the lister",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1", "n2"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond, "n2": 150 * time.Millisecond},
+			wantLatency:            150 * time.Millisecond,
+			wantResultChanOpen:     true,
 		},
 		{
-			description:              "Some nodes fails to taint before timeout",
-			startTime:                time.Now(),
-			nodes:                    []string{"n1", "n3"},
-			nodeTaintAfterNthGetCall: map[string]int{"n1": 1},
-			durations:                []time.Duration{100 * time.Millisecond, 150 * time.Millisecond},
-			wantResultChanOpen:       false,
+			description:            "Some nodes fails to taint before timeout",
+			startTime:              time.Now(),
+			nodes:                  []string{"n1", "n3"},
+			nodeTaintAfterDuration: map[string]time.Duration{"n1": 100 * time.Millisecond},
+			wantResultChanOpen:     false,
+		},
+		{
+			description:               "Expected count is zero resulting in channel closure",
+			startTime:                 time.Now(),
+			nodes:                     []string{"n1"},
+			nodeTaintAfterDuration:    map[string]time.Duration{},
+			wantResultChanOpen:        false,
+			simulateZeroExpectedCount: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			mc := NewMockClock(tc.startTime, tc.durations)
+			mc := NewMockClock(tc.startTime)
 			nodes := map[string]*apiv1.Node{}
 			for _, name := range tc.nodes {
 				node := test.BuildTestNode(name, 100, 100)
 				nodes[name] = node
 			}
-			nodeLister := NewTestCustomNodeLister(nodes, tc.nodeTaintAfterNthGetCall)
+			nodeLister := NewTestCustomNodeLister(nodes, tc.nodeTaintAfterDuration, mc)
 			updateLatencyTracker := NewUpdateLatencyTrackerForTesting(nodeLister, mc.Now)
+
+			// Synthetically advance mock clock upon each sleep.
+			updateLatencyTracker.sleep = func(d time.Duration) {
+				mc.SetTime(mc.Now().Add(d))
+				// We must explicitly yield because advancing a fake clock doesn't block.
+				// Without this, the Start() loop could starve the main test thread on single-core setups (e.g. GOMAXPROCS=1).
+				runtime.Gosched()
+			}
 			go updateLatencyTracker.Start(context.TODO())
 			for _, node := range nodes {
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, tc.startTime}
 			}
-			updateLatencyTracker.AwaitOrStopChan <- true
+			updateLatencyTracker.ExpectedNodeCountChan <- len(tc.nodes)
+
 			latency, ok := <-updateLatencyTracker.ResultChan
 			assert.Equal(t, tc.wantResultChanOpen, ok)
 			if ok {
 				assert.Equal(t, tc.wantLatency, latency)
-				assert.Equal(t, len(tc.durations), mc.getIndex())
 			}
 		})
 	}

--- a/pkg/core/scaledown/actuation/update_latency_tracker_test.go
+++ b/pkg/core/scaledown/actuation/update_latency_tracker_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package actuation
 
 import (
-	"context"
 	"fmt"
 	"runtime"
 	"sync"
@@ -28,6 +27,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/taints"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+	. "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
 )
 
 type mockClock struct {
@@ -167,6 +167,8 @@ func TestUpdateLatencyCalculation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			ctx := GetTestContext(t)
+
 			mc := NewMockClock(tc.startTime)
 			nodes := map[string]*apiv1.Node{}
 			for _, name := range tc.nodes {
@@ -183,7 +185,7 @@ func TestUpdateLatencyCalculation(t *testing.T) {
 				// Without this, the Start() loop could starve the main test thread on single-core setups (e.g. GOMAXPROCS=1).
 				runtime.Gosched()
 			}
-			go updateLatencyTracker.Start(context.TODO())
+			go updateLatencyTracker.Start(ctx)
 			for _, node := range nodes {
 				updateLatencyTracker.StartTimeChan <- nodeTaintStartTime{node.Name, tc.startTime}
 			}

--- a/pkg/test/integration/clusterstateregistry/scale_up_with_deleted_nodes_test_utils.go
+++ b/pkg/test/integration/clusterstateregistry/scale_up_with_deleted_nodes_test_utils.go
@@ -97,11 +97,11 @@ func RunTestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T, setupFacto
 
 		// ======== STEP 1: Force CA to scale down some empty Nodes ========
 		// The remaining Nodes from the NodeGroup that don't have a Pod scheduled are empty. Run CA loop once to start tracking them as unneeded.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, 0); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, 0); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// Run CA loop again after the unneeded threshold has passed, CA should start scaling down the empty Nodes.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, sdUnneededTime+time.Microsecond); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, sdUnneededTime+time.Microsecond); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// RunOnceAfter() above only returns after all goroutines in the bubble are blocked, so we're guaranteed that DeleteNodes() already decreased the
@@ -117,7 +117,7 @@ func RunTestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T, setupFacto
 			k8s.AddPod(pod)
 		}
 		// Run CA loop with the new pending Pods, CA should scale up a dedicated Node for each pending Pod.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, stepDuration); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// RunOnceAfter() above only returns after all goroutines in the bubble are blocked, so we're guaranteed that IncreaseSize() already increased the
@@ -127,7 +127,7 @@ func RunTestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T, setupFacto
 
 		// ======== STEP 3: Assert that CA doesn't scale up again for the same Pods ========
 		// Run CA loop after a short delay. The deleted Nodes should still be present, and the new Nodes still shouldn't.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, stepDuration); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// CA shouldn't scale up, because the pending Pods should be packed on upcoming Nodes from the previous scale-up. The sizes should be identical to the previous step.
@@ -135,7 +135,7 @@ func RunTestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T, setupFacto
 
 		// ======== STEP 4: Assert that deleted Nodes disappear from the API at the expected time ========
 		// Run CA loop after nodeGarbageCollectionDelay (3 times stepDuration) elapses since the scale-down.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, stepDuration); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// The Nodes should be gone from the API, so we should only see the original Nodes that had Pods scheduled. No changes to the targetSize are expected.
@@ -143,7 +143,7 @@ func RunTestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T, setupFacto
 
 		// ======== STEP 5: Assert that scaled-up Nodes appear in the API at the expected time ========
 		// Run CA loop after nodeRegistrationDelay elapses since the scale-up.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, stepDuration+time.Microsecond); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, stepDuration+time.Microsecond); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// The new Nodes should finally be visible in the API. No changes to the targetSize are expected.
@@ -151,7 +151,7 @@ func RunTestClusterStateRegistryScaleUpWithDeletedNodes(t *testing.T, setupFacto
 
 		// ======== STEP 6: Assert that the final state is stable  ========
 		// Run CA loop after a long delay to verify that the final state is stable.
-		if err := synctestutils.RunOnceAfter(t, autoscaler, 100*stepDuration); err != nil {
+		if err := synctestutils.RunOnceAfter(ctx, t, autoscaler, 100*stepDuration); err != nil {
 			t.Fatalf("RunOnce() unexpected error: %v", err)
 		}
 		// Sizes should be identical to the previous step.

--- a/pkg/test/integration/inmemory/provreq_test.go
+++ b/pkg/test/integration/inmemory/provreq_test.go
@@ -70,7 +70,7 @@ func TestProvReqFullLifecycle(t *testing.T) {
 		tg1, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize(context.TODO())
 		assert.Equal(t, 1, tg1)
 
-		synctestutils.MustRunOnceAfter(t, autoscaler, 10*time.Second)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, 10*time.Second)
 
 		// The NodeGroup should have scaled up by 1 due to the PR
 		tg1After, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize(context.TODO())
@@ -84,10 +84,10 @@ func TestProvReqFullLifecycle(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run CA once to trigger the unneeded evaluation
-		synctestutils.MustRunOnceAfter(t, autoscaler, 10*time.Second)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, 10*time.Second)
 
 		// Step time forward by the ScaleDownUnneededTime (10 mins) + buffer (5 mins)
-		synctestutils.MustRunOnceAfter(t, autoscaler, 15*time.Minute)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, 15*time.Minute)
 
 		tg1Final, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize(context.TODO())
 		assert.Equal(t, 1, tg1Final)

--- a/pkg/test/integration/inmemory/scaledown_test.go
+++ b/pkg/test/integration/inmemory/scaledown_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	k8s_testing "k8s.io/client-go/testing"
+	fakecloudprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	"sigs.k8s.io/cluster-autoscaler/pkg/test/integration"
+	synctestutils "sigs.k8s.io/cluster-autoscaler/pkg/test/integration/synctest"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/taints"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+func TestScaleDown_PartialFailure(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		partialTaintActuationEnabled bool
+		// If PartialTaintActuationEnabled is true, the non-atomic nodegroup will partially delete.
+		// If PartialTaintActuationEnabled is false, the legacy code synchronous logic is used, which aborts the entire targeted batch on any failure.
+		expectedTargetSizeNonAtomic int
+		expectedTargetSizeAtomic    int
+	}{
+		{
+			name:                         "PartialTaintActuation enabled",
+			partialTaintActuationEnabled: true,
+			expectedTargetSizeNonAtomic:  1, // 1 node deleted, 1 node failed
+			expectedTargetSizeAtomic:     2, // atomic group completely aborted
+		},
+		{
+			name:                         "PartialTaintActuation disabled",
+			partialTaintActuationEnabled: false,
+			expectedTargetSizeNonAtomic:  2,
+			expectedTargetSizeAtomic:     2,
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, dynamicDelayEnabled := range []bool{true, false} {
+			testName := fmt.Sprintf("%s-DynamicDelay_%v", tc.name, dynamicDelayEnabled)
+			t.Run(testName, func(t *testing.T) {
+				configBuilder := integration.NewTestConfig().
+					WithOverrides(
+						integration.WithScaleDownUnneededTime(time.Minute),
+						func(o *config.AutoscalingOptions) {
+							o.PartialTaintActuationEnabled = tc.partialTaintActuationEnabled
+							o.DynamicNodeDeleteDelayAfterTaintEnabled = dynamicDelayEnabled
+						},
+					)
+
+				options := configBuilder.ResolveOptions()
+				infra := integration.SetupInfrastructure(t)
+				fakes := infra.Fakes
+
+				synctest.Test(t, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer synctestutils.TearDown(cancel)
+
+					autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+					assert.NoError(t, err)
+
+					// Create atomic node group
+					atomicOpts := &config.NodeGroupAutoscalingOptions{ZeroOrMaxNodeScaling: true}
+					nAtomicTemplate := test.BuildTestNode("ng-atomic-node-template", 1000, 1000, test.IsReady(true))
+					fakes.CloudProvider.AddNodeGroup("ng-atomic",
+						fakecloudprovider.WithNodes(nAtomicTemplate, 2),
+						fakecloudprovider.WithNodeGroupOptions(atomicOpts),
+					)
+					// Create non-atomic node group
+					nNonAtomicTemplate := test.BuildTestNode("ng-nonatomic-node-template", 1000, 1000, test.IsReady(true))
+					fakes.CloudProvider.AddNodeGroup("ng-nonatomic",
+						fakecloudprovider.WithNodes(nNonAtomicTemplate, 2),
+					)
+
+					// Create happy-path node group with no errors
+					nHappyPathTemplate := test.BuildTestNode("ng-happy-path-node-template", 1000, 1000, test.IsReady(true))
+					fakes.CloudProvider.AddNodeGroup("ng-happy-path",
+						fakecloudprovider.WithNodes(nHappyPathTemplate, 2),
+					)
+
+					nodeToFailAtomic := "ng-atomic-node-0"
+					nodeToFailNonAtomic := "ng-nonatomic-node-0"
+
+					// Simulate API failure when applying ToBeDeletedTaint to specific nodes
+					fakes.KubeClient.Fake.PrependReactor("update", "nodes", func(action k8s_testing.Action) (handled bool, ret apimachineryruntime.Object, err error) {
+						updateAction, ok := action.(k8s_testing.UpdateAction)
+						if !ok {
+							return false, nil, nil
+						}
+						node, ok := updateAction.GetObject().(*corev1.Node)
+						if !ok {
+							return false, nil, nil
+						}
+
+						if node.Name == nodeToFailAtomic || node.Name == nodeToFailNonAtomic {
+							if taints.HasToBeDeletedTaint(node) {
+								return true, nil, fmt.Errorf("simulated network error updating taint on node %s", node.Name)
+							}
+						}
+						return false, nil, nil
+					})
+
+					// 1st loop: Marks non-atomic nodes as unneeded. Atomic node groups bypass unneeded time and attempt scale-down immediately, but fail due to taint errors.
+					synctestutils.RunOnceAfter(t, autoscaler, 10*time.Second)
+
+					// 2nd loop: timer exceeds unneeded time, deletion triggered
+					synctestutils.RunOnceAfter(t, autoscaler, time.Minute+time.Second)
+
+					// Wait for Actuator.deleteNodesAsync to wake up from its nodeDeleteDelayAfterTaint sleep
+					time.Sleep(2 * time.Second)
+					synctest.Wait()
+
+					// Verify expected target sizes after partial deletion
+					atomicGroup := fakes.CloudProvider.GetNodeGroup("ng-atomic")
+					assert.NotNil(t, atomicGroup, "expected ng-atomic group to exist")
+					atomicSize, err := atomicGroup.TargetSize()
+					assert.NoError(t, err)
+					assert.Equal(t, tc.expectedTargetSizeAtomic, atomicSize, "atomic target size mismatch")
+
+					nonAtomicGroup := fakes.CloudProvider.GetNodeGroup("ng-nonatomic")
+					assert.NotNil(t, nonAtomicGroup, "expected ng-nonatomic group to exist")
+					nonAtomicSize, err := nonAtomicGroup.TargetSize()
+					assert.NoError(t, err)
+					assert.Equal(t, tc.expectedTargetSizeNonAtomic, nonAtomicSize, fmt.Sprintf("nonatomic target size mismatch, PartialTaintActuation enabled: %v", tc.partialTaintActuationEnabled))
+
+					happyPathGroup := fakes.CloudProvider.GetNodeGroup("ng-happy-path")
+					assert.NotNil(t, happyPathGroup, "expected ng-happy-path group to exist")
+					happyPathSize, err := happyPathGroup.TargetSize()
+					assert.NoError(t, err)
+
+					if tc.partialTaintActuationEnabled {
+						assert.Equal(t, 0, happyPathSize, "expected happy path nodegroup to be fully scaled down")
+					} else {
+						assert.Equal(t, 2, happyPathSize, "expected happy path nodegroup to remain untouched in legacy fallback")
+					}
+
+					// Validate end state: the exact correct nodes are deleted, and all remaining nodes have no taints
+					var remainingNodeNames []string
+					for _, n := range fakes.K8s.Nodes().Items {
+						remainingNodeNames = append(remainingNodeNames, n.Name)
+						assert.False(t, taints.HasToBeDeletedTaint(&n), "node %s should have clean taints", n.Name)
+					}
+
+					if tc.partialTaintActuationEnabled {
+						assert.ElementsMatch(t, []string{"ng-atomic-node-0", "ng-atomic-node-1", "ng-nonatomic-node-0"}, remainingNodeNames, "expected successfully tainted non-atomic sibling to be deleted while failed nodes remain")
+					} else {
+						assert.ElementsMatch(t, []string{"ng-atomic-node-0", "ng-atomic-node-1", "ng-nonatomic-node-0", "ng-nonatomic-node-1", "ng-happy-path-node-0", "ng-happy-path-node-1"}, remainingNodeNames, "with PartialTaintActuation disabled, a taint failure aborts the entire scale-down batch and rolls back all nodes to remain untouched")
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestScaleDown_HappyPath(t *testing.T) {
+	atomicNodeGroupConfig := fakecloudprovider.WithNodeGroupOptions(&config.NodeGroupAutoscalingOptions{ZeroOrMaxNodeScaling: true})
+	nonAtomicNodeGroupConfig := fakecloudprovider.WithNodeGroupOptions(&config.NodeGroupAutoscalingOptions{ZeroOrMaxNodeScaling: false})
+
+	testCases := []struct {
+		name            string
+		nodeGroupConfig fakecloudprovider.NodeGroupOption
+	}{
+		{
+			name:            "Atomic nodegroup",
+			nodeGroupConfig: atomicNodeGroupConfig,
+		},
+		{
+			name:            "Non-atomic nodegroup",
+			nodeGroupConfig: nonAtomicNodeGroupConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, partialTaintActuationEnabled := range []bool{true, false} {
+			for _, dynamicDelayEnabled := range []bool{true, false} {
+				testName := fmt.Sprintf("%s/PartialTaintActuation_enabled_%v-DynamicDelay_%v", tc.name, partialTaintActuationEnabled, dynamicDelayEnabled)
+				t.Run(testName, func(t *testing.T) {
+					configBuilder := integration.NewTestConfig().
+						WithOverrides(
+							integration.WithScaleDownUnneededTime(time.Minute),
+							func(o *config.AutoscalingOptions) {
+								o.PartialTaintActuationEnabled = partialTaintActuationEnabled
+								o.DynamicNodeDeleteDelayAfterTaintEnabled = dynamicDelayEnabled
+							},
+						)
+
+					options := configBuilder.ResolveOptions()
+					infra := integration.SetupInfrastructure(t)
+					fakes := infra.Fakes
+
+					synctest.Test(t, func(t *testing.T) {
+						ctx, cancel := context.WithCancel(context.Background())
+						defer synctestutils.TearDown(cancel)
+
+						autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+						assert.NoError(t, err)
+
+						nTemplate := test.BuildTestNode("ng-node-template", 1000, 1000, test.IsReady(true))
+						fakes.CloudProvider.AddNodeGroup("ng",
+							fakecloudprovider.WithNodes(nTemplate, 2),
+							tc.nodeGroupConfig,
+						)
+
+						// 1st loop: Marks non-atomic nodes as unneeded.
+						synctestutils.MustRunOnceAfter(t, autoscaler, 10*time.Second)
+
+						// 2nd loop: timer exceeds unneeded time, deletion triggered for non-atomic nodes
+						synctestutils.MustRunOnceAfter(t, autoscaler, time.Minute+time.Second)
+
+						// Wait for Actuator.deleteNodesAsync to wake up from its nodeDeleteDelayAfterTaint sleep
+						time.Sleep(2 * time.Second)
+						synctest.Wait()
+
+						// Verify expected target sizes after deletion
+						group := fakes.CloudProvider.GetNodeGroup("ng")
+						assert.NotNil(t, group, "expected ng group to exist")
+						size, err := group.TargetSize()
+						assert.NoError(t, err)
+						assert.Equal(t, 0, size, "expected target size to be 0 for happy path scaledown")
+
+						// Validate end state: all nodes are deleted
+						var remainingNodeNames []string
+						for _, n := range fakes.K8s.Nodes().Items {
+							remainingNodeNames = append(remainingNodeNames, n.Name)
+							assert.False(t, taints.HasToBeDeletedTaint(&n), "node %s should have clean taints", n.Name)
+						}
+						assert.Empty(t, remainingNodeNames, "all nodes should be successfully deleted")
+					})
+				})
+			}
+		}
+	}
+}

--- a/pkg/test/integration/inmemory/scaledown_test.go
+++ b/pkg/test/integration/inmemory/scaledown_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package inmemory
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"testing/synctest"
@@ -76,7 +75,7 @@ func TestScaleDown_PartialFailure(t *testing.T) {
 				fakes := infra.Fakes
 
 				synctest.Test(t, func(t *testing.T) {
-					ctx, cancel := context.WithCancel(context.Background())
+					ctx, cancel := synctestutils.GetTestContext(t)
 					defer synctestutils.TearDown(cancel)
 
 					autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
@@ -124,10 +123,10 @@ func TestScaleDown_PartialFailure(t *testing.T) {
 					})
 
 					// 1st loop: Marks non-atomic nodes as unneeded. Atomic node groups bypass unneeded time and attempt scale-down immediately, but fail due to taint errors.
-					synctestutils.RunOnceAfter(t, autoscaler, 10*time.Second)
+					synctestutils.RunOnceAfter(ctx, t, autoscaler, 10*time.Second)
 
 					// 2nd loop: timer exceeds unneeded time, deletion triggered
-					synctestutils.RunOnceAfter(t, autoscaler, time.Minute+time.Second)
+					synctestutils.RunOnceAfter(ctx, t, autoscaler, time.Minute+time.Second)
 
 					// Wait for Actuator.deleteNodesAsync to wake up from its nodeDeleteDelayAfterTaint sleep
 					time.Sleep(2 * time.Second)
@@ -136,19 +135,19 @@ func TestScaleDown_PartialFailure(t *testing.T) {
 					// Verify expected target sizes after partial deletion
 					atomicGroup := fakes.CloudProvider.GetNodeGroup("ng-atomic")
 					assert.NotNil(t, atomicGroup, "expected ng-atomic group to exist")
-					atomicSize, err := atomicGroup.TargetSize()
+					atomicSize, err := atomicGroup.TargetSize(ctx)
 					assert.NoError(t, err)
 					assert.Equal(t, tc.expectedTargetSizeAtomic, atomicSize, "atomic target size mismatch")
 
 					nonAtomicGroup := fakes.CloudProvider.GetNodeGroup("ng-nonatomic")
 					assert.NotNil(t, nonAtomicGroup, "expected ng-nonatomic group to exist")
-					nonAtomicSize, err := nonAtomicGroup.TargetSize()
+					nonAtomicSize, err := nonAtomicGroup.TargetSize(ctx)
 					assert.NoError(t, err)
 					assert.Equal(t, tc.expectedTargetSizeNonAtomic, nonAtomicSize, fmt.Sprintf("nonatomic target size mismatch, PartialTaintActuation enabled: %v", tc.partialTaintActuationEnabled))
 
 					happyPathGroup := fakes.CloudProvider.GetNodeGroup("ng-happy-path")
 					assert.NotNil(t, happyPathGroup, "expected ng-happy-path group to exist")
-					happyPathSize, err := happyPathGroup.TargetSize()
+					happyPathSize, err := happyPathGroup.TargetSize(ctx)
 					assert.NoError(t, err)
 
 					if tc.partialTaintActuationEnabled {
@@ -212,7 +211,7 @@ func TestScaleDown_HappyPath(t *testing.T) {
 					fakes := infra.Fakes
 
 					synctest.Test(t, func(t *testing.T) {
-						ctx, cancel := context.WithCancel(context.Background())
+						ctx, cancel := synctestutils.GetTestContext(t)
 						defer synctestutils.TearDown(cancel)
 
 						autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
@@ -225,10 +224,10 @@ func TestScaleDown_HappyPath(t *testing.T) {
 						)
 
 						// 1st loop: Marks non-atomic nodes as unneeded.
-						synctestutils.MustRunOnceAfter(t, autoscaler, 10*time.Second)
+						synctestutils.MustRunOnceAfter(ctx, t, autoscaler, 10*time.Second)
 
 						// 2nd loop: timer exceeds unneeded time, deletion triggered for non-atomic nodes
-						synctestutils.MustRunOnceAfter(t, autoscaler, time.Minute+time.Second)
+						synctestutils.MustRunOnceAfter(ctx, t, autoscaler, time.Minute+time.Second)
 
 						// Wait for Actuator.deleteNodesAsync to wake up from its nodeDeleteDelayAfterTaint sleep
 						time.Sleep(2 * time.Second)
@@ -237,7 +236,7 @@ func TestScaleDown_HappyPath(t *testing.T) {
 						// Verify expected target sizes after deletion
 						group := fakes.CloudProvider.GetNodeGroup("ng")
 						assert.NotNil(t, group, "expected ng group to exist")
-						size, err := group.TargetSize()
+						size, err := group.TargetSize(ctx)
 						assert.NoError(t, err)
 						assert.Equal(t, 0, size, "expected target size to be 0 for happy path scaledown")
 

--- a/pkg/test/integration/inmemory/staticautoscaler_test.go
+++ b/pkg/test/integration/inmemory/staticautoscaler_test.go
@@ -63,7 +63,7 @@ func TestStaticAutoscaler_FullLifecycle(t *testing.T) {
 		fakes.K8s.AddPod(p)
 
 		// Run a loop, CA should scale up a single Node for the pending Pod.
-		synctestutils.MustRunOnceAfter(t, autoscaler, stepDuration)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, stepDuration)
 		tg1, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize(context.TODO())
 		assert.Equal(t, 2, tg1)
 		assert.Equal(t, 2, len(fakes.K8s.Nodes().Items))
@@ -72,9 +72,9 @@ func TestStaticAutoscaler_FullLifecycle(t *testing.T) {
 		fakes.K8s.DeletePod(p.Namespace, p.Name)
 
 		// Run CA loop once to mark the Node as unneeded.
-		synctestutils.MustRunOnceAfter(t, autoscaler, stepDuration)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, stepDuration)
 		// Run another CA loop after the unneeded time elapses, CA should delete the Node.
-		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime+time.Nanosecond)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, unneededTime+time.Nanosecond)
 
 		finalSize, _ := fakes.CloudProvider.GetNodeGroup("ng1").TargetSize(context.TODO())
 		assert.Equal(t, 1, finalSize)
@@ -105,14 +105,14 @@ func TestScaleUp_ResourceLimits(t *testing.T) {
 		// Scale-up should be blocked.
 		fakes.CloudProvider.SetResourceLimit(cloudprovider.ResourceNameCores, 0, 1)
 
-		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, unneededTime)
 		size, _ := fakes.CloudProvider.GetNodeGroup("ng").TargetSize(context.TODO())
 		assert.Equal(t, 1, size, "Should not scale up when max cores limit is reached")
 
 		// Scale-up should succeed.
 		fakes.CloudProvider.SetResourceLimit(cloudprovider.ResourceNameCores, 0, 2)
 
-		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime)
+		synctestutils.MustRunOnceAfter(ctx, t, autoscaler, unneededTime)
 		newSize, _ := fakes.CloudProvider.GetNodeGroup("ng").TargetSize(context.TODO())
 		assert.Equal(t, 2, newSize, "Should scale up after resource limit is increased")
 	})

--- a/pkg/test/integration/synctest/template_test.go
+++ b/pkg/test/integration/synctest/template_test.go
@@ -63,7 +63,7 @@ func TestStaticAutoscaler_Template(t *testing.T) {
 		fakes.CloudProvider.AddNodeGroup("ng", fakecloudprovider.WithNode(n))
 		fakes.K8s.AddPod(test.BuildScheduledTestPod("p", 600, 100, n.Name))
 
-		err = RunOnceAfter(t, autoscaler, unneededTime)
+		err = RunOnceAfter(ctx, t, autoscaler, unneededTime)
 		assert.NoError(t, err)
 		// Make assertions.
 		size, _ := fakes.CloudProvider.GetNodeGroup("ng").TargetSize(context.TODO())

--- a/pkg/test/integration/synctest/utils.go
+++ b/pkg/test/integration/synctest/utils.go
@@ -18,23 +18,26 @@ package synctest
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/cluster-autoscaler/pkg/core"
 	"testing"
 	"testing/synctest"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core"
 )
 
 // RunOnceAfter advances the virtual clock by the specified duration and then
 // executes a single Cluster Autoscaler cycle.
-func RunOnceAfter(t *testing.T, autoscaler core.Autoscaler, d time.Duration) error {
+func RunOnceAfter(ctx context.Context, t *testing.T, autoscaler core.Autoscaler, d time.Duration) error {
 	t.Helper()
 
 	// Ensure any pending work is done before changing the time.
 	synctest.Wait()
 
 	time.Sleep(d)
-	err := autoscaler.RunOnce(t.Context(), time.Now())
+	err := autoscaler.RunOnce(ctx, time.Now())
 
 	// Let side-effects of the RunOnce finish.
 	synctest.Wait()
@@ -44,9 +47,9 @@ func RunOnceAfter(t *testing.T, autoscaler core.Autoscaler, d time.Duration) err
 // MustRunOnceAfter is a helper that calls RunOnceAfter and
 // immediately fails the test if an error occurs.
 // Use this for "happy path" simulation steps.
-func MustRunOnceAfter(t *testing.T, autoscaler core.Autoscaler, d time.Duration) {
+func MustRunOnceAfter(ctx context.Context, t *testing.T, autoscaler core.Autoscaler, d time.Duration) {
 	t.Helper()
-	err := RunOnceAfter(t, autoscaler, d)
+	err := RunOnceAfter(ctx, t, autoscaler, d)
 	assert.NoError(t, err)
 }
 
@@ -58,4 +61,11 @@ func TearDown(cancel context.CancelFunc) {
 	// closed context channel, and terminate gracefully.
 	time.Sleep(1 * time.Minute)
 	synctest.Wait()
+}
+
+func GetTestContext(t *testing.T) (context.Context, context.CancelFunc) {
+	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
+	logger = klog.LoggerWithValues(logger, "test", t.Name())
+	ctx, cancel := context.WithCancel(t.Context())
+	return klog.NewContext(ctx, logger), cancel
 }

--- a/pkg/test/integration/synctest/utils.go
+++ b/pkg/test/integration/synctest/utils.go
@@ -63,6 +63,8 @@ func TearDown(cancel context.CancelFunc) {
 	synctest.Wait()
 }
 
+// GetTestContext returns a cancellable context to be used in unit tests and the cancellation function.
+// Logger in this context contains test name in the metadata.
 func GetTestContext(t *testing.T) (context.Context, context.CancelFunc) {
 	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
 	logger = klog.LoggerWithValues(logger, "test", t.Name())

--- a/pkg/utils/test/test_utils.go
+++ b/pkg/utils/test/test_utils.go
@@ -17,10 +17,12 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	kube_types "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
@@ -375,7 +379,7 @@ func BuildTestNode(name string, millicpuCapacity int64, memCapacity int64, opts 
 	node := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:     name,
-				UID:      types.UID(name),
+			UID:      types.UID(name),
 			SelfLink: fmt.Sprintf("/api/v1/nodes/%s", name),
 			Labels:   map[string]string{},
 		},
@@ -658,4 +662,15 @@ func IgnoreObjectOrder[T interface{ GetName() string }]() cmp.Option {
 	return cmpopts.SortSlices(func(c1, c2 T) bool {
 		return c1.GetName() < c2.GetName()
 	})
+}
+
+// GetTestContext returns context to be used in unit tests
+// Logger in this context contains test name in the metadata.
+func GetTestContext(t *testing.T) context.Context {
+	logger, ctx := ktesting.NewTestContext(t)
+	// Append test name to logs
+	logger = klog.LoggerWithValues(logger, "test", t.Name())
+	// Re-wrap the updated logger back into the context
+	ctx = klog.NewContext(ctx, logger)
+	return ctx
 }

--- a/pkg/utils/test/test_utils.go
+++ b/pkg/utils/test/test_utils.go
@@ -375,6 +375,7 @@ func BuildTestNode(name string, millicpuCapacity int64, memCapacity int64, opts 
 	node := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:     name,
+				UID:      types.UID(name),
 			SelfLink: fmt.Sprintf("/api/v1/nodes/%s", name),
 			Labels:   map[string]string{},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, if at least one node couldn't be tainted in a batch of nodes selected for scaledown, taints are cleaned up from all nodes and none of the nodes in the batch are scaled down.

This PR has 4 commits:

1. First commit adds a feature flag `--partial-taint-actuation-enabled`. 
2. Second commit removes a 30s wait in the latency tracker unit tests and refactors latency tracker expect specific number of nodes.
3. Third commit implements the partial taint actuation. If the flag is set to true, CA will scale down all nodes in non-atomic nodegroups that were successfully tainted.  For atomic nodegroups, the behavior is unchanged. If any nodes from an atomic nodegroup weren't tainted successfully, the taints are cleaned up from all the nodes in this nodegroup. The only change is that with partial-taint-actuation-enabled set to true, cleanup is done in parallel  (maxConcurrentNodesTainting nodes at a time). Integration tests for scaledown were added. 
4. The last commit changes how dynamic delay after taint behaves. Currently it measures the time between calling taints.MarkToBeDeleted() and the time when the node appears tainted in the nodeLister (the informer). This mechanism overestimates the latency greatly because the request can spend many seconds in the client-side queue (the queue size is controlled by --kube-api-qps and --kube-api-burst flags). This is a bug fix and it is not hidden behind the feature flag.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds `--partial-taint-actuation-enabled` flag. If it is set to true, CA will scale down all nodes in non-atomic nodegroups that were successfully tainted. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```