### PR TITLE
Track node removal latency for empty and non-empty nodes

### DIFF
--- a/pkg/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/pkg/core/scaledown/latencytracker/node_latency_tracker.go
@@ -39,6 +39,7 @@ const (
 )
 
 type unneededNodeState struct {
+	nodeType metrics.UnneededNodeType
 	unneededSince     time.Time
 	removalThreshold  time.Duration
 	latestDelayReason string
@@ -68,6 +69,7 @@ func (t *NodeLatencyTracker) UpdateScaleDownCandidates(list []*scaledown.Unneede
 		if info, exists := t.unneededNodes[nodeName]; !exists {
 			t.unneededNodes[nodeName] = unneededNodeState{
 				unneededSince:    timestamp,
+				nodeType:         candidate.NodeType,
 				removalThreshold: candidate.RemovalThreshold,
 			}
 			klog.V(6).Infof("Started tracking unneeded node %s at %v with removal threshold %v.", nodeName, timestamp, candidate.RemovalThreshold)
@@ -123,7 +125,7 @@ func (t *NodeLatencyTracker) recordAndCleanup(nodeName string, isRemoved bool) {
 	}
 
 	if latency > 0 {
-		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, delayReason, latency)
+		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, delayReason, info.nodeType, latency)
 	} else {
 		klog.V(6).Infof("Node %q was unneeded for %s (threshold %s). Latency %s is <= 0, skipping metric. isRemoved: %v, delayReason: %v",
 			nodeName, duration, info.removalThreshold, latency, isRemoved, delayReason)

--- a/pkg/core/scaledown/scaledown.go
+++ b/pkg/core/scaledown/scaledown.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaledown
 
 import (
+	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
 	"time"
 
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/status"
@@ -96,4 +97,7 @@ type UnneededNode struct {
 	// This value is derived from either --scale-down-unneeded-time or
 	// --scale-down-unready-time, depending on the node's readiness state.
 	RemovalThreshold time.Duration
+
+	// NodeType indicates whether the node was empty (no pods to reschedule) or non-empty when it was scaled down.
+	NodeType metrics.UnneededNodeType
 }

--- a/pkg/core/scaledown/unneeded/nodes.go
+++ b/pkg/core/scaledown/unneeded/nodes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package unneeded
 
 import (
+	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
 	"fmt"
 	"time"
 
@@ -186,9 +187,15 @@ func (n *Nodes) AsList() []*scaledown.UnneededNode {
 	if n.cachedList == nil {
 		n.cachedList = make([]*scaledown.UnneededNode, 0, len(n.byName))
 		for _, v := range n.byName {
+			nodeType := metrics.NonEmptyUnneededNode
+			if len(v.ntbr.PodsToReschedule) == 0 {
+				nodeType = metrics.EmptyUnneededNode
+			}
+
 			n.cachedList = append(n.cachedList, &scaledown.UnneededNode{
 				Node:             v.ntbr.Node,
 				RemovalThreshold: v.removalThreshold,
+				NodeType:         nodeType,
 			})
 		}
 	}

--- a/pkg/metrics/legacy_functions.go
+++ b/pkg/metrics/legacy_functions.go
@@ -248,8 +248,8 @@ func ObserveBinpackingHeterogeneity(instanceType, cpuCount, namespaceCount strin
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneeded
-func UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, duration time.Duration) {
-	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, delayReason, duration)
+func UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, nodeType UnneededNodeType, duration time.Duration) {
+	DefaultMetrics.UpdateScaleDownNodeRemovalLatency(deleted, delayReason, nodeType, duration)
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,6 +36,9 @@ import (
 // NodeScaleDownReason describes reason for removing node
 type NodeScaleDownReason string
 
+// UnneededNodeType describes if an unneeded node is empty or non-empty
+type UnneededNodeType string
+
 // FailedScaleUpReason describes reason of failed scale-up
 type FailedScaleUpReason string
 
@@ -97,6 +100,11 @@ const (
 	PodEvictionSucceed PodEvictionResult = "succeeded"
 	// PodEvictionFailed means creation of the pod eviction object failed
 	PodEvictionFailed PodEvictionResult = "failed"
+
+	// EmptyUnneededNode is an unneeded node with no pods to reschedule
+	EmptyUnneededNode UnneededNodeType = "empty"
+	// NonEmptyUnneededNode is an unneeded node with pods to reschedule
+	NonEmptyUnneededNode UnneededNodeType = "non-empty"
 
 	gpuNodeMetricsDeprecatedVersion = "1.36.0"
 )
@@ -529,7 +537,7 @@ func newCaMetrics() *caMetrics {
 				Name:      "node_removal_latency_seconds",
 				Help:      "Latency from when an unneeded node is eligible for scale down until it is removed (deleted=true) or it became needed again (deleted=false). The 'delay_reason' label indicates the technical bottleneck that delayed the scale-down ('none' if not delayed).",
 				Buckets:   k8smetrics.ExponentialBuckets(1, 1.5, 19), // ~1s → ~24min
-			}, []string{"deleted", "delay_reason"},
+			}, []string{"deleted", "delay_reason", "type"},
 		),
 
 		nodeTemplateResourcesMismatch: k8smetrics.NewGaugeVec(
@@ -923,8 +931,8 @@ func (m *caMetrics) ObserveBinpackingHeterogeneity(instanceType, cpuCount, names
 
 // UpdateScaleDownNodeRemovalLatency records the time after which node was deleted/needed
 // again after being marked unneeded
-func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, duration time.Duration) {
-	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), delayReason).Observe(duration.Seconds())
+func (m *caMetrics) UpdateScaleDownNodeRemovalLatency(deleted bool, delayReason string, nodeType UnneededNodeType, duration time.Duration) {
+	m.scaleDownNodeRemovalLatency.WithLabelValues(strconv.FormatBool(deleted), delayReason, string(nodeType)).Observe(duration.Seconds())
 }
 
 // ObserveMaxNodeSkipEvalDurationSeconds records the longest time during which node was skipped during ScaleDown.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -92,17 +92,17 @@ func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	m := newCaMetricsWithRegistry(reg)
 	m.RegisterAll(false)
 
-	m.UpdateScaleDownNodeRemovalLatency(true, "none", 10*time.Second)
-	m.UpdateScaleDownNodeRemovalLatency(false, "BlockedByPod", 20*time.Second)
+	m.UpdateScaleDownNodeRemovalLatency(true, "none", EmptyUnneededNode, 10*time.Second)
+	m.UpdateScaleDownNodeRemovalLatency(false, "BlockedByPod", NonEmptyUnneededNode, 20*time.Second)
 
 	var metric1 dto.Metric
-	err := m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("true", "none").(prometheus.Histogram).Write(&metric1)
+	err := m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("true", "none", "empty").(prometheus.Histogram).Write(&metric1)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), metric1.Histogram.GetSampleCount())
 	assert.Equal(t, 10.0, metric1.Histogram.GetSampleSum())
 
 	var metric2 dto.Metric
-	err = m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("false", "BlockedByPod").(prometheus.Histogram).Write(&metric2)
+	err = m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("false", "BlockedByPod", "non-empty").(prometheus.Histogram).Write(&metric2)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), metric2.Histogram.GetSampleCount())
 	assert.Equal(t, 20.0, metric2.Histogram.GetSampleSum())


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR allows us to track node removal latency for empty and non-empty nodes. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An unneded_type field was added to the node removal latency metric.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
