### PR TITLE
Support ResourceClaimTemplates in check-capacity ProvisioningRequests

### DIFF
--- a/kwok/charts/templates/clusterrole.yaml
+++ b/kwok/charts/templates/clusterrole.yaml
@@ -62,6 +62,7 @@ rules:
       - resourceslices
       - deviceclasses
       - resourceclaims
+      - resourceclaimtemplates
     verbs:
       - watch
       - list

--- a/pkg/FAQ.md
+++ b/pkg/FAQ.md
@@ -584,7 +584,7 @@ For a detailed explanation of the ProvisioningRequest API, please refer to the
 2. __Feature Flag__: Enable ProvisioningRequest support by setting the following flag in your Cluster Autoscaler configuration:
 `--enable-provisioning-requests=true`.
 
-4. __RBAC permissions__: Ensure your cluster-autoscaler pod has the necessary permissions to interact with ProvisioningRequests and PodTemplates:
+4. __RBAC permissions__: Ensure your cluster-autoscaler pod has the necessary permissions to interact with ProvisioningRequests, PodTemplates, and ResourceClaimTemplates:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1
@@ -600,6 +600,9 @@ rules:
     verbs: ["watch", "list", "get", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["podtemplates"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaimtemplates"]
     verbs: ["watch", "list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/builder/clients.go
+++ b/pkg/builder/clients.go
@@ -23,6 +23,7 @@ import (
 
 	provreqclientset "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/clientset/versioned"
 	provreqinformers "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/informers/externalversions"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	coreoptions "sigs.k8s.io/cluster-autoscaler/pkg/core/options"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/besteffortatomic"
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/checkcapacity"
 	provreqorchestrator "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/orchestrator"
+	provreqpods "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/pods"
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqclient"
 	kube_util "sigs.k8s.io/cluster-autoscaler/pkg/utils/kubernetes"
 )
@@ -66,6 +68,11 @@ func (b *AutoscalerBuilder) buildProvisioningRequest(
 	provReqLister := prFactory.Autoscaling().V1().ProvisioningRequests().Lister()
 
 	podTemplLister := b.informerFactory.Core().V1().PodTemplates().Lister()
+	var resourceClaimTemplateLister resourcelisters.ResourceClaimTemplateLister
+	if autoscalingOptions.DynamicResourceAllocationEnabled {
+		resourceClaimTemplateLister = b.informerFactory.Resource().V1().ResourceClaimTemplates().Lister()
+	}
+	simulationWorkloadBuilder := provreqpods.NewSimulationWorkloadBuilder(resourceClaimTemplateLister)
 
 	client := provreqclient.NewProvisioningRequestClient(prClient, provReqLister, podTemplLister)
 
@@ -79,7 +86,7 @@ func (b *AutoscalerBuilder) buildProvisioningRequest(
 	}
 	klog.V(2).Info("Successful initial Provisioning Request sync")
 
-	injector := provreq.NewProvisioningRequestPodsInjector(client, opts.ProvisioningRequestInitialBackoffTime, opts.ProvisioningRequestMaxBackoffTime, opts.ProvisioningRequestMaxBackoffCacheSize, opts.CheckCapacityBatchProcessing, opts.CheckCapacityProcessorInstance)
+	injector := provreq.NewProvisioningRequestPodsInjector(client, opts.ProvisioningRequestInitialBackoffTime, opts.ProvisioningRequestMaxBackoffTime, opts.ProvisioningRequestMaxBackoffCacheSize, opts.CheckCapacityBatchProcessing, opts.CheckCapacityProcessorInstance, simulationWorkloadBuilder)
 	podListProcessor.AddProcessor(injector)
 
 	var provisioningRequestPodsInjector *provreq.ProvisioningRequestPodsInjector
@@ -89,13 +96,13 @@ func (b *AutoscalerBuilder) buildProvisioningRequest(
 	}
 
 	provreqOrchestrator := provreqorchestrator.New(client, []provreqorchestrator.ProvisioningClass{
-		checkcapacity.New(client, provisioningRequestPodsInjector),
+		checkcapacity.New(client, provisioningRequestPodsInjector, simulationWorkloadBuilder),
 		besteffortatomic.New(client),
 	})
 
 	scaleUpOrchestrator := provreqorchestrator.NewWrapperOrchestrator(provreqOrchestrator)
 	opts.ScaleUpOrchestrator = scaleUpOrchestrator
-	provreqProcesor := provreq.NewProvReqProcessor(client, opts.CheckCapacityProcessorInstance)
+	provreqProcesor := provreq.NewProvReqProcessor(client, opts.CheckCapacityProcessorInstance, simulationWorkloadBuilder)
 
 	podListProcessor.AddProcessor(provreqProcesor)
 

--- a/pkg/builder/clients_test.go
+++ b/pkg/builder/clients_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	provreqfake "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/client/clientset/versioned/fake"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	coreoptions "sigs.k8s.io/cluster-autoscaler/pkg/core/options"
+	ca_processors "sigs.k8s.io/cluster-autoscaler/pkg/processors"
+	"sigs.k8s.io/cluster-autoscaler/pkg/processors/pods"
+)
+
+func TestBuildProvisioningRequestRegistersResourceClaimTemplateInformerOnlyWithDRA(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		draEnabled bool
+	}{
+		{name: "DRA disabled", draEnabled: false},
+		{name: "DRA enabled", draEnabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			kubeClient := kubefake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+			builder := &AutoscalerBuilder{
+				informerFactory: informerFactory,
+				prClient:        provreqfake.NewSimpleClientset(),
+			}
+			opts := &coreoptions.AutoscalerOptions{Processors: &ca_processors.AutoscalingProcessors{}}
+
+			_, _, err := builder.buildProvisioningRequest(
+				ctx,
+				config.AutoscalingOptions{DynamicResourceAllocationEnabled: tc.draEnabled},
+				opts,
+				pods.NewCombinedPodListProcessor(nil),
+			)
+			require.NoError(t, err)
+
+			informerFactory.Start(ctx.Done())
+			for _, synced := range informerFactory.WaitForCacheSync(ctx.Done()) {
+				require.True(t, synced)
+			}
+
+			rctInformerStarted := false
+			for _, action := range kubeClient.Actions() {
+				if action.GetResource().Resource == "resourceclaimtemplates" {
+					rctInformerStarted = true
+					break
+				}
+			}
+			assert.Equal(t, tc.draEnabled, rctInformerStarted)
+		})
+	}
+}

--- a/pkg/hack/e2e/gce-deployment-template.yaml
+++ b/pkg/hack/e2e/gce-deployment-template.yaml
@@ -67,7 +67,7 @@ rules:
     resources: [ "leases" ]
     verbs: [ "get", "update" ]
   - apiGroups: [ "resource.k8s.io" ]
-    resources: [ "resourceslices", "deviceclasses", "resourceclaims" ]
+    resources: [ "resourceslices", "deviceclasses", "resourceclaims", "resourceclaimtemplates" ]
     verbs: [ "list", "watch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/processors/provreq/injector.go
+++ b/pkg/processors/provreq/injector.go
@@ -45,6 +45,7 @@ type ProvisioningRequestPodsInjector struct {
 	lastProvisioningRequestProcessTime time.Time
 	checkCapacityBatchProcessing       bool
 	checkCapacityProcessorInstance     string
+	simulationWorkloadBuilder          *provreqpods.SimulationWorkloadBuilder
 }
 
 // IsAvailableForProvisioning checks if the provisioning request is the correct state for processing and provisioning has not been attempted recently.
@@ -145,16 +146,16 @@ func (p *ProvisioningRequestPodsInjector) GetPodsFromNextRequest(ctx context.Con
 	return nil, nil
 }
 
-// ProvisioningRequestWithPods contains a ProvisioningRequest Wrapper
-// and its associated pods.
+// ProvisioningRequestWithPods contains a ProvisioningRequest wrapper and its
+// complete in-memory scheduling workload.
 type ProvisioningRequestWithPods struct {
 	PrWrapper *provreqwrapper.ProvisioningRequest
-	Pods      []*apiv1.Pod
+	Workload  *provreqpods.SimulationWorkload
 }
 
 // GetCheckCapacityBatch returns up to the requested number of ProvisioningRequestWithPods.
 // We do not mark the PRs as accepted here.
-// If we fail to get the pods for a PR, we mark the PR as failed and issue an update.
+// If we fail to build the simulation workload for a PR, we mark the PR as failed and issue an update.
 func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(ctx context.Context, maxPrs int) ([]ProvisioningRequestWithPods, error) {
 	logger := klog.FromContext(ctx)
 	provReqs, err := p.client.ProvisioningRequests(ctx)
@@ -173,13 +174,13 @@ func (p *ProvisioningRequestPodsInjector) GetCheckCapacityBatch(ctx context.Cont
 			continue
 		}
 
-		pods, err := provreqpods.PodsForProvisioningRequest(pr)
+		workload, err := p.simulationWorkloadBuilder.ForProvisioningRequest(pr)
 		if err != nil {
-			logger.Error(err, "Failed to get pods for ProvisioningRequest", "provReq", klog.KObj(pr))
+			logger.Error(err, "Failed to create simulation workload for ProvisioningRequest", "provReq", klog.KObj(pr))
 			p.MarkAsFailed(ctx, pr, provreqconditions.FailedToCreatePodsReason, err.Error())
 			continue
 		}
-		prsWithPods = append(prsWithPods, ProvisioningRequestWithPods{pr, pods})
+		prsWithPods = append(prsWithPods, ProvisioningRequestWithPods{PrWrapper: pr, Workload: workload})
 	}
 	return prsWithPods, nil
 }
@@ -202,7 +203,7 @@ func (p *ProvisioningRequestPodsInjector) Process(
 func (p *ProvisioningRequestPodsInjector) CleanUp() {}
 
 // NewProvisioningRequestPodsInjector creates a ProvisioningRequest filter processor.
-func NewProvisioningRequestPodsInjector(client *provreqclient.ProvisioningRequestClient, initialBackoffTime, maxBackoffTime time.Duration, maxCacheSize int, checkCapacityBatchProcessing bool, checkCapacityProcessorInstance string) *ProvisioningRequestPodsInjector {
+func NewProvisioningRequestPodsInjector(client *provreqclient.ProvisioningRequestClient, initialBackoffTime, maxBackoffTime time.Duration, maxCacheSize int, checkCapacityBatchProcessing bool, checkCapacityProcessorInstance string, simulationWorkloadBuilder *provreqpods.SimulationWorkloadBuilder) *ProvisioningRequestPodsInjector {
 	return &ProvisioningRequestPodsInjector{
 		initialRetryTime:                   initialBackoffTime,
 		maxBackoffTime:                     maxBackoffTime,
@@ -212,6 +213,7 @@ func NewProvisioningRequestPodsInjector(client *provreqclient.ProvisioningReques
 		lastProvisioningRequestProcessTime: time.Now(),
 		checkCapacityBatchProcessing:       checkCapacityBatchProcessing,
 		checkCapacityProcessorInstance:     checkCapacityProcessorInstance,
+		simulationWorkloadBuilder:          simulationWorkloadBuilder,
 	}
 }
 

--- a/pkg/processors/provreq/injector_materialization_test.go
+++ b/pkg/processors/provreq/injector_materialization_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provreq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	provreqv1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/tools/cache"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/conditions"
+	provreqpods "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/pods"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqclient"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqwrapper"
+)
+
+func TestGetCheckCapacityBatchCarriesMaterializedClaims(t *testing.T) {
+	pr := provisioningRequestWithTemplateClaim("gpu-template", 2)
+	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr)
+	builder := provreqpods.NewSimulationWorkloadBuilder(injectorTemplateLister(t,
+		&resourcev1.ResourceClaimTemplate{ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"}},
+	))
+	injector := NewFakePodsInjector(client, clocktesting.NewFakePassiveClock(time.Now()), builder)
+
+	batch, err := injector.GetCheckCapacityBatch(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	require.NotNil(t, batch[0].Workload)
+	require.Len(t, batch[0].Workload.Pods, 2)
+	require.Len(t, batch[0].Workload.Claims, 2)
+	assert.NotEqual(t, batch[0].Workload.Claims[0].Name, batch[0].Workload.Claims[1].Name)
+	for i, pod := range batch[0].Workload.Pods {
+		require.Len(t, pod.Status.ResourceClaimStatuses, 1)
+		assert.Equal(t, batch[0].Workload.Claims[i].Name, ptr.Deref(pod.Status.ResourceClaimStatuses[0].ResourceClaimName, ""))
+	}
+}
+
+func TestGetCheckCapacityBatchMarksMissingTemplateFailed(t *testing.T) {
+	pr := provisioningRequestWithTemplateClaim("missing-template", 1)
+	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr)
+	injector := NewProvisioningRequestPodsInjector(client, time.Minute, 10*time.Minute, 100, true, "",
+		provreqpods.NewSimulationWorkloadBuilder(injectorTemplateLister(t)))
+
+	batch, err := injector.GetCheckCapacityBatch(t.Context(), 1)
+	require.NoError(t, err)
+	assert.Empty(t, batch)
+	updated, err := client.ProvisioningRequestNoCache(pr.Namespace, pr.Name)
+	require.NoError(t, err)
+	failed := apimeta.FindStatusCondition(updated.Status.Conditions, provreqv1.Failed)
+	require.NotNil(t, failed)
+	assert.Equal(t, conditions.FailedToCreatePodsReason, failed.Reason)
+}
+
+func provisioningRequestWithTemplateClaim(templateName string, count int) *provreqwrapper.ProvisioningRequest {
+	pr := testProvisioningRequestWithCondition("test-pr", count, provreqv1.ProvisioningClassCheckCapacity)
+	pr.PodTemplates[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+	return pr
+}
+
+func injectorTemplateLister(t *testing.T, templates ...*resourcev1.ResourceClaimTemplate) resourcelisters.ResourceClaimTemplateLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, template := range templates {
+		require.NoError(t, indexer.Add(template))
+	}
+	return resourcelisters.NewResourceClaimTemplateLister(indexer)
+}

--- a/pkg/processors/provreq/injector_test.go
+++ b/pkg/processors/provreq/injector_test.go
@@ -174,7 +174,16 @@ func TestProvisioningRequestPodsInjector(t *testing.T) {
 		client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, tc.provReqs...)
 		backoffTime := lru.New(100)
 		backoffTime.Add(key(notProvisionedRecentlyProvReqB), 2*time.Minute)
-		injector := ProvisioningRequestPodsInjector{1 * time.Minute, 10 * time.Minute, backoffTime, clock.NewFakePassiveClock(now), client, now, tc.checkCapacityBatchProcessing, tc.checkCapacityProcessorInstance}
+		injector := ProvisioningRequestPodsInjector{
+			initialRetryTime:                   time.Minute,
+			maxBackoffTime:                     10 * time.Minute,
+			backoffDuration:                    backoffTime,
+			clock:                              clock.NewFakePassiveClock(now),
+			client:                             client,
+			lastProvisioningRequestProcessTime: now,
+			checkCapacityBatchProcessing:       tc.checkCapacityBatchProcessing,
+			checkCapacityProcessorInstance:     tc.checkCapacityProcessorInstance,
+		}
 		getUnscheduledPods, err := injector.Process(context.Background(), nil, provreqwrapper.BuildTestPods("ns", "pod", tc.existingUnsUnschedulablePodCount))
 		if err != nil {
 			t.Errorf("%s failed: injector.Process return error %v", tc.name, err)

--- a/pkg/processors/provreq/processor.go
+++ b/pkg/processors/provreq/processor.go
@@ -24,6 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/klog/v2"
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
@@ -55,11 +56,12 @@ type provReqProcessor struct {
 	client                         *provreqclient.ProvisioningRequestClient
 	injector                       injector
 	checkCapacityProcessorInstance string
+	simulationWorkloadBuilder      *provreq_pods.SimulationWorkloadBuilder
 }
 
 // NewProvReqProcessor return ProvisioningRequestProcessor.
-func NewProvReqProcessor(client *provreqclient.ProvisioningRequestClient, checkCapacityProcessorInstance string) *provReqProcessor {
-	return &provReqProcessor{now: time.Now, maxUpdated: defaultMaxUpdated, client: client, injector: scheduling.NewHintingSimulator(), checkCapacityProcessorInstance: checkCapacityProcessorInstance}
+func NewProvReqProcessor(client *provreqclient.ProvisioningRequestClient, checkCapacityProcessorInstance string, simulationWorkloadBuilder *provreq_pods.SimulationWorkloadBuilder) *provReqProcessor {
+	return &provReqProcessor{now: time.Now, maxUpdated: defaultMaxUpdated, client: client, injector: scheduling.NewHintingSimulator(), checkCapacityProcessorInstance: checkCapacityProcessorInstance, simulationWorkloadBuilder: simulationWorkloadBuilder}
 }
 
 // Refresh implements loop.Observer interface and will be run at the start
@@ -142,11 +144,20 @@ func (p *provReqProcessor) Process(ctx context.Context, autoscalingCtx *ca_conte
 // bookCapacity schedule fake pods for ProvisioningRequest that should have reserved capacity
 // in the cluster.
 func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext) error {
-	logger := klog.FromContext(ctx)
 	provReqs, err := p.client.ProvisioningRequests(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't fetch ProvisioningRequests in the cluster: %v", err)
 	}
+	return p.bookProvisioningRequests(ctx, autoscalingCtx, provReqs)
+}
+
+type capacityBooking struct {
+	provReq  *provreqwrapper.ProvisioningRequest
+	workload *provreq_pods.SimulationWorkload
+}
+
+func (p *provReqProcessor) bookProvisioningRequests(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, provReqs []*provreqwrapper.ProvisioningRequest) error {
+	logger := klog.FromContext(ctx)
 	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
 	if err != nil {
 		return fmt.Errorf("couldn't list nodes: %v", err)
@@ -160,7 +171,7 @@ func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_
 			}
 		}
 	}
-	podsToCreate := []*apiv1.Pod{}
+	var bookings []capacityBooking
 	for _, provReq := range provReqs {
 		if !conditions.ShouldCapacityBeBooked(ctx, provReq, p.checkCapacityProcessorInstance) {
 			continue
@@ -173,27 +184,93 @@ func (p *provReqProcessor) bookCapacity(ctx context.Context, autoscalingCtx *ca_
 			}
 			continue
 		}
+		if provisioningrequest.SupportedCheckCapacityClass(ctx, provReq.ProvisioningRequest, p.checkCapacityProcessorInstance) {
+			workload, err := p.simulationWorkloadBuilder.ForProvisioningRequest(provReq)
+			if err != nil {
+				p.markFailedToBookCapacity(ctx, provReq, fmt.Sprintf("Couldn't create simulation workload: %v", err))
+				continue
+			}
+			bookings = append(bookings, capacityBooking{provReq: provReq, workload: workload})
+			continue
+		}
 		pods, err := provreq_pods.PodsForProvisioningRequest(provReq)
 		if err != nil {
 			// ClusterAutoscaler was able to create pods before, so we shouldn't have error here.
 			// If there is an error, mark PR as invalid, because we won't be able to book capacity
 			// for it anyway.
-			conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.FailedToBookCapacityReason, fmt.Sprintf("Couldn't create pods, err: %v", err), metav1.Now())
-			if _, err := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest); err != nil {
-				logger.Error(err, "failed to add Accepted condition to ProvReq", "provReq", klog.KObj(provReq))
-			}
+			p.markFailedToBookCapacity(ctx, provReq, fmt.Sprintf("Couldn't create pods, err: %v", err))
 			continue
 		}
-		podsToCreate = append(podsToCreate, pods...)
+		bookings = append(bookings, capacityBooking{workload: &provreq_pods.SimulationWorkload{Pods: pods}})
 	}
-	if len(podsToCreate) == 0 {
+	return p.bookCapacityBookings(ctx, autoscalingCtx, bookings)
+}
+
+func (p *provReqProcessor) bookCapacityBookings(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, bookings []capacityBooking) error {
+	if len(bookings) == 0 {
 		return nil
 	}
-	// Scheduling the pods to reserve capacity for provisioning request.
-	if _, err = p.injector.TrySchedulePods(context.Background(), autoscalingCtx.ClusterSnapshot, podsToCreate, false, clustersnapshot.SchedulingOptions{}); err != nil {
+
+	// Schedule all booking Pods together so pod priority is applied globally.
+	autoscalingCtx.ClusterSnapshot.Fork()
+	validBookings := make([]capacityBooking, 0, len(bookings))
+	var pods []*apiv1.Pod
+	for _, booking := range bookings {
+		if len(booking.workload.Claims) > 0 {
+			if err := autoscalingCtx.ClusterSnapshot.DraSnapshot().AddClaims(booking.workload.Claims); err != nil {
+				p.markFailedToBookCapacity(ctx, booking.provReq, fmt.Sprintf("Couldn't add simulated ResourceClaims: %v", err))
+				continue
+			}
+		}
+		validBookings = append(validBookings, booking)
+		pods = append(pods, booking.workload.Pods...)
+	}
+	if len(pods) == 0 {
+		autoscalingCtx.ClusterSnapshot.Revert()
+		return nil
+	}
+
+	schedulingResult, err := p.injector.TrySchedulePods(ctx, autoscalingCtx.ClusterSnapshot, pods, false, clustersnapshot.SchedulingOptions{})
+	if err != nil {
+		autoscalingCtx.ClusterSnapshot.Revert()
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		autoscalingCtx.ClusterSnapshot.Revert()
+		return fmt.Errorf("couldn't book capacity because scheduling was interrupted: %w", err)
+	}
+
+	// Retain claims only for Pods that scheduled; statuses may be reordered.
+	scheduledPods := make(map[types.UID]struct{}, len(schedulingResult.Statuses))
+	for _, schedulingStatus := range schedulingResult.Statuses {
+		if schedulingStatus.Pod != nil {
+			scheduledPods[schedulingStatus.Pod.UID] = struct{}{}
+		}
+	}
+	for _, booking := range validBookings {
+		if len(booking.workload.Claims) == 0 {
+			continue
+		}
+		for _, pod := range booking.workload.Pods {
+			if _, found := scheduledPods[pod.UID]; !found {
+				autoscalingCtx.ClusterSnapshot.DraSnapshot().RemovePodOwnedClaims(ctx, pod)
+			}
+		}
+	}
+
+	if err := autoscalingCtx.ClusterSnapshot.Commit(); err != nil {
+		autoscalingCtx.ClusterSnapshot.Revert()
+		return fmt.Errorf("couldn't commit booked capacity: %w", err)
+	}
 	return nil
+}
+
+func (p *provReqProcessor) markFailedToBookCapacity(ctx context.Context, provReq *provreqwrapper.ProvisioningRequest, message string) {
+	logger := klog.FromContext(ctx)
+	conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.FailedToBookCapacityReason, message, metav1.Now())
+	if _, err := p.client.UpdateProvisioningRequest(ctx, provReq.ProvisioningRequest); err != nil {
+		logger.Error(err, "failed to add Failed condition to ProvReq", "provReq", klog.KObj(provReq))
+	}
 }
 
 // DeleteOldProvReqs delete ProvReq that have terminal state (Provisioned/Failed == True) more than a week.

--- a/pkg/processors/provreq/processor_materialization_test.go
+++ b/pkg/processors/provreq/processor_materialization_test.go
@@ -1,0 +1,470 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provreq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
+	coretest "sigs.k8s.io/cluster-autoscaler/pkg/core/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/conditions"
+	provreqpods "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/pods"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqclient"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqwrapper"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/scheduling"
+	testutils "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+const bookingProcessorInstance = "test-instance"
+
+func TestBookCapacityPreservesPriorityAcrossProvisioningRequests(t *testing.T) {
+	lowPriorityPr := ordinaryBookingProvisioningRequest("low-priority")
+	setBookingPodPriorityAndCPU(lowPriorityPr, 10)
+	highPriorityPr := priorityBookingProvisioningRequest("high-priority", 100)
+	highPriorityPr.Spec.Parameters = nil
+	highPriorityPr.PodTemplates[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To("gpu-template")},
+	}
+	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, lowPriorityPr, highPriorityPr)
+	autoscalingCtx, err := coretest.NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	node := testutils.BuildTestNode("node", 1000, 10000)
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, nil, nil))
+	simulator := scheduling.NewHintingSimulator()
+	injector := &bookingInjector{schedule: func(snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		return simulator.TrySchedulePods(t.Context(), snapshot, pods, false, clustersnapshot.SchedulingOptions{})
+	}}
+	processor := &provReqProcessor{
+		now:                       time.Now,
+		maxUpdated:                20,
+		client:                    client,
+		injector:                  injector,
+		simulationWorkloadBuilder: provreqpods.NewSimulationWorkloadBuilder(bookingTemplateLister(t, bookingTemplate("gpu-template"))),
+	}
+
+	require.NoError(t, processor.bookProvisioningRequests(t.Context(), &autoscalingCtx, []*provreqwrapper.ProvisioningRequest{lowPriorityPr, highPriorityPr}))
+	assert.Equal(t, 1, injector.calls, "all booking Pods must share one priority-sorted scheduling call")
+	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	require.NoError(t, err)
+	require.Len(t, nodeInfos, 1)
+	require.Len(t, nodeInfos[0].Pods(), 1)
+	scheduledPod := nodeInfos[0].Pods()[0].Pod
+	assert.Equal(t, highPriorityPr.Name, scheduledPod.Annotations[v1.ProvisioningRequestPodAnnotationKey])
+	claims := snapshotClaims(t, &autoscalingCtx)
+	require.Len(t, claims, 1)
+	require.Len(t, claims[0].OwnerReferences, 1)
+	assert.Equal(t, scheduledPod.UID, claims[0].OwnerReferences[0].UID)
+}
+
+func TestBookCapacityAddsMaterializedClaimsToSnapshot(t *testing.T) {
+	pr := bookingProvisioningRequest("gpu-template", 2)
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+	injector.schedule = func(snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		claims, err := snapshot.DraSnapshot().ResourceClaims().List()
+		require.NoError(t, err)
+		assert.Len(t, claims, len(pods), "claims must be in the same snapshot transaction before scheduling")
+		return allPodsScheduled(pods), nil
+	}
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	assert.Len(t, snapshotClaims(t, autoscalingCtx), 2)
+	assert.Equal(t, 1, injector.calls)
+	assertProvisioningRequestNotFailed(t, client, pr)
+}
+
+func TestBookCapacityKeepsOnlyClaimsForScheduledPodUIDs(t *testing.T) {
+	pr := bookingProvisioningRequest("gpu-template", 3)
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+	var scheduledUIDs []string
+	injector.schedule = func(_ clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		require.Len(t, pods, 3)
+		// Return deep copies in a different order than the input. Booking must be
+		// matched by immutable Pod UID, not by pointer or slice position.
+		scheduledUIDs = []string{string(pods[2].UID), string(pods[0].UID)}
+		return scheduling.Result{Statuses: []scheduling.Status{
+			{Pod: pods[2].DeepCopy(), NodeName: "node"},
+			{Pod: pods[0].DeepCopy(), NodeName: "node"},
+		}}, nil
+	}
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	claims := snapshotClaims(t, autoscalingCtx)
+	require.Len(t, claims, 2)
+	ownerUIDs := make([]string, 0, len(claims))
+	for _, claim := range claims {
+		require.Len(t, claim.OwnerReferences, 1)
+		ownerUIDs = append(ownerUIDs, string(claim.OwnerReferences[0].UID))
+	}
+	assert.ElementsMatch(t, scheduledUIDs, ownerUIDs)
+	assertProvisioningRequestNotFailed(t, client, pr)
+}
+
+func TestBookCapacityZeroFitRemovesAllMaterializedClaims(t *testing.T) {
+	pr := bookingProvisioningRequest("gpu-template", 2)
+	injector := &bookingInjector{schedule: func(_ clustersnapshot.ClusterSnapshot, _ []*corev1.Pod) (scheduling.Result, error) {
+		return scheduling.Result{}, nil
+	}}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	assert.Empty(t, snapshotClaims(t, autoscalingCtx))
+	assertProvisioningRequestNotFailed(t, client, pr)
+}
+
+func TestBookCapacitySchedulingErrorRevertsMaterializedClaims(t *testing.T) {
+	pr := bookingProvisioningRequest("gpu-template", 2)
+	injector := &bookingInjector{schedule: func(_ clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		return allPodsScheduled(pods[:1]), errors.New("scheduling failed")
+	}}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+
+	err := processor.bookCapacity(t.Context(), autoscalingCtx)
+	require.ErrorContains(t, err, "scheduling failed")
+	assert.Empty(t, snapshotClaims(t, autoscalingCtx))
+	assertProvisioningRequestNotFailed(t, client, pr)
+}
+
+func TestBookCapacityCancellationRevertsPartialBookingWithClaims(t *testing.T) {
+	pr := bookingProvisioningRequest("gpu-template", 2)
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+	node := testutils.BuildTestNode("node", 10000, 10000)
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, nil, nil))
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	injector.schedule = func(snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		require.Len(t, pods, 2)
+		require.NoError(t, snapshot.SchedulePod(pods[0], node.Name))
+		cancel()
+		result := allPodsScheduled(pods[:1])
+		result.UnprocessedPods = pods[1:]
+		return result, nil
+	}
+
+	err := processor.bookCapacity(ctx, autoscalingCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, snapshotClaims(t, autoscalingCtx), "a canceled booking must revert materialized claims")
+	nodeInfos, listErr := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	require.NoError(t, listErr)
+	require.Len(t, nodeInfos, 1)
+	assert.Empty(t, nodeInfos[0].Pods(), "a canceled booking must revert partially scheduled Pods")
+	assertProvisioningRequestNotFailed(t, client, pr)
+}
+
+func TestBookCapacitySchedulingErrorRevertsAggregateBooking(t *testing.T) {
+	ordinaryPr := ordinaryBookingProvisioningRequest("ordinary-pr")
+	checkCapacityPr := bookingProvisioningRequest("gpu-template", 1)
+	checkCapacityPr.Spec.Parameters = nil
+	injector := &bookingInjector{}
+	processor, _, autoscalingCtx := newBookingProcessorForRequests(t, []*provreqwrapper.ProvisioningRequest{ordinaryPr, checkCapacityPr}, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+	processor.checkCapacityProcessorInstance = ""
+	node := testutils.BuildTestNode("node", 10000, 10000)
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, nil, nil))
+
+	injector.schedule = func(snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		require.Len(t, pods, 2)
+		assert.Equal(t, ordinaryPr.Name, pods[0].Annotations[v1.ProvisioningRequestPodAnnotationKey])
+		assert.Equal(t, checkCapacityPr.Name, pods[1].Annotations[v1.ProvisioningRequestPodAnnotationKey])
+		claims, err := snapshot.DraSnapshot().ResourceClaims().List()
+		require.NoError(t, err)
+		require.Len(t, claims, 1)
+		require.NoError(t, snapshot.SchedulePod(pods[0], node.Name))
+		return allPodsScheduled(pods[:1]), errors.New("aggregate booking failed")
+	}
+
+	err := processor.bookProvisioningRequests(t.Context(), autoscalingCtx, []*provreqwrapper.ProvisioningRequest{ordinaryPr, checkCapacityPr})
+	require.ErrorContains(t, err, "aggregate booking failed")
+	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	require.NoError(t, err)
+	require.Len(t, nodeInfos, 1)
+	assert.Empty(t, nodeInfos[0].Pods(), "failed aggregate booking must revert partially scheduled Pods")
+	assert.Empty(t, snapshotClaims(t, autoscalingCtx), "failed aggregate booking must revert materialized claims")
+	assert.Equal(t, 1, injector.calls)
+}
+
+func TestBookCapacityCancellationRevertsPartialOrdinaryBooking(t *testing.T) {
+	pr := ordinaryBookingProvisioningRequest("ordinary-pr")
+	pr.Spec.PodSets[0].Count = 2
+	injector := &bookingInjector{}
+	processor, _, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t), injector)
+	processor.checkCapacityProcessorInstance = ""
+	node := testutils.BuildTestNode("node", 10000, 10000)
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, nil, nil))
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	injector.schedule = func(snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		require.NoError(t, snapshot.SchedulePod(pods[0], node.Name))
+		cancel()
+		result := allPodsScheduled(pods[:1])
+		result.UnprocessedPods = pods[1:]
+		return result, nil
+	}
+
+	err := processor.bookCapacity(ctx, autoscalingCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	nodeInfos, listErr := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	require.NoError(t, listErr)
+	require.Len(t, nodeInfos, 1)
+	assert.Empty(t, nodeInfos[0].Pods(), "a canceled booking must revert partially scheduled Pods")
+}
+
+func TestBookCapacityCommitsSuccessfulOrdinaryScheduling(t *testing.T) {
+	pr := ordinaryBookingProvisioningRequest("ordinary-pr")
+	injector := &bookingInjector{}
+	processor, _, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t), injector)
+	processor.checkCapacityProcessorInstance = ""
+	node := testutils.BuildTestNode("node", 10000, 10000)
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, nil, nil))
+	injector.schedule = func(snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod) (scheduling.Result, error) {
+		require.NoError(t, snapshot.SchedulePod(pods[0], node.Name))
+		return allPodsScheduled(pods), nil
+	}
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	nodeInfos, err := autoscalingCtx.ClusterSnapshot.ListNodeInfos()
+	require.NoError(t, err)
+	require.Len(t, nodeInfos, 1)
+	require.Len(t, nodeInfos[0].Pods(), 1)
+	assert.Equal(t, pr.Name, nodeInfos[0].Pods()[0].Pod.Annotations[v1.ProvisioningRequestPodAnnotationKey])
+}
+
+func TestBookCapacityClaimCollisionPreservesSnapshotAndMarksProvisioningRequestFailed(t *testing.T) {
+	pr := bookingProvisioningRequest("gpu-template", 1)
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t, bookingTemplate("gpu-template")), injector)
+	workload, err := processor.simulationWorkloadBuilder.ForProvisioningRequest(pr)
+	require.NoError(t, err)
+	require.Len(t, workload.Claims, 1)
+	existingClaim := workload.Claims[0].DeepCopy()
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.DraSnapshot().AddClaims([]*resourcev1.ResourceClaim{existingClaim}))
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	require.Equal(t, []*resourcev1.ResourceClaim{existingClaim}, snapshotClaims(t, autoscalingCtx))
+	assert.Zero(t, injector.calls, "claim collision must fail before scheduling")
+	failed := apimeta.FindStatusCondition(getProvisioningRequest(t, client, pr).Status.Conditions, v1.Failed)
+	require.NotNil(t, failed)
+	assert.Equal(t, conditions.FailedToBookCapacityReason, failed.Reason)
+	assert.Contains(t, failed.Message, existingClaim.Name)
+}
+
+func TestBookCapacityClaimCollisionSkipsOnlyAffectedProvisioningRequest(t *testing.T) {
+	collidingPr := bookingProvisioningRequest("gpu-template", 1)
+	validPr := bookingProvisioningRequest("gpu-template", 1)
+	validPr.Name = "valid-pr"
+	validPr.Spec.PodSets[0].PodTemplateRef.Name = "valid-pr-pod-template"
+	validPr.PodTemplates[0].Name = "valid-pr-pod-template"
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessorForRequests(
+		t,
+		[]*provreqwrapper.ProvisioningRequest{collidingPr, validPr},
+		bookingTemplateLister(t, bookingTemplate("gpu-template")),
+		injector,
+	)
+	collidingWorkload, err := processor.simulationWorkloadBuilder.ForProvisioningRequest(collidingPr)
+	require.NoError(t, err)
+	require.Len(t, collidingWorkload.Claims, 1)
+	existingClaim := collidingWorkload.Claims[0].DeepCopy()
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.DraSnapshot().AddClaims([]*resourcev1.ResourceClaim{existingClaim}))
+
+	require.NoError(t, processor.bookProvisioningRequests(t.Context(), autoscalingCtx, []*provreqwrapper.ProvisioningRequest{collidingPr, validPr}))
+	require.Equal(t, 1, injector.calls)
+	require.Len(t, injector.lastPods, 1)
+	assert.Equal(t, validPr.Name, injector.lastPods[0].Annotations[v1.ProvisioningRequestPodAnnotationKey])
+	assert.Len(t, snapshotClaims(t, autoscalingCtx), 2, "the existing claim and the valid request's claim must remain")
+	failed := apimeta.FindStatusCondition(getProvisioningRequest(t, client, collidingPr).Status.Conditions, v1.Failed)
+	require.NotNil(t, failed)
+	assert.Equal(t, conditions.FailedToBookCapacityReason, failed.Reason)
+	assertProvisioningRequestNotFailed(t, client, validPr)
+}
+
+func TestBookCapacityMissingTemplateMarksProvisioningRequestFailed(t *testing.T) {
+	pr := bookingProvisioningRequest("missing-template", 2)
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t), injector)
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	assert.Empty(t, snapshotClaims(t, autoscalingCtx))
+	assert.Zero(t, injector.calls)
+	updated := getProvisioningRequest(t, client, pr)
+	failed := apimeta.FindStatusCondition(updated.Status.Conditions, v1.Failed)
+	require.NotNil(t, failed)
+	assert.Equal(t, conditions.FailedToBookCapacityReason, failed.Reason)
+	assert.Contains(t, failed.Message, "missing-template")
+}
+
+func TestBookCapacityConsumedRequestSkipsMissingTemplateMaterialization(t *testing.T) {
+	pr := bookingProvisioningRequest("missing-template", 2)
+	injector := &bookingInjector{}
+	processor, client, autoscalingCtx := newBookingProcessor(t, pr, bookingTemplateLister(t), injector)
+	node := testutils.BuildTestNode("node", 10000, 10000)
+	scheduledPods := make([]*corev1.Pod, 0, pr.PodCount())
+	for i := 0; i < pr.PodCount(); i++ {
+		pod := testutils.BuildTestPod(fmt.Sprintf("consumer-%d", i), 100, 100, func(pod *corev1.Pod) {
+			pod.Namespace = pr.Namespace
+			pod.Spec.NodeName = node.Name
+		})
+		pod.Annotations[v1.ProvisioningRequestPodAnnotationKey] = pr.Name
+		scheduledPods = append(scheduledPods, pod)
+	}
+	require.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, scheduledPods, nil, nil))
+
+	require.NoError(t, processor.bookCapacity(t.Context(), autoscalingCtx))
+	assert.Empty(t, snapshotClaims(t, autoscalingCtx))
+	assert.Zero(t, injector.calls, "a consumed booking must be detected before materialization")
+	updated := getProvisioningRequest(t, client, pr)
+	expired := apimeta.FindStatusCondition(updated.Status.Conditions, v1.BookingExpired)
+	require.NotNil(t, expired)
+	assert.Equal(t, metav1.ConditionTrue, expired.Status)
+	assert.Equal(t, conditions.CapacityBookingConsumedReason, expired.Reason)
+	assert.Nil(t, apimeta.FindStatusCondition(updated.Status.Conditions, v1.Failed))
+}
+
+type bookingInjector struct {
+	calls    int
+	lastPods []*corev1.Pod
+	schedule func(clustersnapshot.ClusterSnapshot, []*corev1.Pod) (scheduling.Result, error)
+}
+
+func (i *bookingInjector) TrySchedulePods(_ context.Context, snapshot clustersnapshot.ClusterSnapshot, pods []*corev1.Pod, _ bool, _ clustersnapshot.SchedulingOptions) (scheduling.Result, error) {
+	i.calls++
+	i.lastPods = pods
+	if i.schedule != nil {
+		return i.schedule(snapshot, pods)
+	}
+	return allPodsScheduled(pods), nil
+}
+
+func allPodsScheduled(pods []*corev1.Pod) scheduling.Result {
+	statuses := make([]scheduling.Status, 0, len(pods))
+	for _, pod := range pods {
+		statuses = append(statuses, scheduling.Status{Pod: pod, NodeName: "node"})
+	}
+	return scheduling.Result{Statuses: statuses}
+}
+
+func bookingProvisioningRequest(templateName string, count int32) *provreqwrapper.ProvisioningRequest {
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("ns", "test-pr")
+	pr.Spec.ProvisioningClassName = v1.ProvisioningClassCheckCapacity
+	pr.Spec.Parameters = map[string]v1.Parameter{
+		provisioningrequest.CheckCapacityProcessorInstanceKey: bookingProcessorInstance,
+	}
+	pr.Spec.PodSets[0].Count = count
+	pr.PodTemplates[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+	conditions.AddOrUpdateCondition(context.Background(), pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+	return pr
+}
+
+func ordinaryBookingProvisioningRequest(name string) *provreqwrapper.ProvisioningRequest {
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("ns", name)
+	pr.Spec.ProvisioningClassName = v1.ProvisioningClassBestEffortAtomicScaleUp
+	conditions.AddOrUpdateCondition(context.Background(), pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+	return pr
+}
+
+func priorityBookingProvisioningRequest(name string, priority int32) *provreqwrapper.ProvisioningRequest {
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("ns", name)
+	pr.Spec.ProvisioningClassName = v1.ProvisioningClassCheckCapacity
+	pr.Spec.Parameters = map[string]v1.Parameter{
+		provisioningrequest.CheckCapacityProcessorInstanceKey: bookingProcessorInstance,
+	}
+	setBookingPodPriorityAndCPU(pr, priority)
+	conditions.AddOrUpdateCondition(context.Background(), pr, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
+	return pr
+}
+
+func setBookingPodPriorityAndCPU(pr *provreqwrapper.ProvisioningRequest, priority int32) {
+	pr.PodTemplates[0].Template.Spec.Priority = ptr.To(priority)
+	pr.PodTemplates[0].Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("1"),
+	}
+}
+
+func bookingTemplate(name string) *resourcev1.ResourceClaimTemplate {
+	return &resourcev1.ResourceClaimTemplate{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"}}
+}
+
+func bookingTemplateLister(t *testing.T, templates ...*resourcev1.ResourceClaimTemplate) resourcelisters.ResourceClaimTemplateLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, template := range templates {
+		require.NoError(t, indexer.Add(template))
+	}
+	return resourcelisters.NewResourceClaimTemplateLister(indexer)
+}
+
+func newBookingProcessor(t *testing.T, pr *provreqwrapper.ProvisioningRequest, templateLister resourcelisters.ResourceClaimTemplateLister, injector *bookingInjector) (*provReqProcessor, *provreqclient.ProvisioningRequestClient, *ca_context.AutoscalingContext) {
+	t.Helper()
+	return newBookingProcessorForRequests(t, []*provreqwrapper.ProvisioningRequest{pr}, templateLister, injector)
+}
+
+func newBookingProcessorForRequests(t *testing.T, prs []*provreqwrapper.ProvisioningRequest, templateLister resourcelisters.ResourceClaimTemplateLister, injector *bookingInjector) (*provReqProcessor, *provreqclient.ProvisioningRequestClient, *ca_context.AutoscalingContext) {
+	t.Helper()
+	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, prs...)
+	autoscalingCtx, err := coretest.NewScaleTestAutoscalingContext(config.AutoscalingOptions{}, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	return &provReqProcessor{
+		now:                            time.Now,
+		maxUpdated:                     20,
+		client:                         client,
+		injector:                       injector,
+		checkCapacityProcessorInstance: bookingProcessorInstance,
+		simulationWorkloadBuilder:      provreqpods.NewSimulationWorkloadBuilder(templateLister),
+	}, client, &autoscalingCtx
+}
+
+func snapshotClaims(t *testing.T, autoscalingCtx *ca_context.AutoscalingContext) []*resourcev1.ResourceClaim {
+	t.Helper()
+	claims, err := autoscalingCtx.ClusterSnapshot.DraSnapshot().ResourceClaims().List()
+	require.NoError(t, err)
+	return claims
+}
+
+func getProvisioningRequest(t *testing.T, client *provreqclient.ProvisioningRequestClient, pr *provreqwrapper.ProvisioningRequest) *provreqwrapper.ProvisioningRequest {
+	t.Helper()
+	updated, err := client.ProvisioningRequestNoCache(pr.Namespace, pr.Name)
+	require.NoError(t, err)
+	return updated
+}
+
+func assertProvisioningRequestNotFailed(t *testing.T, client *provreqclient.ProvisioningRequestClient, pr *provreqwrapper.ProvisioningRequest) {
+	t.Helper()
+	updated := getProvisioningRequest(t, client, pr)
+	assert.Nil(t, apimeta.FindStatusCondition(updated.Status.Conditions, v1.Failed))
+	assert.True(t, apimeta.IsStatusConditionTrue(updated.Status.Conditions, v1.Provisioned))
+}

--- a/pkg/processors/provreq/processor_test.go
+++ b/pkg/processors/provreq/processor_test.go
@@ -157,7 +157,11 @@ func TestRefresh(t *testing.T) {
 		additionalPr.CreationTimestamp = metav1.NewTime(weekAgo)
 		additionalPr.Spec.ProvisioningClassName = v1.ProvisioningClassCheckCapacity
 
-		processor := provReqProcessor{func() time.Time { return now }, 1, provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr, additionalPr), nil, ""}
+		processor := provReqProcessor{
+			now:        func() time.Time { return now },
+			maxUpdated: 1,
+			client:     provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr, additionalPr),
+		}
 		processor.refresh(context.Background(), []*provreqwrapper.ProvisioningRequest{pr, additionalPr})
 
 		assert.ElementsMatch(t, test.wantConditions, pr.Status.Conditions)
@@ -217,7 +221,7 @@ func TestDeleteOldProvReqs(t *testing.T) {
 
 	client := provreqclient.NewFakeProvisioningRequestClient(context.Background(), t, pr, additionalPr, oldFailedPr, oldExpiredPr)
 
-	processor := provReqProcessor{func() time.Time { return now }, 1, client, nil, ""}
+	processor := provReqProcessor{now: func() time.Time { return now }, maxUpdated: 1, client: client}
 	processor.refresh(context.Background(), []*provreqwrapper.ProvisioningRequest{pr, additionalPr, oldFailedPr, oldExpiredPr})
 
 	_, err := client.ProvisioningRequestNoCache(oldFailedPr.Namespace, oldFailedPr.Name)

--- a/pkg/processors/provreq/testutils.go
+++ b/pkg/processors/provreq/testutils.go
@@ -21,10 +21,18 @@ import (
 
 	"k8s.io/utils/clock/testing"
 	"k8s.io/utils/lru"
+	provreqpods "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/pods"
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqclient"
 )
 
-// NewFakePodsInjector creates a new instance of ProvisioningRequestPodsInjector with the given client and clock for testing.
-func NewFakePodsInjector(client *provreqclient.ProvisioningRequestClient, clock *testing.FakePassiveClock) *ProvisioningRequestPodsInjector {
-	return &ProvisioningRequestPodsInjector{initialRetryTime: 1 * time.Minute, maxBackoffTime: 10 * time.Minute, backoffDuration: lru.New(1000), client: client, clock: clock}
+// NewFakePodsInjector creates a ProvisioningRequestPodsInjector with the given test dependencies.
+func NewFakePodsInjector(client *provreqclient.ProvisioningRequestClient, clock *testing.FakePassiveClock, simulationWorkloadBuilder *provreqpods.SimulationWorkloadBuilder) *ProvisioningRequestPodsInjector {
+	return &ProvisioningRequestPodsInjector{
+		initialRetryTime:          time.Minute,
+		maxBackoffTime:            10 * time.Minute,
+		backoffDuration:           lru.New(1000),
+		client:                    client,
+		clock:                     clock,
+		simulationWorkloadBuilder: simulationWorkloadBuilder,
+	}
 }

--- a/pkg/provisioningrequest/checkcapacity/provisioningclass.go
+++ b/pkg/provisioningrequest/checkcapacity/provisioningclass.go
@@ -26,6 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/klog/v2"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/provreq"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/status"
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/conditions"
+	provreqpods "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/pods"
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqclient"
 	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqwrapper"
 	"sigs.k8s.io/cluster-autoscaler/pkg/resourcequotas"
@@ -62,14 +64,16 @@ type checkCapacityProvClass struct {
 	checkCapacityProvisioningRequestMaxBatchSize int
 	checkCapacityProvisioningRequestBatchTimebox time.Duration
 	provreqInjector                              *provreq.ProvisioningRequestPodsInjector
+	simulationWorkloadBuilder                    *provreqpods.SimulationWorkloadBuilder
 }
 
 // New create check-capacity scale-up mode.
 func New(
 	client *provreqclient.ProvisioningRequestClient,
 	provreqInjector *provreq.ProvisioningRequestPodsInjector,
+	simulationWorkloadBuilder *provreqpods.SimulationWorkloadBuilder,
 ) *checkCapacityProvClass {
-	return &checkCapacityProvClass{client: client, provreqInjector: provreqInjector}
+	return &checkCapacityProvClass{client: client, provreqInjector: provreqInjector, simulationWorkloadBuilder: simulationWorkloadBuilder}
 }
 
 func (o *checkCapacityProvClass) Initialize(
@@ -142,7 +146,16 @@ func (o *checkCapacityProvClass) getProvisioningRequestsAndPods(ctx context.Cont
 		if len(prs) == 0 {
 			return nil, nil
 		}
-		return []provreq.ProvisioningRequestWithPods{{PrWrapper: prs[0], Pods: unschedulablePods}}, nil
+		workload, err := o.simulationWorkloadBuilder.ForProvisioningRequest(prs[0])
+		if err != nil {
+			logger.Error(err, "Failed to create simulation workload for ProvisioningRequest", "provReq", klog.KObj(prs[0]))
+			conditions.AddOrUpdateCondition(ctx, prs[0], v1.Failed, metav1.ConditionTrue, conditions.FailedToCreatePodsReason, err.Error(), metav1.Now())
+			if _, updateErr := o.client.UpdateProvisioningRequest(ctx, prs[0].ProvisioningRequest); updateErr != nil {
+				logger.Error(updateErr, "failed add Failed condition to ProvReq", "provReq", klog.KObj(prs[0]))
+			}
+			return nil, nil
+		}
+		return []provreq.ProvisioningRequestWithPods{{PrWrapper: prs[0], Workload: workload}}, nil
 	}
 
 	batch, err := o.provreqInjector.GetCheckCapacityBatch(ctx, o.checkCapacityProvisioningRequestMaxBatchSize)
@@ -161,12 +174,18 @@ func (o *checkCapacityProvClass) checkCapacityBatch(ctx context.Context, reqs []
 	logger := klog.FromContext(ctx)
 	updates := make([]*provreqwrapper.ProvisioningRequest, 0, len(reqs))
 	for _, req := range reqs {
-		if err := o.checkCapacity(ctx, req.Pods, req.PrWrapper, combinedStatus); err != nil {
+		shouldUpdate := true
+		if err := o.checkCapacity(ctx, req.Workload, req.PrWrapper, combinedStatus); err != nil {
+			addInternalError(combinedStatus, err)
 			logger.Error(err, "Error checking capacity")
-			continue
+			// Failed requests are filtered before this point, so a true condition
+			// here was set by checkCapacity during this iteration.
+			shouldUpdate = apimeta.IsStatusConditionTrue(req.PrWrapper.Status.Conditions, v1.Failed)
 		}
 
-		updates = append(updates, req.PrWrapper)
+		if shouldUpdate {
+			updates = append(updates, req.PrWrapper)
+		}
 
 		// timebox checkCapacity when batch processing.
 		if o.isBatchEnabled() && time.Since(startTime) > o.checkCapacityProvisioningRequestBatchTimebox {
@@ -178,17 +197,31 @@ func (o *checkCapacityProvClass) checkCapacityBatch(ctx context.Context, reqs []
 }
 
 // checkCapacity checks if there is capacity, updates combinedStatus and Conditions. If capacity is found, it commits to the clusterSnapshot.
-func (o *checkCapacityProvClass) checkCapacity(ctx context.Context, unschedulablePods []*apiv1.Pod, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
+func (o *checkCapacityProvClass) checkCapacity(ctx context.Context, workload *provreqpods.SimulationWorkload, provReq *provreqwrapper.ProvisioningRequest, combinedStatus *combinedStatusSet) error {
 	logger := klog.FromContext(ctx)
 	o.autoscalingCtx.ClusterSnapshot.Fork()
+	if err := o.autoscalingCtx.ClusterSnapshot.DraSnapshot().AddClaims(workload.Claims); err != nil {
+		o.autoscalingCtx.ClusterSnapshot.Revert()
+		simulationErr := fmt.Errorf("could not add simulated ResourceClaims for ProvisioningRequest %s/%s: %w", provReq.Namespace, provReq.Name, err)
+		conditions.AddOrUpdateCondition(ctx, provReq, v1.Failed, metav1.ConditionTrue, conditions.FailedToCreatePodsReason, simulationErr.Error(), metav1.Now())
+		return simulationErr
+	}
 
 	// Case 1: Capacity fits.
-	schedulingResult, err := o.schedulingSimulator.TrySchedulePods(context.Background(), o.autoscalingCtx.ClusterSnapshot, unschedulablePods, true, clustersnapshot.SchedulingOptions{})
-	if err == nil && len(schedulingResult.Statuses) == len(unschedulablePods) {
+	schedulingResult, err := o.schedulingSimulator.TrySchedulePods(ctx, o.autoscalingCtx.ClusterSnapshot, workload.Pods, true, clustersnapshot.SchedulingOptions{})
+	if err != nil {
+		o.autoscalingCtx.ClusterSnapshot.Revert()
+		return fmt.Errorf("could not simulate ProvisioningRequest %s/%s: %w", provReq.Namespace, provReq.Name, err)
+	}
+	if err := ctx.Err(); err != nil {
+		o.autoscalingCtx.ClusterSnapshot.Revert()
+		return fmt.Errorf("could not simulate ProvisioningRequest %s/%s because scheduling was interrupted: %w", provReq.Namespace, provReq.Name, err)
+	}
+	if len(schedulingResult.Statuses) == len(workload.Pods) {
 		commitError := o.autoscalingCtx.ClusterSnapshot.Commit()
 		if commitError != nil {
 			o.autoscalingCtx.ClusterSnapshot.Revert()
-			return commitError
+			return fmt.Errorf("could not commit simulation for ProvisioningRequest %s/%s: %w", provReq.Namespace, provReq.Name, commitError)
 		}
 		combinedStatus.Add(&status.ScaleUpStatus{Result: status.ScaleUpSuccessful})
 		conditions.AddOrUpdateCondition(ctx, provReq, v1.Provisioned, metav1.ConditionTrue, conditions.CapacityIsFoundReason, conditions.CapacityIsFoundMsg, metav1.Now())
@@ -207,7 +240,12 @@ func (o *checkCapacityProvClass) checkCapacity(ctx context.Context, unschedulabl
 		}
 		conditions.AddOrUpdateCondition(ctx, provReq, v1.Provisioned, metav1.ConditionFalse, conditions.CapacityIsNotFoundReason, "Capacity is not found, CA will try to find it later.", metav1.Now())
 	}
-	return err
+	return nil
+}
+
+func addInternalError(combinedStatus *combinedStatusSet, err error) {
+	scaleUpStatus, _ := status.UpdateScaleUpError(&status.ScaleUpStatus{}, errors.NewAutoscalerErrorf(errors.InternalError, "error during ScaleUp: %s", err.Error()))
+	combinedStatus.Add(scaleUpStatus)
 }
 
 // updateRequests calls the client to update ProvisioningRequests, in parallel.

--- a/pkg/provisioningrequest/checkcapacity/provisioningclass_test.go
+++ b/pkg/provisioningrequest/checkcapacity/provisioningclass_test.go
@@ -17,12 +17,35 @@ limitations under the License.
 package checkcapacity
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	provreqv1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
+	"sigs.k8s.io/cluster-autoscaler/pkg/processors/provreq"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/status"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/conditions"
+	provreqpods "sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/pods"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqclient"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqwrapper"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/testsnapshot"
+	csisnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/csi/snapshot"
+	drasnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/snapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/scheduling"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
+	testutils "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
 )
 
 func TestCombinedStatusSet(t *testing.T) {
@@ -126,4 +149,412 @@ func generateStatuses(n int, result status.ScaleUpResult) []*status.ScaleUpStatu
 		statuses[i] = &status.ScaleUpStatus{Result: result, ScaleUpError: scaleUpErr}
 	}
 	return statuses
+}
+
+func TestGetProvisioningRequestsAndPodsNonBatchIgnoresUnrelatedRCTPod(t *testing.T) {
+	const (
+		namespace    = "test-ns"
+		templateName = "gpu-template"
+	)
+	pr := provreqclient.ProvisioningRequestWrapperForTesting(namespace, "test-pr")
+	pr.Spec.ProvisioningClassName = provreqv1.ProvisioningClassCheckCapacity
+	pr.PodTemplates[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+	virtualPods, err := provreqpods.PodsForProvisioningRequest(pr)
+	require.NoError(t, err)
+
+	realClaimName := "real-pod-gpu-controller-suffix"
+	realPod := testutils.BuildTestPod("real-pod", 100, 100, func(pod *corev1.Pod) {
+		pod.Namespace = namespace
+	})
+	realPod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(templateName)},
+	}
+	realPod.Status.ResourceClaimStatuses = []corev1.PodResourceClaimStatus{
+		{Name: "gpu", ResourceClaimName: ptr.To(realClaimName)},
+	}
+	realPodBefore := realPod.DeepCopy()
+
+	template := &resourcev1.ResourceClaimTemplate{ObjectMeta: metav1.ObjectMeta{Name: templateName, Namespace: namespace}}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(template))
+	checkCapacityClass := &checkCapacityProvClass{
+		autoscalingCtx: &ca_context.AutoscalingContext{},
+		client:         provreqclient.NewFakeProvisioningRequestClient(t.Context(), t, pr),
+		simulationWorkloadBuilder: provreqpods.NewSimulationWorkloadBuilder(
+			resourcelisters.NewResourceClaimTemplateLister(indexer),
+		),
+	}
+
+	requests, err := checkCapacityClass.getProvisioningRequestsAndPods(t.Context(), append(virtualPods, realPod))
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+	assert.Equal(t, pr.Name, requests[0].PrWrapper.Name)
+	require.NotNil(t, requests[0].Workload)
+	require.Len(t, requests[0].Workload.Pods, len(virtualPods))
+	require.Len(t, requests[0].Workload.Claims, len(virtualPods))
+	for _, pod := range requests[0].Workload.Pods {
+		assert.Equal(t, pr.Name, pod.Annotations[provreqv1.ProvisioningRequestPodAnnotationKey])
+		assert.NotEqual(t, realPod.Name, pod.Name)
+	}
+	assert.Equal(t, realPodBefore, realPod, "the unrelated real Pod was mutated")
+}
+
+func TestGetProvisioningRequestsAndPodsNonBatchMarksMaterializationErrorsFailed(t *testing.T) {
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("test-ns", "test-pr")
+	pr.Spec.ProvisioningClassName = provreqv1.ProvisioningClassCheckCapacity
+	pr.PodTemplates[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To("missing-template")},
+	}
+	virtualPods, err := provreqpods.PodsForProvisioningRequest(pr)
+	require.NoError(t, err)
+	client := provreqclient.NewFakeProvisioningRequestClient(t.Context(), t, pr)
+	builder := provreqpods.NewSimulationWorkloadBuilder(resourcelisters.NewResourceClaimTemplateLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})))
+	checkCapacityClass := New(client, nil, builder)
+	checkCapacityClass.autoscalingCtx = &ca_context.AutoscalingContext{}
+
+	requests, err := checkCapacityClass.getProvisioningRequestsAndPods(t.Context(), virtualPods)
+	require.NoError(t, err)
+	assert.Empty(t, requests, "a request with an invalid simulation workload must be skipped")
+
+	updated, err := client.ProvisioningRequestNoCache(pr.Namespace, pr.Name)
+	require.NoError(t, err)
+	failed := apimeta.FindStatusCondition(updated.Status.Conditions, provreqv1.Failed)
+	require.NotNil(t, failed)
+	assert.Equal(t, metav1.ConditionTrue, failed.Status)
+	assert.Equal(t, conditions.FailedToCreatePodsReason, failed.Reason)
+	assert.Contains(t, failed.Message, "ResourceClaimTemplate test-ns/missing-template")
+}
+
+func TestCheckCapacityBatchTreatsSchedulingErrorAsInternalError(t *testing.T) {
+	baseSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	require.NoError(t, baseSnapshot.SetClusterState(t.Context(), nil, nil, nil, nil))
+	snapshot := &schedulingInternalErrorSnapshot{ClusterSnapshot: baseSnapshot}
+	checkCapacityClass := newCheckCapacityTestClass(snapshot)
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("test-ns", "test-pr")
+	pr.Spec.Parameters = map[string]provreqv1.Parameter{NoRetryParameterKey: "true"}
+	combinedStatus := NewCombinedStatusSet()
+
+	updates := checkCapacityClass.checkCapacityBatch(
+		t.Context(),
+		[]provreq.ProvisioningRequestWithPods{
+			{
+				PrWrapper: pr,
+				Workload: &provreqpods.SimulationWorkload{
+					Pods: []*corev1.Pod{testutils.BuildTestPod("virtual-pod", 100, 100)},
+				},
+			},
+		},
+		&combinedStatus,
+		time.Now(),
+	)
+
+	assert.Empty(t, updates, "transient internal errors must not trigger a ProvisioningRequest update")
+	assertNoCapacityMissCondition(t, pr)
+	assertInternalScaleUpError(t, &combinedStatus, "scheduling failed")
+}
+
+func TestCheckCapacityBatchTreatsCanceledSimulationAsInternalError(t *testing.T) {
+	baseSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	node := testutils.BuildTestNode("node", 10000, 10000, testutils.IsReady(true))
+	require.NoError(t, baseSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, nil, nil))
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	snapshot := &cancelAfterFirstScheduleSnapshot{ClusterSnapshot: baseSnapshot, cancel: cancel}
+	checkCapacityClass := newCheckCapacityTestClass(snapshot)
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("test-ns", "test-pr")
+	pr.Spec.Parameters = map[string]provreqv1.Parameter{NoRetryParameterKey: "true"}
+	combinedStatus := NewCombinedStatusSet()
+	claim := &resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "simulated-claim", Namespace: "test-ns"}}
+
+	updates := checkCapacityClass.checkCapacityBatch(
+		ctx,
+		[]provreq.ProvisioningRequestWithPods{
+			{
+				PrWrapper: pr,
+				Workload: &provreqpods.SimulationWorkload{
+					Pods: []*corev1.Pod{
+						testutils.BuildTestPod("virtual-pod-1", 100, 100),
+						testutils.BuildTestPod("virtual-pod-2", 100, 100),
+					},
+					Claims: []*resourcev1.ResourceClaim{claim},
+				},
+			},
+		},
+		&combinedStatus,
+		time.Now(),
+	)
+
+	assert.Empty(t, updates, "a canceled simulation must not trigger a ProvisioningRequest update")
+	assertNoCapacityMissCondition(t, pr)
+	assertInternalScaleUpError(t, &combinedStatus, context.Canceled.Error())
+	assert.Equal(t, 1, snapshot.scheduled, "the test must cancel after a partial simulation")
+	nodeInfos, err := snapshot.ListNodeInfos()
+	require.NoError(t, err)
+	require.Len(t, nodeInfos, 1)
+	assert.Empty(t, nodeInfos[0].Pods(), "a canceled simulation must revert partially scheduled Pods")
+	require.NoError(t, snapshot.DraSnapshot().AddClaims([]*resourcev1.ResourceClaim{claim.DeepCopy()}), "a canceled simulation must revert materialized claims")
+}
+
+func TestCheckCapacityBatchTreatsAddClaimsErrorAsInternalError(t *testing.T) {
+	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	require.NoError(t, snapshot.SetClusterState(t.Context(), nil, nil, nil, nil))
+	claim := &resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "simulated-claim", Namespace: "test-ns"}}
+	require.NoError(t, snapshot.DraSnapshot().AddClaims([]*resourcev1.ResourceClaim{claim}))
+	checkCapacityClass := newCheckCapacityTestClass(snapshot)
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("test-ns", "test-pr")
+	pr.Spec.Parameters = map[string]provreqv1.Parameter{NoRetryParameterKey: "true"}
+	combinedStatus := NewCombinedStatusSet()
+
+	updates := checkCapacityClass.checkCapacityBatch(
+		t.Context(),
+		[]provreq.ProvisioningRequestWithPods{
+			{
+				PrWrapper: pr,
+				Workload: &provreqpods.SimulationWorkload{
+					Pods:   []*corev1.Pod{testutils.BuildTestPod("virtual-pod", 100, 100)},
+					Claims: []*resourcev1.ResourceClaim{claim.DeepCopy()},
+				},
+			},
+		},
+		&combinedStatus,
+		time.Now(),
+	)
+
+	require.Equal(t, []*provreqwrapper.ProvisioningRequest{pr}, updates)
+	failed := apimeta.FindStatusCondition(pr.Status.Conditions, provreqv1.Failed)
+	require.NotNil(t, failed)
+	assert.Equal(t, conditions.FailedToCreatePodsReason, failed.Reason)
+	assertNoCapacityMissCondition(t, pr)
+	assertInternalScaleUpError(t, &combinedStatus, "already tracked")
+}
+
+func TestCheckCapacityAddsMaterializedClaimsBeforeScheduling(t *testing.T) {
+	baseSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	require.NoError(t, baseSnapshot.SetClusterState(t.Context(), nil, nil, nil, nil))
+	snapshot := &claimObservingSnapshot{ClusterSnapshot: baseSnapshot}
+	checkCapacityClass := newCheckCapacityTestClass(snapshot)
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("test-ns", "test-pr")
+	combinedStatus := NewCombinedStatusSet()
+	claim := &resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "materialized-claim", Namespace: "test-ns"}}
+	pod := testutils.BuildTestPod("virtual-pod", 100, 100, func(pod *corev1.Pod) {
+		pod.Namespace = "test-ns"
+	}, testutils.WithResourceClaim("device", claim.Name, "device-template"))
+
+	updates := checkCapacityClass.checkCapacityBatch(
+		t.Context(),
+		[]provreq.ProvisioningRequestWithPods{
+			{
+				PrWrapper: pr,
+				Workload: &provreqpods.SimulationWorkload{
+					Pods:   []*corev1.Pod{pod},
+					Claims: []*resourcev1.ResourceClaim{claim},
+				},
+			},
+		},
+		&combinedStatus,
+		time.Now(),
+	)
+
+	require.Equal(t, []*provreqwrapper.ProvisioningRequest{pr}, updates)
+	assert.True(t, snapshot.observedClaim, "scheduler did not observe the materialized ResourceClaim")
+	provisioned := apimeta.FindStatusCondition(pr.Status.Conditions, provreqv1.Provisioned)
+	require.NotNil(t, provisioned)
+	assert.Equal(t, metav1.ConditionTrue, provisioned.Status)
+	assert.Equal(t, conditions.CapacityIsFoundReason, provisioned.Reason)
+	exported, err := combinedStatus.Export()
+	require.NoError(t, err)
+	assert.Equal(t, status.ScaleUpSuccessful, exported.Result)
+	assert.ErrorContains(t, snapshot.DraSnapshot().AddClaims([]*resourcev1.ResourceClaim{claim.DeepCopy()}), "already tracked", "successful simulation did not commit the claim")
+}
+
+func TestMaterializedWorkloadSchedulesInDraSnapshot(t *testing.T) {
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "default"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{
+						{
+							Name: "gpu",
+							Exactly: &resourcev1.ExactDeviceRequest{
+								DeviceClassName: "gpu.example.com",
+								AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+								Count:           1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(claimTemplate))
+	builder := provreqpods.NewSimulationWorkloadBuilder(resourcelisters.NewResourceClaimTemplateLister(indexer))
+	pr := provreqclient.ProvisioningRequestWrapperForTesting("default", "test-pr")
+	pr.PodTemplates[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+		{Name: "gpu", ResourceClaimTemplateName: ptr.To(claimTemplate.Name)},
+	}
+
+	workload, err := builder.ForProvisioningRequest(pr)
+	require.NoError(t, err)
+	require.Len(t, workload.Claims, 1)
+
+	node := testutils.BuildTestNode("node", 1000, 1000)
+	resourceSlice := &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-gpus"},
+		Spec: resourcev1.ResourceSliceSpec{
+			NodeName: ptr.To(node.Name),
+			Driver:   "gpu.example.com",
+			Pool: resourcev1.ResourcePool{
+				Name:               "node-gpus",
+				ResourceSliceCount: 1,
+			},
+			Devices: []resourcev1.Device{{Name: "gpu-0"}},
+		},
+	}
+	draState := drasnapshot.NewSnapshot(
+		nil,
+		map[string][]*resourcev1.ResourceSlice{node.Name: {resourceSlice}},
+		nil,
+		map[string]*resourcev1.DeviceClass{
+			"gpu.example.com": {ObjectMeta: metav1.ObjectMeta{Name: "gpu.example.com"}},
+		},
+	)
+	clusterSnapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	require.NoError(t, clusterSnapshot.SetClusterState(t.Context(), []*corev1.Node{node}, nil, draState, csisnapshot.NewEmptySnapshot()))
+
+	clusterSnapshot.Fork()
+	require.NoError(t, clusterSnapshot.DraSnapshot().AddClaims(workload.Claims))
+	require.NoError(t, clusterSnapshot.SchedulePod(workload.Pods[0], node.Name))
+	require.NoError(t, clusterSnapshot.Commit())
+
+	claims, err := clusterSnapshot.DraSnapshot().ResourceClaims().List()
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+	assert.NotNil(t, claims[0].Status.Allocation)
+	assert.NotEmpty(t, claims[0].Status.ReservedFor)
+}
+
+func TestCheckCapacityPreservesNoCapacityConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]provreqv1.Parameter
+		wantType   string
+		wantStatus metav1.ConditionStatus
+	}{
+		{
+			name:       "retry later",
+			wantType:   provreqv1.Provisioned,
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name:       "do not retry",
+			parameters: map[string]provreqv1.Parameter{NoRetryParameterKey: "true"},
+			wantType:   provreqv1.Failed,
+			wantStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			require.NoError(t, snapshot.SetClusterState(t.Context(), nil, nil, nil, nil))
+			checkCapacityClass := newCheckCapacityTestClass(snapshot)
+			pr := provreqclient.ProvisioningRequestWrapperForTesting("test-ns", "test-pr")
+			pr.Spec.Parameters = test.parameters
+			combinedStatus := NewCombinedStatusSet()
+
+			updates := checkCapacityClass.checkCapacityBatch(
+				t.Context(),
+				[]provreq.ProvisioningRequestWithPods{
+					{
+						PrWrapper: pr,
+						Workload: &provreqpods.SimulationWorkload{
+							Pods: []*corev1.Pod{testutils.BuildTestPod("virtual-pod", 100, 100)},
+						},
+					},
+				},
+				&combinedStatus,
+				time.Now(),
+			)
+
+			require.Equal(t, []*provreqwrapper.ProvisioningRequest{pr}, updates)
+			capacityMiss := apimeta.FindStatusCondition(pr.Status.Conditions, test.wantType)
+			require.NotNil(t, capacityMiss)
+			assert.Equal(t, test.wantStatus, capacityMiss.Status)
+			assert.Equal(t, conditions.CapacityIsNotFoundReason, capacityMiss.Reason)
+			exported, err := combinedStatus.Export()
+			require.NoError(t, err)
+			assert.Equal(t, status.ScaleUpNoOptionsAvailable, exported.Result)
+			assert.Nil(t, exported.ScaleUpError)
+		})
+	}
+}
+
+func newCheckCapacityTestClass(snapshot clustersnapshot.ClusterSnapshot) *checkCapacityProvClass {
+	autoscalingCtx := &ca_context.AutoscalingContext{ClusterSnapshot: snapshot}
+	return &checkCapacityProvClass{
+		autoscalingCtx:      autoscalingCtx,
+		schedulingSimulator: scheduling.NewHintingSimulator(),
+	}
+}
+
+func assertNoCapacityMissCondition(t *testing.T, pr *provreqwrapper.ProvisioningRequest) {
+	t.Helper()
+	for _, condition := range pr.Status.Conditions {
+		assert.NotEqual(t, conditions.CapacityIsNotFoundReason, condition.Reason)
+	}
+}
+
+func assertInternalScaleUpError(t *testing.T, combinedStatus *combinedStatusSet, message string) {
+	t.Helper()
+	exported, err := combinedStatus.Export()
+	require.ErrorContains(t, err, message)
+	assert.Equal(t, status.ScaleUpError, exported.Result)
+	require.NotNil(t, exported.ScaleUpError)
+	assert.Contains(t, (*exported.ScaleUpError).Error(), message)
+}
+
+type schedulingInternalErrorSnapshot struct {
+	clustersnapshot.ClusterSnapshot
+}
+
+func (s *schedulingInternalErrorSnapshot) SchedulePodOnAnyNodeMatching(pod *corev1.Pod, _ clustersnapshot.SchedulingOptions) (string, clustersnapshot.SchedulingError) {
+	return "", clustersnapshot.NewSchedulingInternalError(pod, "scheduling failed")
+}
+
+type cancelAfterFirstScheduleSnapshot struct {
+	clustersnapshot.ClusterSnapshot
+	cancel    context.CancelFunc
+	scheduled int
+}
+
+func (s *cancelAfterFirstScheduleSnapshot) SchedulePodOnAnyNodeMatching(pod *corev1.Pod, opts clustersnapshot.SchedulingOptions) (string, clustersnapshot.SchedulingError) {
+	nodeName, err := s.ClusterSnapshot.SchedulePodOnAnyNodeMatching(pod, opts)
+	if err == nil && nodeName != "" {
+		s.scheduled++
+		if s.scheduled == 1 {
+			s.cancel()
+		}
+	}
+	return nodeName, err
+}
+
+type claimObservingSnapshot struct {
+	clustersnapshot.ClusterSnapshot
+	observedClaim bool
+}
+
+func (s *claimObservingSnapshot) SchedulePodOnAnyNodeMatching(pod *corev1.Pod, _ clustersnapshot.SchedulingOptions) (string, clustersnapshot.SchedulingError) {
+	claims, err := s.DraSnapshot().PodClaims(pod)
+	if err != nil {
+		return "", clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("materialized claim not available: %v", err))
+	}
+	if len(claims) != 1 {
+		return "", clustersnapshot.NewSchedulingInternalError(pod, fmt.Sprintf("got %d claims, want 1", len(claims)))
+	}
+	s.observedClaim = true
+	return "test-node", nil
 }

