### PR TITLE
ci: remove global gc flag from workflow

### DIFF
--- a/.github/workflows/ca-benchmark.yaml
+++ b/.github/workflows/ca-benchmark.yaml
@@ -39,13 +39,13 @@ jobs:
         shell: bash
         run: |
           cd base/
-          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./pkg/core/bench/... -args -gc true | tee ../base.txt
+          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./pkg/core/bench/... | tee ../base.txt
 
       - name: Run Benchmark (PR)
         shell: bash
         run: |
           cd pr/
-          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./pkg/core/bench/... -args -gc true | tee ../pr.txt
+          go test -v -bench=BenchmarkRunOnce -benchmem -count=8 ./pkg/core/bench/... | tee ../pr.txt
 
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest

--- a/pkg/core/bench/benchmark_runonce_test.go
+++ b/pkg/core/bench/benchmark_runonce_test.go
@@ -91,7 +91,7 @@ const (
 var (
 	runOnceCpuProfile = flag.String("profile-cpu", "", "If set, the benchmark writes a CPU profile to this file, covering the RunOnce execution during the first iteration.")
 	runOnceTrace      = flag.String("trace", "", "If set, the benchmark writes an execution trace to this file, covering the RunOnce execution during the first iteration.")
-	withGC            = flag.Bool("gc", false, "If set to false, the benchmark disables garbage collection to stabilize the runtime.")
+	withGC            = flag.Bool("gc", true, "If set to false, the benchmark disables garbage collection to stabilize the runtime.")
 )
 
 type scenario struct {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test

#### What this PR does / why we need it:
This change removes the global `-gc` flag from benchmarking CI workflow and moves default activation directly into the specific benchmark to prepare the CI for upcoming changes in PR #18 . This way, the existing benchmark retains intended `gc` behaviour without applying the flag to other benchmark suites in the package and causing CI tests to fail. The change is backward-compatible and independent from #18.