--- a/pkg/provisioningrequest/orchestrator/orchestrator_test.go
+++ b/pkg/provisioningrequest/orchestrator/orchestrator_test.go
@@ -516,8 +516,9 @@ func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, no
 	clusterState.UpdateNodes(context.Background(), nodes, now)
 
 	var injector *provreq.ProvisioningRequestPodsInjector
+	simulationWorkloadBuilder := pods.NewSimulationWorkloadBuilder(nil)
 	if batchProcessing {
-		injector = provreq.NewFakePodsInjector(client, clocktesting.NewFakePassiveClock(now))
+		injector = provreq.NewFakePodsInjector(client, clocktesting.NewFakePassiveClock(now), simulationWorkloadBuilder)
 	}
 
 	quotasTrackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
@@ -526,7 +527,7 @@ func setupTest(t *testing.T, client *provreqclient.ProvisioningRequestClient, no
 	})
 	orchestrator := &provReqOrchestrator{
 		client:              client,
-		provisioningClasses: []ProvisioningClass{checkcapacity.New(client, injector), besteffortatomic.New(client)},
+		provisioningClasses: []ProvisioningClass{checkcapacity.New(client, injector, simulationWorkloadBuilder), besteffortatomic.New(client)},
 	}
 	orchestrator.Initialize(&autoscalingCtx, processors, clusterState, estimatorBuilder, taints.TaintConfig{}, quotasTrackerFactory)
 	return orchestrator, nodeInfos

--- a/pkg/provisioningrequest/pods/simulation_workload.go
+++ b/pkg/provisioningrequest/pods/simulation_workload.go
@@ -1,0 +1,176 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"maps"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqwrapper"
+	drautils "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/utils"
+)
+
+const (
+	// Match the 63-character limit used by the Kubernetes ResourceClaim controller
+	// for template-generated claims (pkg/controller/resourceclaim/controller.go).
+	// The hash replaces its random API-server suffix so later booking passes
+	// reconstruct the same in-memory claim identity.
+	maxSimulationResourceClaimNameLength = validation.DNS1123LabelMaxLength
+	simulationResourceClaimHashLength    = 16
+)
+
+// SimulationWorkload contains virtual Pods and the ResourceClaims which must
+// be added to the same ClusterSnapshot transaction before scheduling them.
+type SimulationWorkload struct {
+	Pods   []*corev1.Pod
+	Claims []*resourcev1.ResourceClaim
+}
+
+// SimulationWorkloadBuilder expands ProvisioningRequests and materializes
+// ResourceClaimTemplate-backed claims without creating Kubernetes API objects.
+type SimulationWorkloadBuilder struct {
+	resourceClaimTemplateLister resourcelisters.ResourceClaimTemplateLister
+}
+
+// NewSimulationWorkloadBuilder creates a builder backed by the shared
+// ResourceClaimTemplate informer cache.
+func NewSimulationWorkloadBuilder(resourceClaimTemplateLister resourcelisters.ResourceClaimTemplateLister) *SimulationWorkloadBuilder {
+	return &SimulationWorkloadBuilder{resourceClaimTemplateLister: resourceClaimTemplateLister}
+}
+
+// ForProvisioningRequest expands a ProvisioningRequest and returns the
+// complete in-memory workload needed to schedule it.
+func (b *SimulationWorkloadBuilder) ForProvisioningRequest(pr *provreqwrapper.ProvisioningRequest) (*SimulationWorkload, error) {
+	pods, err := PodsForProvisioningRequest(pr)
+	if err != nil {
+		return nil, err
+	}
+	workload, err := b.forPods(pods)
+	if err != nil {
+		return nil, fmt.Errorf("ProvisioningRequest %s/%s: %w", pr.Namespace, pr.Name, err)
+	}
+	return workload, nil
+}
+
+// forPods materializes ResourceClaimTemplate-backed claims. Callers must
+// provide newly created Pods which are safe to update in place.
+func (b *SimulationWorkloadBuilder) forPods(pods []*corev1.Pod) (*SimulationWorkload, error) {
+	workload := &SimulationWorkload{
+		Pods:   make([]*corev1.Pod, 0, len(pods)),
+		Claims: make([]*resourcev1.ResourceClaim, 0),
+	}
+
+	for _, pod := range pods {
+		for claimIndex := range pod.Spec.ResourceClaims {
+			podClaim := &pod.Spec.ResourceClaims[claimIndex]
+			templateName := podClaim.ResourceClaimTemplateName
+			if templateName == nil {
+				continue
+			}
+
+			if b.resourceClaimTemplateLister == nil {
+				return nil, fmt.Errorf("virtual pod %s/%s resource claim %q references ResourceClaimTemplate %s/%s, but no ResourceClaimTemplate lister is configured", pod.Namespace, pod.Name, podClaim.Name, pod.Namespace, *templateName)
+			}
+
+			template, err := b.resourceClaimTemplateLister.ResourceClaimTemplates(pod.Namespace).Get(*templateName)
+			if err != nil {
+				return nil, fmt.Errorf("virtual pod %s/%s resource claim %q could not get ResourceClaimTemplate %s/%s: %w", pod.Namespace, pod.Name, podClaim.Name, pod.Namespace, *templateName, err)
+			}
+
+			// Keep this materialization in sync with the Kubernetes ResourceClaim
+			// controller in pkg/controller/resourceclaim/controller.go. Simulation
+			// uses deterministic names and UIDs so later autoscaler loops recreate
+			// the same in-memory claim.
+			claimName := simulationResourceClaimName(pod, podClaim.Name)
+			pod.Status.ResourceClaimStatuses = append(pod.Status.ResourceClaimStatuses, corev1.PodResourceClaimStatus{
+				Name:              podClaim.Name,
+				ResourceClaimName: ptr.To(claimName),
+			})
+
+			annotations := maps.Clone(template.Spec.Annotations)
+			if annotations == nil {
+				annotations = make(map[string]string, 1)
+			}
+			// Preserve metadata added by the Kubernetes ResourceClaim controller.
+			annotations[resourcev1.PodResourceClaimAnnotation] = podClaim.Name
+			workload.Claims = append(workload.Claims, &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            claimName,
+					Namespace:       pod.Namespace,
+					UID:             types.UID(pod.Namespace + "/" + claimName),
+					Labels:          maps.Clone(template.Spec.Labels),
+					Annotations:     annotations,
+					OwnerReferences: []metav1.OwnerReference{drautils.PodClaimOwnerReference(pod)},
+				},
+				Spec: *template.Spec.Spec.DeepCopy(),
+			})
+		}
+		workload.Pods = append(workload.Pods, pod)
+	}
+
+	return workload, nil
+}
+
+// simulationResourceClaimName returns a deterministic name for a ResourceClaim
+// that exists only in the scheduling snapshot. It follows the controller's
+// proportional truncation of the Pod and logical claim names, then appends an
+// identity hash instead of relying on an API-server-generated suffix.
+//
+// Both name parts retain at least one character. Trailing dots and hyphens
+// exposed by truncation are removed to keep the result DNS-compliant.
+func simulationResourceClaimName(pod *corev1.Pod, logicalClaimName string) string {
+	suffix := "-" + simulationResourceClaimHash(pod, logicalClaimName)
+	prefix := pod.Name + "-" + logicalClaimName
+	maxPrefixLength := maxSimulationResourceClaimNameLength - len(suffix)
+	if len(prefix) > maxPrefixLength {
+		nameLength := maxPrefixLength - 1
+		podNameLength := len(pod.Name) * nameLength / (len(pod.Name) + len(logicalClaimName))
+		podNameLength = max(1, min(podNameLength, nameLength-1))
+		logicalClaimNameLength := nameLength - podNameLength
+		podNamePrefix := strings.TrimRight(pod.Name[:podNameLength], ".-")
+		logicalClaimNamePrefix := strings.TrimRight(logicalClaimName[:logicalClaimNameLength], ".-")
+		prefix = podNamePrefix + "-" + logicalClaimNamePrefix
+	}
+	prefix = strings.TrimRight(prefix, ".-")
+	if prefix == "" {
+		prefix = "simulated-claim"
+	}
+	return prefix + suffix
+}
+
+// simulationResourceClaimHash hashes length-prefixed identity fields to
+// preserve field boundaries.
+func simulationResourceClaimHash(pod *corev1.Pod, logicalClaimName string) string {
+	hasher := sha256.New()
+	for _, field := range []string{pod.Namespace, pod.Name, string(pod.UID), logicalClaimName} {
+		_, _ = io.WriteString(hasher, strconv.Itoa(len(field)))
+		_, _ = io.WriteString(hasher, ":")
+		_, _ = io.WriteString(hasher, field)
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil))[:simulationResourceClaimHashLength]
+}

--- a/pkg/provisioningrequest/pods/simulation_workload_test.go
+++ b/pkg/provisioningrequest/pods/simulation_workload_test.go
@@ -1,0 +1,359 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	provreqv1 "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/dynamic-resource-allocation/resourceclaim"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-autoscaler/pkg/provisioningrequest/provreqwrapper"
+	drautils "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/utils"
+)
+
+func TestSimulationWorkloadBuilderForProvisioningRequestMaterializesEveryPod(t *testing.T) {
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "test-ns"},
+	}
+	podTemplate := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-template", Namespace: "test-ns"},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{
+					{Name: "gpu", ResourceClaimTemplateName: ptr.To(claimTemplate.Name)},
+				},
+			},
+		},
+	}
+	pr := &provreqv1.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pr", Namespace: "test-ns", UID: types.UID("pr-uid")},
+		Spec: provreqv1.ProvisioningRequestSpec{
+			ProvisioningClassName: "test-class",
+			PodSets: []provreqv1.PodSet{
+				{Count: 3, PodTemplateRef: provreqv1.Reference{Name: podTemplate.Name}},
+			},
+		},
+	}
+	builder := NewSimulationWorkloadBuilder(newResourceClaimTemplateLister(t, claimTemplate))
+	wrapped := provreqwrapper.NewProvisioningRequest(pr, []*corev1.PodTemplate{podTemplate})
+
+	workload, err := builder.ForProvisioningRequest(wrapped)
+	require.NoError(t, err)
+	require.Len(t, workload.Pods, 3)
+	require.Len(t, workload.Claims, 3)
+
+	claimNames := make(map[string]struct{})
+	for i := range workload.Pods {
+		pod := workload.Pods[i]
+		claim := workload.Claims[i]
+		require.Len(t, pod.Status.ResourceClaimStatuses, 1)
+		assert.Equal(t, claim.Name, ptr.Deref(pod.Status.ResourceClaimStatuses[0].ResourceClaimName, ""))
+		claimNames[claim.Name] = struct{}{}
+	}
+	assert.Len(t, claimNames, 3)
+	replayed, err := builder.ForProvisioningRequest(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, workload, replayed)
+}
+
+func TestSimulationWorkloadBuilderCopiesTemplateData(t *testing.T) {
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "test-ns"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{"template-label": "original"},
+				Annotations: map[string]string{"template-annotation": "original"},
+			},
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{
+						{Name: "device", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: "gpu.example.com"}},
+					},
+				},
+			},
+		},
+	}
+	networkTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "network-template", Namespace: "test-ns"},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 245),
+			Namespace: "test-ns",
+			UID:       types.UID("pod-uid"),
+		},
+		Spec: corev1.PodSpec{
+			ResourceClaims: []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: ptr.To(claimTemplate.Name)},
+				{Name: "shared", ResourceClaimName: ptr.To("shared-claim")},
+				{Name: "network", ResourceClaimTemplateName: ptr.To(networkTemplate.Name)},
+			},
+		},
+	}
+	builder := NewSimulationWorkloadBuilder(newResourceClaimTemplateLister(t, claimTemplate, networkTemplate))
+
+	workload, err := builder.forPods([]*corev1.Pod{pod})
+	require.NoError(t, err)
+	require.Len(t, workload.Pods, 1)
+	require.Len(t, workload.Claims, 2)
+	materializedPod := workload.Pods[0]
+	claim := workload.Claims[0]
+	networkClaim := workload.Claims[1]
+
+	assert.Same(t, pod, materializedPod)
+	assert.Equal(t, pod.Spec.ResourceClaims, materializedPod.Spec.ResourceClaims)
+	require.Len(t, materializedPod.Status.ResourceClaimStatuses, 2)
+	assert.Equal(t, claim.Name, ptr.Deref(materializedPod.Status.ResourceClaimStatuses[0].ResourceClaimName, ""))
+	assert.Equal(t, networkClaim.Name, ptr.Deref(materializedPod.Status.ResourceClaimStatuses[1].ResourceClaimName, ""))
+	assert.Equal(t, "network", networkClaim.Annotations[resourcev1.PodResourceClaimAnnotation])
+	assert.LessOrEqual(t, len(claim.Name), maxSimulationResourceClaimNameLength)
+	assert.Empty(t, validation.IsDNS1123Subdomain(claim.Name))
+	assert.Regexp(t, `-[0-9a-f]{16}$`, claim.Name)
+	assert.Equal(t, types.UID(claim.Namespace+"/"+claim.Name), claim.UID)
+	assert.Equal(t, "original", claim.Labels["template-label"])
+	assert.Equal(t, "original", claim.Annotations["template-annotation"])
+	assert.Equal(t, "gpu", claim.Annotations[resourcev1.PodResourceClaimAnnotation])
+	assert.Equal(t, claimTemplate.Spec.Spec, claim.Spec)
+	require.Len(t, claim.OwnerReferences, 1)
+	assert.Equal(t, drautils.PodClaimOwnerReference(pod), claim.OwnerReferences[0])
+	require.NoError(t, resourceclaim.IsForPod(pod, claim, false))
+	require.NoError(t, resourceclaim.IsForPod(pod, networkClaim, false))
+
+	assert.NotContains(t, claimTemplate.Spec.Annotations, resourcev1.PodResourceClaimAnnotation, "cached template was mutated")
+	workload.Claims[0].Labels["template-label"] = "changed"
+	workload.Claims[0].Annotations["template-annotation"] = "changed"
+	workload.Claims[0].Spec.Devices.Requests[0].Name = "changed"
+	assert.Equal(t, "original", claimTemplate.Spec.Labels["template-label"])
+	assert.Equal(t, "original", claimTemplate.Spec.Annotations["template-annotation"])
+	assert.Equal(t, "device", claimTemplate.Spec.Spec.Devices.Requests[0].Name)
+}
+
+func TestSimulationWorkloadBuilderReturnsRuntimeErrors(t *testing.T) {
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "test-ns"},
+	}
+	validPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "test-ns", UID: types.UID("pod-uid")},
+			Spec: corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{
+					{Name: "gpu", ResourceClaimTemplateName: ptr.To(claimTemplate.Name)},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		builder *SimulationWorkloadBuilder
+		pod     *corev1.Pod
+		wantErr string
+	}{
+		{
+			name:    "missing template",
+			builder: NewSimulationWorkloadBuilder(newResourceClaimTemplateLister(t)),
+			pod:     validPod(),
+			wantErr: "could not get ResourceClaimTemplate test-ns/gpu-template",
+		},
+		{
+			name:    "lister not configured",
+			builder: NewSimulationWorkloadBuilder(nil),
+			pod:     validPod(),
+			wantErr: "no ResourceClaimTemplate lister is configured",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.builder.forPods([]*corev1.Pod{test.pod})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
+func TestSimulationWorkloadBuilderPassesDirectClaimsThroughWithoutTemplateLister(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "test-ns", UID: types.UID("pod-uid")},
+		Spec: corev1.PodSpec{
+			ResourceClaims: []corev1.PodResourceClaim{
+				{Name: "shared", ResourceClaimName: ptr.To("shared-claim")},
+			},
+		},
+	}
+
+	workload, err := NewSimulationWorkloadBuilder(nil).forPods([]*corev1.Pod{pod})
+
+	require.NoError(t, err)
+	assert.Empty(t, workload.Claims)
+	require.Len(t, workload.Pods, 1)
+	assert.Equal(t, pod.Spec.ResourceClaims, workload.Pods[0].Spec.ResourceClaims)
+	assert.Empty(t, workload.Pods[0].Status.ResourceClaimStatuses)
+}
+
+func TestSimulationResourceClaimName(t *testing.T) {
+	tests := []struct {
+		name             string
+		podName          string
+		logicalClaimName string
+		wantPrefix       string
+	}{
+		{
+			name:             "short names remain intact",
+			podName:          "pod",
+			logicalClaimName: "gpu",
+			wantPrefix:       "pod-gpu",
+		},
+		{
+			name:             "prefix exactly fills available space",
+			podName:          strings.Repeat("a", 40),
+			logicalClaimName: strings.Repeat("b", 5),
+			wantPrefix:       strings.Repeat("a", 40) + "-" + strings.Repeat("b", 5),
+		},
+		{
+			name:             "one extra character triggers proportional truncation",
+			podName:          strings.Repeat("a", 40),
+			logicalClaimName: strings.Repeat("b", 6),
+			wantPrefix:       strings.Repeat("a", 39) + "-" + strings.Repeat("b", 6),
+		},
+		{
+			name:             "both parts are truncated proportionally",
+			podName:          strings.Repeat("a", 50),
+			logicalClaimName: strings.Repeat("b", 20),
+			wantPrefix:       strings.Repeat("a", 32) + "-" + strings.Repeat("b", 13),
+		},
+		{
+			name:             "logical claim keeps at least one character",
+			podName:          strings.Repeat("a", 253),
+			logicalClaimName: "gpu",
+			wantPrefix:       strings.Repeat("a", 44) + "-g",
+		},
+		{
+			name:             "pod keeps at least one character",
+			podName:          "p",
+			logicalClaimName: strings.Repeat("b", 63),
+			wantPrefix:       "p-" + strings.Repeat("b", 44),
+		},
+		{
+			name:             "trailing dot exposed in pod name is removed",
+			podName:          strings.Repeat("a", 31) + "." + strings.Repeat("a", 18),
+			logicalClaimName: strings.Repeat("b", 20),
+			wantPrefix:       strings.Repeat("a", 31) + "-" + strings.Repeat("b", 13),
+		},
+		{
+			name:             "trailing hyphen exposed in claim name is removed",
+			podName:          strings.Repeat("a", 20),
+			logicalClaimName: strings.Repeat("b", 32) + "-" + strings.Repeat("b", 17),
+			wantPrefix:       strings.Repeat("a", 12) + "-" + strings.Repeat("b", 32),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:      test.podName,
+				Namespace: "test-ns",
+				UID:       types.UID("pod-uid"),
+			}}
+
+			name := simulationResourceClaimName(pod, test.logicalClaimName)
+			replayedName := simulationResourceClaimName(pod, test.logicalClaimName)
+			require.Greater(t, len(name), simulationResourceClaimHashLength+1)
+			prefix := name[:len(name)-simulationResourceClaimHashLength-1]
+
+			assert.Equal(t, test.wantPrefix, prefix)
+			assert.Equal(t, len(test.wantPrefix)+simulationResourceClaimHashLength+1, len(name))
+			assert.LessOrEqual(t, len(name), maxSimulationResourceClaimNameLength)
+			assert.Empty(t, validation.IsDNS1123Subdomain(name))
+			assert.Regexp(t, `-[0-9a-f]{16}$`, name)
+			assert.Equal(t, name, replayedName, "same identity must recreate the same name")
+		})
+	}
+}
+
+func TestSimulationResourceClaimHashUsesCompleteFieldIdentity(t *testing.T) {
+	basePod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod",
+		Namespace: "test-ns",
+		UID:       types.UID("pod-uid"),
+	}}
+	baseHash := simulationResourceClaimHash(basePod, "gpu")
+
+	tests := []struct {
+		name             string
+		pod              *corev1.Pod
+		logicalClaimName string
+	}{
+		{
+			name:             "namespace",
+			pod:              &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "other-ns", UID: types.UID("pod-uid")}},
+			logicalClaimName: "gpu",
+		},
+		{
+			name:             "pod name",
+			pod:              &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-pod", Namespace: "test-ns", UID: types.UID("pod-uid")}},
+			logicalClaimName: "gpu",
+		},
+		{
+			name:             "pod UID",
+			pod:              &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "test-ns", UID: types.UID("other-uid")}},
+			logicalClaimName: "gpu",
+		},
+		{
+			name:             "logical claim name",
+			pod:              basePod,
+			logicalClaimName: "network",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.NotEqual(t, baseHash, simulationResourceClaimHash(test.pod, test.logicalClaimName))
+		})
+	}
+	assert.Equal(t, baseHash, simulationResourceClaimHash(basePod, "gpu"))
+}
+
+func TestSimulationResourceClaimHashSeparatesIdentityFields(t *testing.T) {
+	firstPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ab", Name: "c", UID: types.UID("d")}}
+	secondPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "a", Name: "bc", UID: types.UID("d")}}
+
+	// These identities both become "abcde" if their fields are concatenated
+	// without boundaries.
+	assert.NotEqual(t, simulationResourceClaimHash(firstPod, "e"), simulationResourceClaimHash(secondPod, "e"))
+}
+
+func newResourceClaimTemplateLister(t *testing.T, templates ...*resourcev1.ResourceClaimTemplate) resourcelisters.ResourceClaimTemplateLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, template := range templates {
+		require.NoError(t, indexer.Add(template))
+	}
+	return resourcelisters.NewResourceClaimTemplateLister(indexer)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area cluster-autoscaler
/area core-autoscaler
/wg device-management

#### What this PR does / why we need it:

Cluster Autoscaler expands ProvisioningRequest PodTemplates into virtual Pods that exist only in memory. When a virtual Pod references a ResourceClaimTemplate, Kubernetes's ResourceClaim controller never observes it, so no ResourceClaim is created and no concrete claim name is added to the Pod's status.

The DRA snapshot therefore cannot resolve the claim, and `check-capacity` could incorrectly report `CapacityIsNotFound` even when sufficient capacity is available.

The code in this PR:
- materializes the ResourceClaims (in-memory) from referenced ResourceClaimTemplates 
- adds concrete ResourceClaim mappings onto the virtual Pods
- adds the virtual Pods and ResourceClaims to the same DRA snapshot transaction
- reuses the same workload construction for the initial capacity check and capacity booking subsequently
- supports both batch and non-batch check-capacity processing
- prevents the default non-batch path from including unrelated real pending Pods in the selected ProvisioningRequest
- reverts partially modified snapshot state when booking fails

The generated ResourceClaims are used only for scheduling simulation and are never created in the Kubernetes API.

A note on scope: ResourceClaimTemplate materialization in this PR is limited to virtual Pods generated from `check-capacity` ProvisioningRequests. This happens during the initial capacity check and when CA books that capacity for the request afterwards. It does not add ResourceClaimTemplate materialization for CapacityBuffer virtual Pods, and also does not add/change PVC handling for virtual Pods.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/10065

Related context:
- https://github.com/kubernetes/autoscaler/issues/7686
- https://github.com/kubernetes/autoscaler/pull/7530
- https://github.com/kubernetes/autoscaler/issues/7321

This PR fixes only the `check-capacity` ProvisioningRequest ResourceClaimTemplate path described in [#10065](https://github.com/kubernetes/autoscaler/issues/10065). The unschedulable-Pod snapshot refactor in [#7686](https://github.com/kubernetes/autoscaler/issues/7686), the ResourceClaimTemplate materialization for CapacityBuffer-generated virtual Pods and the PVC/generic-ephemeral-volume problem in [#7321](https://github.com/kubernetes/autoscaler/issues/7321) remain out of scope for this PR.

#### Special notes for your reviewer:

CA creates the simulated ResourceClaims only in memory for the initial capacity check, then recreates them with the same names/UIDs when booking the request's capacity in later autoscaler loops.

Deployments with `--enable-provisioning-requests=true` need `list` & `watch` permissions for `resource.k8s.io/resourceclaimtemplates`.

My testing:
- Unit tests and race tests
- Full `make test-ci` test suite
- Repository verification scripts, including `hack/verify-all.sh -v`
- End-to-end testing on a Kubernetes v1.35 cluster with NVIDIA DRA:
  - I created a real pending Pod with a ResourceClaimTemplate and:
     - confirmed it had a controller-generated ResourceClaim mapping
     - verified that the mapping remained unchanged while a separate ProvisioningRequest passed `check-capacity`
  - I submitted a separate workload with a ResourceClaimTemplate and saw:
    - its ProvisioningRequest passed `check-capacity`
    - the workload was admitted 
    - the workload's Pod received a real device allocation
- While the admitted workload Pod was active, I verified that:
    - exactly two ResourceClaims existed: 
      - one for the separate pending Pod
      - one for the admitted workload Pod
    - CA did not create any additional ResourceClaim in the cluster during this capacity simulation


#### Does this PR introduce a user-facing change?
```release-note
action required: check-capacity ProvisioningRequests now support Pods that reference ResourceClaimTemplates. Cluster Autoscaler materializes the implied ResourceClaims in memory only. Deployments using --enable-provisioning-requests must grant CA list & watch access to resource.k8s.io/resourceclaimtemplates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
- [Other doc]: https://github.com/kubernetes/autoscaler/issues/10065
- [Other doc]: https://github.com/kubernetes/autoscaler/pull/7530
```