### PR TITLE
Refactor cluster autoscaler flags to be injected on-demand and not on import

### DIFF
--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -37,452 +38,311 @@ import (
 	"k8s.io/klog/v2"
 	kubelet_config "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	scheduler_config "k8s.io/kubernetes/pkg/scheduler/apis/config"
-
-	"k8s.io/utils/ptr"
 )
 
-// MultiStringFlag is a flag for passing multiple parameters using same flag
-type MultiStringFlag []string
+const (
+	// MaxGracefulTerminationSecDefault the default max graceful termination value in seconds.
+	MaxGracefulTerminationSecDefault = 600
+)
 
-// String returns string representation of the node groups.
-func (flag *MultiStringFlag) String() string {
-	return "[" + strings.Join(*flag, " ") + "]"
+// AutoscalingFlags holds the command line flags for the autoscaler and responsible
+// for parsing and building the AutoscalingOptions struct from commandline flags.
+type AutoscalingFlags struct {
+	// Flags that require post-processing to be converted to the AutoscalingOptions struct
+	schedulerConfigFile        string
+	coresTotal                 string
+	memoryTotal                string
+	drainPriorityConfig        string
+	gpuTotal                   []string
+	nodeGroups                 []string
+	nodeGroupAutodiscovery     []string
+	startupTaints              []string
+	statusTaints               []string
+	ignoreTaints               []string
+	bypassedSchedulers         []string
+	allowedSchedulers          []string
+	maxGracefulTerminationSec  int
+	kubeClientQPS              float64
+	clusterSnapshotParallelism int
+	startupTaintPrefixes       []string
+	balancingIgnoreLabels      []string
+	balancingLabels            []string
+	schedulerVerbosity         int
+	// The AutoscalingOptions struct that will be populated by the flags
+	// as a result of parsing the flags
+	o config.AutoscalingOptions
 }
 
-// Set adds a new configuration.
-func (flag *MultiStringFlag) Set(value string) error {
-	*flag = append(*flag, value)
-	return nil
-}
-
-func multiStringFlag(name string, usage string) *MultiStringFlag {
-	value := new(MultiStringFlag)
-	flag.Var(value, name, usage)
-	return value
-}
-
-var (
-	clusterName             = flag.String("cluster-name", "", "Autoscaled cluster name, if available")
-	address                 = flag.String("address", ":8085", "The address to expose prometheus metrics.")
-	kubernetes              = flag.String("kubernetes", "", "Kubernetes master location. Leave blank for default")
-	kubeConfigFile          = flag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
-	kubeAPIContentType      = flag.String("kube-api-content-type", "application/vnd.kubernetes.protobuf", "Content type of requests sent to apiserver.")
-	kubeClientBurst         = flag.Int("kube-client-burst", rest.DefaultBurst, "Burst value for kubernetes client.")
-	kubeClientQPS           = flag.Float64("kube-client-qps", float64(rest.DefaultQPS), "QPS value for kubernetes client.")
-	cloudConfig             = flag.String("cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
-	namespace               = flag.String("namespace", "kube-system", "Namespace in which cluster-autoscaler run.")
-	enforceNodeGroupMinSize = flag.Bool("enforce-node-group-min-size", false, "Should CA scale up the node group to the configured min size if needed.")
-	scaleDownUnreadyEnabled = flag.Bool("scale-down-unready-enabled", true, "Should CA scale down unready nodes of the cluster")
-	scaleDownDelayAfterAdd  = flag.Duration("scale-down-delay-after-add", 10*time.Minute,
-		"How long after scale up that scale down evaluation resumes")
-	scaleDownDelayTypeLocal = flag.Bool("scale-down-delay-type-local", false,
-		"Should --scale-down-delay-after-* flags be applied locally per nodegroup or globally across all nodegroups")
-	scaleDownDelayAfterDelete = flag.Duration("scale-down-delay-after-delete", 0,
-		"How long after node deletion that scale down evaluation resumes")
-	scaleDownDelayAfterFailure = flag.Duration("scale-down-delay-after-failure", config.DefaultScaleDownDelayAfterFailure,
-		"How long after scale down failure that scale down evaluation resumes")
-	scaleDownUnneededTime = flag.Duration("scale-down-unneeded-time", config.DefaultScaleDownUnneededTime,
-		"How long a node should be unneeded before it is eligible for scale down")
-	scaleDownUnreadyTime = flag.Duration("scale-down-unready-time", config.DefaultScaleDownUnreadyTime,
-		"How long an unready node should be unneeded before it is eligible for scale down")
-	scaleDownUtilizationThreshold = flag.Float64("scale-down-utilization-threshold", config.DefaultScaleDownUtilizationThreshold,
-		"The maximum value between the sum of cpu requests and sum of memory requests of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down")
-	scaleDownGpuUtilizationThreshold = flag.Float64("scale-down-gpu-utilization-threshold", config.DefaultScaleDownGpuUtilizationThreshold,
+// AddFlags injects autoscaling CLI flags for a given flagset
+func (p *AutoscalingFlags) AddFlags(fs *pflag.FlagSet) {
+	// Set of flags directly bound to internal AutoscalingOptions struct
+	fs.StringVar(&p.o.ClusterName, "cluster-name", "", "Autoscaled cluster name, if available")
+	fs.StringVar(&p.o.Address, "address", ":8085", "The address to expose prometheus metrics.")
+	fs.StringVar(&p.o.KubeClientOpts.Master, "kubernetes", "", "Kubernetes master location. Leave blank for default")
+	fs.StringVar(&p.o.KubeClientOpts.KubeConfigPath, "kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
+	fs.StringVar(&p.o.KubeClientOpts.APIContentType, "kube-api-content-type", "application/vnd.kubernetes.protobuf", "Content type of requests sent to apiserver.")
+	fs.IntVar(&p.o.KubeClientOpts.KubeClientBurst, "kube-client-burst", rest.DefaultBurst, "Burst value for kubernetes client.")
+	fs.Float64Var(&p.kubeClientQPS, "kube-client-qps", float64(rest.DefaultQPS), "QPS value for kubernetes client.")
+	fs.StringVar(&p.o.CloudConfig, "cloud-config", "", "The path to the cloud provider configuration file.  Empty string for no configuration file.")
+	fs.StringVar(&p.o.CloudProviderName, "cloud-provider", "gce", "Cloud provider type. Available values: ["+strings.Join(cloudBuilder.AvailableCloudProviders(), ",")+"]")
+	fs.StringVar(&p.o.ConfigNamespace, "namespace", "kube-system", "Namespace in which cluster-autoscaler run.")
+	fs.BoolVar(&p.o.EnforceNodeGroupMinSize, "enforce-node-group-min-size", false, "Should CA scale up the node group to the configured min size if needed.")
+	fs.BoolVar(&p.o.ScaleDownUnreadyEnabled, "scale-down-unready-enabled", true, "Should CA scale down unready nodes of the cluster")
+	fs.DurationVar(&p.o.ScaleDownDelayAfterAdd, "scale-down-delay-after-add", 10*time.Minute, "How long after scale up that scale down evaluation resumes")
+	fs.BoolVar(&p.o.ScaleDownDelayTypeLocal, "scale-down-delay-type-local", false, "Should --scale-down-delay-after-* flags be applied locally per nodegroup or globally across all nodegroups")
+	fs.DurationVar(&p.o.ScaleDownDelayAfterDelete, "scale-down-delay-after-delete", 0, "How long after node deletion that scale down evaluation resumes (default 0s)")
+	fs.DurationVar(&p.o.ScaleDownDelayAfterFailure, "scale-down-delay-after-failure", config.DefaultScaleDownDelayAfterFailure, "How long after scale down failure that scale down evaluation resumes")
+	fs.DurationVar(&p.o.NodeGroupDefaults.ScaleDownUnneededTime, "scale-down-unneeded-time", config.DefaultScaleDownUnneededTime, "How long a node should be unneeded before it is eligible for scale down")
+	fs.DurationVar(&p.o.NodeGroupDefaults.ScaleDownUnreadyTime, "scale-down-unready-time", config.DefaultScaleDownUnreadyTime, "How long an unready node should be unneeded before it is eligible for scale down")
+	fs.Float64Var(&p.o.NodeGroupDefaults.ScaleDownUtilizationThreshold, "scale-down-utilization-threshold", config.DefaultScaleDownUtilizationThreshold, "The maximum value between the sum of cpu requests and sum of memory requests of all pods running on the node divided by node's corresponding allocatable resource, below which a node can be considered for scale down")
+	fs.Float64Var(&p.o.NodeGroupDefaults.ScaleDownGpuUtilizationThreshold, "scale-down-gpu-utilization-threshold", config.DefaultScaleDownGpuUtilizationThreshold,
 		"Sum of gpu requests of all pods running on the node divided by node's allocatable resource, below which a node can be considered for scale down."+
 			"Utilization calculation only cares about gpu resource for accelerator node. cpu and memory utilization will be ignored.")
-	scaleDownNonEmptyCandidatesCount = flag.Int("scale-down-non-empty-candidates-count", 30,
+	fs.IntVar(&p.o.ScaleDownNonEmptyCandidatesCount, "scale-down-non-empty-candidates-count", 30,
 		"Maximum number of non empty nodes considered in one iteration as candidates for scale down with drain."+
 			"Lower value means better CA responsiveness but possible slower scale down latency."+
 			"Higher value can affect CA performance with big clusters (hundreds of nodes)."+
 			"Set to non positive value to turn this heuristic off - CA will not limit the number of nodes it considers.")
-	scaleDownCandidatesPoolRatio = flag.Float64("scale-down-candidates-pool-ratio", 0.1,
+	fs.Float64Var(&p.o.ScaleDownCandidatesPoolRatio, "scale-down-candidates-pool-ratio", 0.1,
 		"A ratio of nodes that are considered as additional non empty candidates for"+
 			"scale down when some candidates from previous iteration are no longer valid."+
 			"Lower value means better CA responsiveness but possible slower scale down latency."+
 			"Higher value can affect CA performance with big clusters (hundreds of nodes)."+
 			"Set to 1.0 to turn this heuristics off - CA will take all nodes as additional candidates.")
-	scaleDownCandidatesPoolMinCount = flag.Int("scale-down-candidates-pool-min-count", 50,
+	fs.IntVar(&p.o.ScaleDownCandidatesPoolMinCount, "scale-down-candidates-pool-min-count", 50,
 		"Minimum number of nodes that are considered as additional non empty candidates"+
 			"for scale down when some candidates from previous iteration are no longer valid."+
 			"When calculating the pool size for additional candidates we take"+
 			"max(#nodes * scale-down-candidates-pool-ratio, scale-down-candidates-pool-min-count).")
-	schedulerConfigFile         = flag.String(config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
-	nodeDeletionDelayTimeout    = flag.Duration("node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
-	nodeDeletionBatcherInterval = flag.Duration("node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch.")
-	scanInterval                = flag.Duration("scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
-	maxNodesTotal               = flag.Int("max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
-	coresTotal                  = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	memoryTotal                 = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
-	gpuTotal                    = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
-	cloudProviderFlag           = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider(),
-		"Cloud provider type. Available values: ["+strings.Join(cloudBuilder.AvailableCloudProviders(), ",")+"]")
-	maxBulkSoftTaintCount      = flag.Int("max-bulk-soft-taint-count", 10, "Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting.")
-	maxBulkSoftTaintTime       = flag.Duration("max-bulk-soft-taint-time", 3*time.Second, "Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time.")
-	maxGracefulTerminationFlag = flag.Int("max-graceful-termination-sec", 10*60, "Maximum number of seconds CA waits for pod termination when trying to scale down a node. "+
-		"This flag is mutually exclusion with drain-priority-config flag which allows more configuration options.")
-	maxTotalUnreadyPercentage = flag.Float64("max-total-unready-percentage", 45, "Maximum percentage of unready nodes in the cluster.  After this is exceeded, CA halts operations")
-	okTotalUnreadyCount       = flag.Int("ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
-	scaleUpFromZero           = flag.Bool("scale-up-from-zero", true, "Should CA scale up when there are 0 ready nodes.")
-	parallelScaleUp           = flag.Bool("parallel-scale-up", false, "Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk.")
-	salvoScaleUp              = flag.Bool("salvo-scale-up", false, "Whether to allow multiple scale-ups in a single CA loop.")
-	salvoScaleUpBudget        = flag.Duration("salvo-scale-up-budget", 1*time.Minute, "Maximum time CA spends on subsequent scale ups in a single CA loop. Requires salvo-scale-up flag to be enabled.")
-	maxNodeProvisionTime      = flag.Duration("max-node-provision-time", 15*time.Minute, "The default maximum time CA waits for node to be provisioned - the value can be overridden per node group")
-	maxNodeStartupTime        = flag.Duration("max-node-startup-time", 15*time.Minute, "The maximum time from the moment the node is registered to the time the node is ready - the value can be overridden per node group")
-	maxPodEvictionTime        = flag.Duration("max-pod-eviction-time", 2*time.Minute, "Maximum time CA tries to evict a pod before giving up")
-	nodeGroupsFlag            = multiStringFlag(
-		"nodes",
-		"sets min,max size and other configuration data for a node group in a format accepted by cloud provider. Can be used multiple times. Format: <min>:<max>:<other...>")
-	nodeGroupAutoDiscoveryFlag = multiStringFlag(
-		"node-group-auto-discovery",
-		"One or more definition(s) of node group auto-discovery. "+
-			"A definition is expressed `<name of discoverer>:[<key>[=<value>]]`. "+
-			"The `aws`, `gce`, and `azure` cloud providers are currently supported. AWS matches by ASG tags, e.g. `asg:tag=tagKey,anotherTagKey`. "+
-			"GCE matches by IG name prefix, and requires you to specify min and max nodes per IG, e.g. `mig:namePrefix=pfx,min=0,max=10` "+
-			"Azure matches by VMSS tags, similar to AWS. And you can optionally specify a default min and max size, e.g. `label:tag=tagKey,anotherTagKey=bar,min=0,max=600`. "+
-			"Can be used multiple times.")
+	fs.DurationVar(&p.o.NodeDeletionDelayTimeout, "node-deletion-delay-timeout", 2*time.Minute, "Maximum time CA waits for removing delay-deletion.cluster-autoscaler.kubernetes.io/ annotations before deleting the node.")
+	fs.DurationVar(&p.o.NodeDeletionBatcherInterval, "node-deletion-batcher-interval", 0*time.Second, "How long CA ScaleDown gather nodes to delete them in batch. (default 0s)")
+	fs.DurationVar(&p.o.ScanInterval, "scan-interval", config.DefaultScanInterval, "How often cluster is reevaluated for scale up or down")
+	fs.IntVar(&p.o.MaxNodesTotal, "max-nodes-total", 0, "Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.")
+	fs.IntVar(&p.o.MaxBulkSoftTaintCount, "max-bulk-soft-taint-count", 10, "Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting.")
+	fs.DurationVar(&p.o.MaxBulkSoftTaintTime, "max-bulk-soft-taint-time", 3*time.Second, "Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time.")
+	fs.Float64Var(&p.o.MaxTotalUnreadyPercentage, "max-total-unready-percentage", 45, "Maximum percentage of unready nodes in the cluster.  After this is exceeded, CA halts operations")
+	fs.IntVar(&p.o.OkTotalUnreadyCount, "ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
+	fs.BoolVar(&p.o.ScaleUpFromZero, "scale-up-from-zero", true, "Should CA scale up when there are 0 ready nodes.")
+	fs.BoolVar(&p.o.ParallelScaleUp, "parallel-scale-up", false, "Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk.")
+	fs.DurationVar(&p.o.NodeGroupDefaults.MaxNodeProvisionTime, "max-node-provision-time", 15*time.Minute, "The default maximum time CA waits for node to be provisioned - the value can be overridden per node group")
+	fs.DurationVar(&p.o.NodeGroupDefaults.MaxNodeStartupTime, "max-node-startup-time", 15*time.Minute, "The maximum time from the moment the node is registered to the time the node is ready - the value can be overridden per node group")
+	fs.DurationVar(&p.o.MaxPodEvictionTime, "max-pod-eviction-time", 2*time.Minute, "Maximum time CA tries to evict a pod before giving up")
+	fs.StringVar(&p.o.EstimatorName, "estimator", estimator.BinpackingEstimatorName, "Type of resource estimator to be used in scale up. Available values: ["+strings.Join(estimator.AvailableEstimators, ",")+"]")
+	fs.StringVar(&p.o.ExpanderNames, "expander", expander.LeastWasteExpanderName, "Type of node group expander to be used in scale up. Available values: ["+strings.Join(expander.AvailableExpanders, ",")+"]. Specifying multiple values separated by commas will call the expanders in succession until there is only one option remaining. Ties still existing after this process are broken randomly.")
+	fs.StringVar(&p.o.GRPCExpanderCert, "grpc-expander-cert", "", "Path to cert used by gRPC server over TLS")
+	fs.StringVar(&p.o.GRPCExpanderURL, "grpc-expander-url", "", "URL to reach gRPC expander server.")
+	fs.BoolVar(&p.o.NodeGroupDefaults.IgnoreDaemonSetsUtilization, "ignore-daemonsets-utilization", false, "Should CA ignore DaemonSet pods when calculating resource utilization for scaling down")
+	fs.BoolVar(&p.o.IgnoreMirrorPodsUtilization, "ignore-mirror-pods-utilization", false, "Should CA ignore Mirror pods when calculating resource utilization for scaling down")
+	fs.BoolVar(&p.o.WriteStatusConfigMap, "write-status-configmap", true, "Should CA write status information to a configmap")
+	fs.StringVar(&p.o.StatusConfigMapName, "status-config-map-name", "cluster-autoscaler-status", "Status configmap name")
+	fs.DurationVar(&p.o.MaxInactivityTime, "max-inactivity", 10*time.Minute, "Maximum time from last recorded autoscaler activity before automatic restart")
+	fs.DurationVar(&p.o.MaxBinpackingTime, "max-binpacking-time", 5*time.Minute, "Maximum time spend on binpacking for a single scale-up. If binpacking is limited by this, scale-up will continue with the already calculated scale-up options.")
+	fs.DurationVar(&p.o.MaxFailingTime, "max-failing-time", 15*time.Minute, "Maximum time from last recorded successful autoscaler run before automatic restart")
+	fs.DurationVar(&p.o.MaxStartupTime, "max-startup-time", 20*time.Minute, "Maximum time until first recorded successful autoscaler run before automatic restart")
+	fs.BoolVar(&p.o.BalanceSimilarNodeGroups, "balance-similar-node-groups", false, "Detect similar node groups and balance the number of nodes between them")
+	fs.DurationVar(&p.o.UnremovableNodeRecheckTimeout, "unremovable-node-recheck-timeout", 5*time.Minute, "The timeout before we check again a node that couldn't be removed before")
+	fs.IntVar(&p.o.ExpendablePodsPriorityCutoff, "expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
+	fs.BoolVar(&p.o.Regional, "regional", false, "Cluster is regional.")
+	fs.DurationVar(&p.o.NewPodScaleUpDelay, "new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'. (default 0s)")
+	fs.BoolVar(&p.o.ScaleFromUnschedulable, "scale-from-unschedulable", false, "Specifies that the CA should ignore a node's .spec.unschedulable field in node templates when considering to scale a node group.")
+	fs.BoolVar(&p.o.EnableProfiling, "profiling", false, "Is debug/pprof endpoint enabled")
+	fs.BoolVar(&p.o.ClusterAPICloudConfigAuthoritative, "clusterapi-cloud-config-authoritative", false, "Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only")
+	fs.BoolVar(&p.o.CordonNodeBeforeTerminate, "cordon-node-before-terminating", true, "Should CA cordon nodes before terminating during downscale process")
+	fs.BoolVar(&p.o.DaemonSetEvictionForEmptyNodes, "daemonset-eviction-for-empty-nodes", false, "DaemonSet pods will be gracefully terminated from empty nodes")
+	fs.BoolVar(&p.o.DaemonSetEvictionForOccupiedNodes, "daemonset-eviction-for-occupied-nodes", true, "DaemonSet pods will be gracefully terminated from non-empty nodes")
+	fs.StringVar(&p.o.UserAgent, "user-agent", "cluster-autoscaler", "User agent used for HTTP calls.")
+	fs.BoolVar(&p.o.EmitPerNodeGroupMetrics, "emit-per-nodegroup-metrics", false, "If true, emit per node group metrics.")
+	fs.BoolVar(&p.o.DebuggingSnapshotEnabled, "debugging-snapshot-enabled", false, "Whether the debugging snapshot of cluster autoscaler feature is enabled")
+	fs.DurationVar(&p.o.NodeInfoCacheExpireTime, "node-info-cache-expire-time", 87600*time.Hour, "Node Info cache expire time for each item. Default value is 10 years.")
+	fs.DurationVar(&p.o.InitialNodeGroupBackoffDuration, "initial-node-group-backoff-duration", 5*time.Minute, "initialNodeGroupBackoffDuration is the duration of first backoff after a new node failed to start.")
+	fs.DurationVar(&p.o.MaxNodeGroupBackoffDuration, "max-node-group-backoff-duration", 30*time.Minute, "maxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start.")
+	fs.DurationVar(&p.o.NodeGroupBackoffResetTimeout, "node-group-backoff-reset-timeout", 3*time.Hour, "nodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.")
+	fs.IntVar(&p.o.MaxScaleDownParallelism, "max-scale-down-parallelism", 10, "Maximum number of nodes (both empty and needing drain) that can be deleted in parallel.")
+	fs.IntVar(&p.o.MaxDrainParallelism, "max-drain-parallelism", 1, "Maximum number of nodes needing drain, that can be drained and deleted in parallel.")
+	fs.BoolVar(&p.o.RecordDuplicatedEvents, "record-duplicated-events", false, "enable duplication of similar events within a 5 minute window.")
+	fs.IntVar(&p.o.MaxNodesPerScaleUp, "max-nodes-per-scaleup", 1000, "Max nodes added in a single scale-up. This is intended strictly for optimizing CA algorithm latency and not a tool to rate-limit scale-up throughput.")
+	fs.DurationVar(&p.o.MaxNodeGroupBinpackingDuration, "max-nodegroup-binpacking-duration", 10*time.Second, "Maximum time that will be spent in binpacking simulation for each NodeGroup.")
+	fs.BoolVar(&p.o.FastpathBinpackingEnabled, "fastpath-binpacking-enabled", false, "Whether to use fastpath binpacking algorithm to optimize scale-ups.")
+	fs.BoolVar(&p.o.SkipNodesWithSystemPods, "skip-nodes-with-system-pods", true, "If true cluster autoscaler will wait for --blocking-system-pod-distruption-timeout before deleting nodes with pods from kube-system (except for DaemonSet or mirror pods)")
+	fs.BoolVar(&p.o.SkipNodesWithLocalStorage, "skip-nodes-with-local-storage", true, "If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath")
+	fs.BoolVar(&p.o.SkipNodesWithCustomControllerPods, "skip-nodes-with-custom-controller-pods", true, "If true cluster autoscaler will never delete nodes with pods owned by custom controllers")
+	fs.IntVar(&p.o.MinReplicaCount, "min-replica-count", 0, "Minimum number or replicas that a replica set or replication controller should have to allow their pods deletion in scale down")
+	fs.DurationVar(&p.o.BspDisruptionTimeout, "blocking-system-pod-distruption-timeout", time.Hour, "The timeout after which CA will evict non-pdb-assigned blocking system pods, applicable only when --skip-nodes-with-system-pods is set to true")
+	fs.DurationVar(&p.o.NodeDeleteDelayAfterTaint, "node-delete-delay-after-taint", 5*time.Second, "How long to wait before deleting a node after tainting it")
+	fs.DurationVar(&p.o.ScaleDownSimulationTimeout, "scale-down-simulation-timeout", 30*time.Second, "How long should we run scale down simulation.")
+	fs.Float64Var(&p.o.NodeGroupSetRatios.MaxCapacityMemoryDifferenceRatio, "memory-difference-ratio", config.DefaultMaxCapacityMemoryDifferenceRatio, "Maximum difference in memory capacity between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's memory capacity.")
+	fs.Float64Var(&p.o.NodeGroupSetRatios.MaxFreeDifferenceRatio, "max-free-difference-ratio", config.DefaultMaxFreeDifferenceRatio, "Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource.")
+	fs.Float64Var(&p.o.NodeGroupSetRatios.MaxAllocatableDifferenceRatio, "max-allocatable-difference-ratio", config.DefaultMaxAllocatableDifferenceRatio, "Maximum difference in allocatable resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's allocatable resource.")
+	fs.BoolVar(&p.o.ForceDaemonSets, "force-ds", false, "Blocks scale-up of node groups too small for all suitable Daemon Sets pods.")
+	fs.BoolVar(&p.o.DynamicNodeDeleteDelayAfterTaintEnabled, "dynamic-node-delete-delay-after-taint-enabled", false, "Enables dynamic adjustment of NodeDeleteDelayAfterTaint based of the latency between CA and api-server")
+	fs.BoolVar(&p.o.ProvisioningRequestEnabled, "enable-provisioning-requests", false, "Whether the clusterautoscaler will be handling the ProvisioningRequest CRs.")
+	fs.DurationVar(&p.o.ProvisioningRequestInitialBackoffTime, "provisioning-request-initial-backoff-time", 1*time.Minute, "Initial backoff time for ProvisioningRequest retry after failed ScaleUp.")
+	fs.DurationVar(&p.o.ProvisioningRequestMaxBackoffTime, "provisioning-request-max-backoff-time", 10*time.Minute, "Max backoff time for ProvisioningRequest retry after failed ScaleUp.")
+	fs.IntVar(&p.o.ProvisioningRequestMaxBackoffCacheSize, "provisioning-request-max-backoff-cache-size", 1000, "Max size for ProvisioningRequest cache size used for retry backoff mechanism.")
+	fs.BoolVar(&p.o.FrequentLoopsEnabled, "frequent-loops-enabled", true, "Whether clusterautoscaler triggers new iterations more frequently when it's needed")
+	fs.BoolVar(&p.o.AsyncNodeGroupsEnabled, "async-node-groups", false, "Whether clusterautoscaler creates and deletes node groups asynchronously. Experimental: requires cloud provider supporting async node group operations, enable at your own risk.")
+	fs.BoolVar(&p.o.ProactiveScaleupEnabled, "enable-proactive-scaleup", false, "Whether to enable/disable proactive scale-ups, defaults to false")
+	fs.BoolVar(&p.o.SalvoScaleUp, "salvo-scale-up", false, "Whether to allow multiple scale-ups in a single CA loop.")
+	fs.DurationVar(&p.o.SalvoScaleUpBudget, "salvo-scale-up-budget", time.Minute, "Maximum time CA spends on subsequent scale ups in a single CA loop. Requires salvo-scale-up flag to be enabled.")
+	fs.BoolVar(&p.o.ScaleUpSimulationForSkippedNodeGroupsEnabled, "scaleup-simulation-for-skipped-node-groups-enabled", false, "Whether to enable the scale up simulation for skipped node groups.")
+	fs.BoolVar(&p.o.GCEOptions.BulkMigInstancesListingEnabled, "bulk-mig-instances-listing-enabled", false, "Fetch GCE mig instances in bulk instead of per mig")
+	fs.IntVar(&p.o.GCEOptions.ConcurrentRefreshes, "gce-concurrent-refreshes", 1, "Maximum number of concurrent refreshes per cloud object type.")
+	fs.DurationVar(&p.o.GCEOptions.MigInstancesMinRefreshWaitTime, "gce-mig-instances-min-refresh-wait-time", 5*time.Second, "The minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed.")
+	fs.BoolVar(&p.o.AWSUseStaticInstanceList, "aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
+	fs.StringArrayVar(&p.balancingIgnoreLabels, "balancing-ignore-label", []string{}, "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
+	fs.StringArrayVar(&p.balancingLabels, "balancing-label", []string{}, "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
+	fs.StringArrayVar(&p.startupTaintPrefixes, "startup-taint-prefix", []string{}, "Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times.")
+	fs.IntVar(&p.o.PodInjectionLimit, "pod-injection-limit", 5000, "Limits total number of pods while injecting fake pods. If unschedulable pods already exceeds the limit, pod injection is disabled but pods are not truncated.")
+	fs.BoolVar(&p.o.CheckCapacityBatchProcessing, "check-capacity-batch-processing", false, "Whether to enable batch processing for check capacity requests.")
+	fs.IntVar(&p.o.CheckCapacityProvisioningRequestMaxBatchSize, "check-capacity-provisioning-request-max-batch-size", 10, "Maximum number of provisioning requests to process in a single batch.")
+	fs.DurationVar(&p.o.CheckCapacityProvisioningRequestBatchTimebox, "check-capacity-provisioning-request-batch-timebox", 10*time.Second, "Maximum time to process a batch of provisioning requests.")
+	fs.BoolVar(&p.o.ForceDeleteLongUnregisteredNodes, "force-delete-unregistered-nodes", false, "Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to.")
+	fs.BoolVar(&p.o.ForceDeleteFailedNodes, "force-delete-failed-nodes", false, "Whether to enable force deletion of failed nodes, regardless of the min size of the node group the belong to.")
+	fs.BoolVar(&p.o.CSINodeAwareSchedulingEnabled, "enable-csi-node-aware-scheduling", false, "Whether logic for handling CSINode objects is enabled.")
+	fs.IntVar(&p.o.PredicateParallelism, "predicate-parallelism", 4, "Maximum parallelism of scheduler predicate checking.")
+	fs.StringVar(&p.o.CheckCapacityProcessorInstance, "check-capacity-processor-instance", "", "Name of the processor instance. Only ProvisioningRequests that define this name in their parameters with the key \"processorInstance\" will be processed by this CA instance. It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance. Not recommended: Until CA 1.35, ProvisioningRequests with this name as prefix in their class will be also processed.")
+	fs.DurationVar(&p.o.NodeDeletionCandidateTTL, "node-deletion-candidate-ttl", time.Duration(0), "Maximum time a node can be marked as removable before the marking becomes stale. This sets the TTL of Cluster-Autoscaler's state if the Cluste-Autoscaler deployment becomes inactive (default 0s)")
+	fs.BoolVar(&p.o.CapacitybufferControllerEnabled, "capacity-buffer-controller-enabled", false, "Whether to enable the default controller for capacity buffers or not")
+	fs.BoolVar(&p.o.CapacitybufferPodInjectionEnabled, "capacity-buffer-pod-injection-enabled", false, "Whether to enable pod list processor that processes ready capacity buffers and injects fake pods accordingly")
+	fs.BoolVar(&p.o.CapacityBufferPodDryRunEnabled, "capacity-buffer-pod-dry-run-enabled", true, "Whether to use server dry run to build managed pod templates for capacity buffers. That ensures that the buffers' fake pods will more reliably resemble real pods by going through the pod defaulting, mutating and validating webhooks. No-op if --capacity-buffer-controller-enabled is false. Note: requires \"create\" permission on pods to call server dry run. No real pods will be created.")
+	fs.BoolVar(&p.o.NodeRemovalLatencyTrackingEnabled, "node-removal-latency-tracking-enabled", false, "Whether to track latency from when an unneeded node is eligible for scale down until it is removed or needed again.")
+	fs.BoolVar(&p.o.MaxNodeSkipEvalTimeTrackerEnabled, "max-node-skip-eval-time-tracker-enabled", false, "Whether to enable the tracking of the maximum time of node being skipped during ScaleDown")
+	fs.BoolVar(&p.o.CapacityQuotasEnabled, "capacity-quotas-enabled", false, "Whether to enable CapacityQuota CRD support.")
+	fs.DurationVar(&p.o.PendingPodsBatchingTimeout, "pending-pods-batching-timeout", 4*time.Minute, "The maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.")
+	fs.BoolVar(&p.o.GracefulDegradationEnabled, "enable-graceful-degradation", false, "Enables graceful degradation for unschedulable pods. When enabled, scheduling simulations during filter out pod list processor will be stopped after a timeout(specified by scheduling-simulation-timeout) and CA will proceed with a sub set of pods.")
 
-	estimatorFlag = flag.String("estimator", estimator.BinpackingEstimatorName,
-		"Type of resource estimator to be used in scale up. Available values: ["+strings.Join(estimator.AvailableEstimators, ",")+"]")
+	// Deprecated flags
+	fs.StringArrayVar(&p.ignoreTaints, "ignore-taint", []string{}, "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
+	fs.BoolVar(&p.o.DynamicResourceAllocationEnabled, "enable-dynamic-resource-allocation", true, "Handle DRA (Dynamic Resource Allocation) objects, locked to true.")
+	fs.IntVar(&p.clusterSnapshotParallelism, "cluster-snapshot-parallelism", 16, "Maximum parallelism of cluster snapshot creation (Deprecated, use predicate-parallelism instead)")
+	fs.BoolVar(&p.o.ScaleDownEnabled, "scale-down-enabled", true, "[Deprecated] Should CA scale down the cluster")
 
-	expanderFlag = flag.String("expander", expander.LeastWasteExpanderName, "Type of node group expander to be used in scale up. Available values: ["+strings.Join(expander.AvailableExpanders, ",")+"]. Specifying multiple values separated by commas will call the expanders in succession until there is only one option remaining. Ties still existing after this process are broken randomly.")
+	// Properties specific to the cloud provider, but kept for the sake of POC
+	fs.StringArrayVar(&p.nodeGroups, "nodes", []string{}, "sets min,max size and other configuration data for a node group in a format accepted by cloud provider. Can be used multiple times. Format: <min>:<max>:<other...>")
+	fs.StringArrayVar(&p.nodeGroupAutodiscovery, "node-group-auto-discovery", []string{}, "One or more definition(s) of node group auto-discovery. "+
+		"A definition is expressed `<name of discoverer>:[<key>[=<value>]]`. "+
+		"The `aws`, `gce`, and `azure` cloud providers are currently supported. AWS matches by ASG tags, e.g. `asg:tag=tagKey,anotherTagKey`. "+
+		"GCE matches by IG name prefix, and requires you to specify min and max nodes per IG, e.g. `mig:namePrefix=pfx,min=0,max=10` "+
+		"Azure matches by VMSS tags, similar to AWS. And you can optionally specify a default min and max size, e.g. `label:tag=tagKey,anotherTagKey=bar,min=0,max=600`. "+
+		"Can be used multiple times.")
 
-	grpcExpanderCert = flag.String("grpc-expander-cert", "", "Path to cert used by gRPC server over TLS")
-	grpcExpanderURL  = flag.String("grpc-expander-url", "", "URL to reach gRPC expander server.")
-
-	ignoreDaemonSetsUtilization = flag.Bool("ignore-daemonsets-utilization", false,
-		"Should CA ignore DaemonSet pods when calculating resource utilization for scaling down")
-	ignoreMirrorPodsUtilization = flag.Bool("ignore-mirror-pods-utilization", false,
-		"Should CA ignore Mirror pods when calculating resource utilization for scaling down")
-
-	writeStatusConfigMapFlag     = flag.Bool("write-status-configmap", true, "Should CA write status information to a configmap")
-	statusConfigMapName          = flag.String("status-config-map-name", "cluster-autoscaler-status", "Status configmap name")
-	maxInactivityTimeFlag        = flag.Duration("max-inactivity", 10*time.Minute, "Maximum time from last recorded autoscaler activity before automatic restart")
-	maxBinpackingTimeFlag        = flag.Duration("max-binpacking-time", 5*time.Minute, "Maximum time spend on binpacking for a single scale-up. If binpacking is limited by this, scale-up will continue with the already calculated scale-up options.")
-	maxFailingTimeFlag           = flag.Duration("max-failing-time", 15*time.Minute, "Maximum time from last recorded successful autoscaler run before automatic restart")
-	maxStartupTimeFlag           = flag.Duration("max-startup-time", 20*time.Minute, "Maximum time until first recorded successful autoscaler run before automatic restart")
-	balanceSimilarNodeGroupsFlag = flag.Bool("balance-similar-node-groups", false, "Detect similar node groups and balance the number of nodes between them")
-
-	unremovableNodeRecheckTimeout = flag.Duration("unremovable-node-recheck-timeout", 5*time.Minute, "The timeout before we check again a node that couldn't be removed before")
-	expendablePodsPriorityCutoff  = flag.Int("expendable-pods-priority-cutoff", -10, "Pods with priority below cutoff will be expendable. They can be killed without any consideration during scale down and they don't cause scale up. Pods with null priority (PodPriority disabled) are non expendable.")
-	regional                      = flag.Bool("regional", false, "Cluster is regional.")
-	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up. Can be increased for individual pods through annotation 'cluster-autoscaler.kubernetes.io/pod-scale-up-delay'.")
-
-	startupTaintsFlag         = multiStringFlag("startup-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
-	startupTaintPrefixesFlag  = multiStringFlag("startup-taint-prefix", "Specifies a taint key prefix. Any taint whose key starts with this prefix will be treated as a startup taint (in addition to the built-in prefixes). Can be used multiple times.")
-	statusTaintsFlag          = multiStringFlag("status-taint", "Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready")
-	balancingIgnoreLabelsFlag = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
-	balancingLabelsFlag       = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
-	awsUseStaticInstanceList  = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
-	scaleFromUnschedulable    = flag.Bool("scale-from-unschedulable", false, "Specifies that the CA should ignore a node's .spec.unschedulable field in node templates when considering to scale a node group.")
-
-	schedulerVerbosity = flag.Int("scheduler-verbosity", 0, "Specifies the verbosity threshold for logs produced by the scheduler.")
-	// GCE specific flags
-	concurrentGceRefreshes             = flag.Int("gce-concurrent-refreshes", 1, "Maximum number of concurrent refreshes per cloud object type.")
-	gceMigInstancesMinRefreshWaitTime  = flag.Duration("gce-mig-instances-min-refresh-wait-time", 5*time.Second, "The minimum time which needs to pass before GCE MIG instances from a given MIG can be refreshed.")
-	bulkGceMigInstancesListingEnabled  = flag.Bool("bulk-mig-instances-listing-enabled", false, "Fetch GCE mig instances in bulk instead of per mig")
-	enableProfiling                    = flag.Bool("profiling", false, "Is debug/pprof endpoint enabled")
-	clusterAPICloudConfigAuthoritative = flag.Bool("clusterapi-cloud-config-authoritative", false, "Treat the cloud-config flag authoritatively (do not fallback to using kubeconfig flag). ClusterAPI only")
-	cordonNodeBeforeTerminate          = flag.Bool("cordon-node-before-terminating", true, "Should CA cordon nodes before terminating during downscale process")
-	daemonSetEvictionForEmptyNodes     = flag.Bool("daemonset-eviction-for-empty-nodes", false, "DaemonSet pods will be gracefully terminated from empty nodes")
-	daemonSetEvictionForOccupiedNodes  = flag.Bool("daemonset-eviction-for-occupied-nodes", true, "DaemonSet pods will be gracefully terminated from non-empty nodes")
-	userAgent                          = flag.String("user-agent", "cluster-autoscaler", "User agent used for HTTP calls.")
-	emitPerNodeGroupMetrics            = flag.Bool("emit-per-nodegroup-metrics", false, "If true, emit per node group metrics.")
-	debuggingSnapshotEnabled           = flag.Bool("debugging-snapshot-enabled", false, "Whether the debugging snapshot of cluster autoscaler feature is enabled")
-	nodeInfoCacheExpireTime            = flag.Duration("node-info-cache-expire-time", 87600*time.Hour, "Node Info cache expire time for each item. Default value is 10 years.")
-
-	initialNodeGroupBackoffDuration = flag.Duration("initial-node-group-backoff-duration", 5*time.Minute,
-		"initialNodeGroupBackoffDuration is the duration of first backoff after a new node failed to start.")
-	maxNodeGroupBackoffDuration = flag.Duration("max-node-group-backoff-duration", 30*time.Minute,
-		"maxNodeGroupBackoffDuration is the maximum backoff duration for a NodeGroup after new nodes failed to start.")
-	nodeGroupBackoffResetTimeout = flag.Duration("node-group-backoff-reset-timeout", 3*time.Hour,
-		"nodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset.")
-	maxScaleDownParallelismFlag             = flag.Int("max-scale-down-parallelism", 10, "Maximum number of nodes (both empty and needing drain) that can be deleted in parallel.")
-	maxDrainParallelismFlag                 = flag.Int("max-drain-parallelism", 1, "Maximum number of nodes needing drain, that can be drained and deleted in parallel.")
-	recordDuplicatedEvents                  = flag.Bool("record-duplicated-events", false, "enable duplication of similar events within a 5 minute window.")
-	maxNodesPerScaleUp                      = flag.Int("max-nodes-per-scaleup", 1000, "Max nodes added in a single scale-up. This is intended strictly for optimizing CA algorithm latency and not a tool to rate-limit scale-up throughput.")
-	maxNodeGroupBinpackingDuration          = flag.Duration("max-nodegroup-binpacking-duration", 10*time.Second, "Maximum time that will be spent in binpacking simulation for each NodeGroup.")
-	fastpathBinpackingEnabled               = flag.Bool("fastpath-binpacking-enabled", false, "Whether to use fastpath binpacking algorithm to optimize scale-ups.")
-	skipNodesWithSystemPods                 = flag.Bool("skip-nodes-with-system-pods", true, "If true cluster autoscaler will wait for --blocking-system-pod-distruption-timeout before deleting nodes with pods from kube-system (except for DaemonSet or mirror pods)")
-	skipNodesWithLocalStorage               = flag.Bool("skip-nodes-with-local-storage", true, "If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath")
-	skipNodesWithCustomControllerPods       = flag.Bool("skip-nodes-with-custom-controller-pods", true, "If true cluster autoscaler will never delete nodes with pods owned by custom controllers")
-	minReplicaCount                         = flag.Int("min-replica-count", 0, "Minimum number or replicas that a replica set or replication controller should have to allow their pods deletion in scale down")
-	bspDisruptionTimeout                    = flag.Duration("blocking-system-pod-distruption-timeout", time.Hour, "The timeout after which CA will evict non-pdb-assigned blocking system pods, applicable only when --skip-nodes-with-system-pods is set to true")
-	nodeDeleteDelayAfterTaint               = flag.Duration("node-delete-delay-after-taint", 5*time.Second, "How long to wait before deleting a node after tainting it")
-	scaleDownSimulationTimeout              = flag.Duration("scale-down-simulation-timeout", 30*time.Second, "How long should we run scale down simulation.")
-	maxCapacityMemoryDifferenceRatio        = flag.Float64("memory-difference-ratio", config.DefaultMaxCapacityMemoryDifferenceRatio, "Maximum difference in memory capacity between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's memory capacity.")
-	maxFreeDifferenceRatio                  = flag.Float64("max-free-difference-ratio", config.DefaultMaxFreeDifferenceRatio, "Maximum difference in free resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's free resource.")
-	maxAllocatableDifferenceRatio           = flag.Float64("max-allocatable-difference-ratio", config.DefaultMaxAllocatableDifferenceRatio, "Maximum difference in allocatable resources between two similar node groups to be considered for balancing. Value is a ratio of the smaller node group's allocatable resource.")
-	forceDaemonSets                         = flag.Bool("force-ds", false, "Blocks scale-up of node groups too small for all suitable Daemon Sets pods.")
-	dynamicNodeDeleteDelayAfterTaintEnabled = flag.Bool("dynamic-node-delete-delay-after-taint-enabled", false, "Enables dynamic adjustment of NodeDeleteDelayAfterTaint based of the latency between CA and api-server")
-	bypassedSchedulers                      = pflag.StringSlice("bypassed-scheduler-names", []string{}, "Names of schedulers to bypass. If set to non-empty value, CA will not wait for pods to reach a certain age before triggering a scale-up.")
-	allowedSchedulers                       = pflag.StringSlice("allowed-scheduler-names", []string{}, "If set to non-empty value, CA will proceed only with pods targeting schedulers in the list, from the list of unschedulable and scheduler unprocessed pods")
-	drainPriorityConfig                     = flag.String("drain-priority-config", "",
+	// Flags which require post-processing
+	fs.StringVar(&p.schedulerConfigFile, config.SchedulerConfigFileFlag, "", "scheduler-config allows changing configuration of in-tree scheduler plugins acting on PreFilter and Filter extension points")
+	fs.StringVar(&p.coresTotal, "cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	fs.StringVar(&p.memoryTotal, "memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
+	fs.IntVar(&p.maxGracefulTerminationSec, "max-graceful-termination-sec", MaxGracefulTerminationSecDefault, "Maximum number of seconds CA waits for pod termination when trying to scale down a node. This flag is mutually exclusion with drain-priority-config flag which allows more configuration options.")
+	fs.StringArrayVar(&p.gpuTotal, "gpu-total", []string{}, "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
+	fs.StringArrayVar(&p.startupTaints, "startup-taint", []string{}, "Specifies a taint to ignore in node templates when considering to scale a node group (Equivalent to ignore-taint)")
+	fs.StringArrayVar(&p.statusTaints, "status-taint", []string{}, "Specifies a taint to ignore in node templates when considering to scale a node group but nodes will not be treated as unready")
+	fs.StringSliceVar(&p.bypassedSchedulers, "bypassed-scheduler-names", []string{}, "Names of schedulers to bypass. If set to non-empty value, CA will not wait for pods to reach a certain age before triggering a scale-up.")
+	fs.StringSliceVar(&p.allowedSchedulers, "allowed-scheduler-names", []string{}, "If set to non-empty value, CA will proceed only with pods targeting schedulers in the list, from the list of unschedulable and scheduler unprocessed pods")
+	fs.StringVar(&p.drainPriorityConfig, "drain-priority-config", "",
 		"List of ',' separated pairs (priority:terminationGracePeriodSeconds) of integers separated by ':' enables priority evictor. Priority evictor groups pods into priority groups based on pod priority and evict pods in the ascending order of group priorities"+
 			"--max-graceful-termination-sec flag should not be set when this flag is set. Not setting this flag will use unordered evictor by default."+
 			"Priority evictor reuses the concepts of drain logic in kubelet(https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown#migration-from-the-node-graceful-shutdown-feature)."+
 			"Eg. flag usage:  '10000:20,1000:100,0:60'")
-	provisioningRequestsEnabled                  = flag.Bool("enable-provisioning-requests", false, "Whether the clusterautoscaler will be handling the ProvisioningRequest CRs.")
-	provisioningRequestInitialBackoffTime        = flag.Duration("provisioning-request-initial-backoff-time", 1*time.Minute, "Initial backoff time for ProvisioningRequest retry after failed ScaleUp.")
-	provisioningRequestMaxBackoffTime            = flag.Duration("provisioning-request-max-backoff-time", 10*time.Minute, "Max backoff time for ProvisioningRequest retry after failed ScaleUp.")
-	provisioningRequestMaxBackoffCacheSize       = flag.Int("provisioning-request-max-backoff-cache-size", 1000, "Max size for ProvisioningRequest cache size used for retry backoff mechanism.")
-	frequentLoopsEnabled                         = flag.Bool("frequent-loops-enabled", true, "Whether clusterautoscaler triggers new iterations more frequently when it's needed")
-	asyncNodeGroupsEnabled                       = flag.Bool("async-node-groups", false, "Whether clusterautoscaler creates and deletes node groups asynchronously. Experimental: requires cloud provider supporting async node group operations, enable at your own risk.")
-	proactiveScaleupEnabled                      = flag.Bool("enable-proactive-scaleup", false, "Whether to enable/disable proactive scale-ups, defaults to false")
-	podInjectionLimit                            = flag.Int("pod-injection-limit", 5000, "Limits total number of pods while injecting fake pods. If unschedulable pods already exceeds the limit, pod injection is disabled but pods are not truncated.")
-	checkCapacityBatchProcessing                 = flag.Bool("check-capacity-batch-processing", false, "Whether to enable batch processing for check capacity requests.")
-	checkCapacityProvisioningRequestMaxBatchSize = flag.Int("check-capacity-provisioning-request-max-batch-size", 10, "Maximum number of provisioning requests to process in a single batch.")
-	checkCapacityProvisioningRequestBatchTimebox = flag.Duration("check-capacity-provisioning-request-batch-timebox", 10*time.Second, "Maximum time to process a batch of provisioning requests.")
-	forceDeleteLongUnregisteredNodes             = flag.Bool("force-delete-unregistered-nodes", false, "Whether to enable force deletion of long unregistered nodes, regardless of the min size of the node group the belong to.")
-	forceDeleteFailedNodes                       = flag.Bool("force-delete-failed-nodes", false, "Whether to enable force deletion of failed nodes, regardless of the min size of the node group the belong to.")
-	enableDynamicResourceAllocation              = flag.Bool("enable-dynamic-resource-allocation", true, "Handle DRA (Dynamic Resource Allocation) objects, locked to true.")
-	enableCSINodeAwareScheduling                 = flag.Bool("enable-csi-node-aware-scheduling", false, "Whether logic for handling CSINode objects is enabled.")
-	predicateParallelism                         = flag.Int("predicate-parallelism", 4, "Maximum parallelism of scheduler predicate checking.")
-	checkCapacityProcessorInstance               = flag.String("check-capacity-processor-instance", "", "Name of the processor instance. Only ProvisioningRequests that define this name in their parameters with the key \"processorInstance\" will be processed by this CA instance. It only refers to check capacity ProvisioningRequests, but if not empty, best-effort atomic ProvisioningRequests processing is disabled in this instance. Not recommended: Until CA 1.35, ProvisioningRequests with this name as prefix in their class will be also processed.")
-	nodeDeletionCandidateTTL                     = flag.Duration("node-deletion-candidate-ttl", time.Duration(0), "Maximum time a node can be marked as removable before the marking becomes stale. This sets the TTL of Cluster-Autoscaler's state if the Cluste-Autoscaler deployment becomes inactive")
-	capacitybufferControllerEnabled              = flag.Bool("capacity-buffer-controller-enabled", false, "Whether to enable the default controller for capacity buffers or not")
-	capacitybufferPodInjectionEnabled            = flag.Bool("capacity-buffer-pod-injection-enabled", false, "Whether to enable pod list processor that processes ready capacity buffers and injects fake pods accordingly")
-	capacityBufferPodDryRunEnabled               = flag.Bool("capacity-buffer-pod-dry-run-enabled", true, "Whether to use server dry run to build managed pod templates for capacity buffers. That ensures that the buffers' fake pods will more reliably resemble real pods by going through the pod defaulting, mutating and validating webhooks. No-op if --capacity-buffer-controller-enabled is false. Note: requires \"create\" permission on pods to call server dry run. No real pods will be created.")
-	nodeRemovalLatencyTrackingEnabled            = flag.Bool("node-removal-latency-tracking-enabled", false, "Whether to track latency from when an unneeded node is eligible for scale down until it is removed or needed again.")
-	maxNodeSkipEvalTimeTrackerEnabled            = flag.Bool("max-node-skip-eval-time-tracker-enabled", false, "Whether to enable the tracking of the maximum time of node being skipped during ScaleDown")
-	capacityQuotasEnabled                        = flag.Bool("capacity-quotas-enabled", false, "Whether to enable CapacityQuota CRD support.")
-	scaleUpSimulationForSkippedNodeGroupsEnabled = flag.Bool("scaleup-simulation-for-skipped-node-groups-enabled", false, "Whether to enable the scale up simulation for skipped node groups.")
-	pendingPodsBatchingTimeout                   = flag.Duration("pending-pods-batching-timeout", 4*time.Minute, "The maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.")
-	enableGracefulDegradation                    = flag.Bool("enable-graceful-degradation", false, "Enables graceful degradation for unschedulable pods. When enabled, scheduling simulations during filter out pod list processor will be stopped after a timeout(specified by scheduling-simulation-timeout) and CA will proceed with a sub set of pods.")
-
-	// Deprecated flags
-	ignoreTaintsFlag           = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")
-	clusterSnapshotParallelism = flag.Int("cluster-snapshot-parallelism", 16, "Maximum parallelism of cluster snapshot creation (Deprecated, use predicate-parallelism instead)")
-	scaleDownEnabled           = flag.Bool("scale-down-enabled", true, "[Deprecated] Should CA scale down the cluster")
-)
-
-var autoscalingOptions *config.AutoscalingOptions
-
-// AutoscalingOptions returns the singleton instance of AutoscalingOptions, initializing it if necessary.
-func AutoscalingOptions() config.AutoscalingOptions {
-	if autoscalingOptions == nil {
-		newAutoscalingOptions := createAutoscalingOptions()
-		autoscalingOptions = &newAutoscalingOptions
-	}
-	return *autoscalingOptions
+	fs.IntVar(&p.schedulerVerbosity, "scheduler-verbosity", 0, "Specifies the verbosity threshold for logs produced by the scheduler.")
 }
 
-func createAutoscalingOptions() config.AutoscalingOptions {
-	minCoresTotal, maxCoresTotal, err := parseMinMaxFlag(*coresTotal)
+// Options builds AutoscalingOptions from the flags and returns them by value
+func (p *AutoscalingFlags) Options() (config.AutoscalingOptions, error) {
+	minCoresTotal, maxCoresTotal, err := parseMinMaxFlag(p.coresTotal)
 	if err != nil {
-		klog.Fatalf("Failed to parse flags: %v", err)
+		return config.AutoscalingOptions{}, fmt.Errorf("Failed to parse flags: %w", err)
 	}
-	minMemoryTotal, maxMemoryTotal, err := parseMinMaxFlag(*memoryTotal)
+
+	minMemoryTotal, maxMemoryTotal, err := parseMinMaxFlag(p.memoryTotal)
 	if err != nil {
-		klog.Fatalf("Failed to parse flags: %v", err)
+		return config.AutoscalingOptions{}, fmt.Errorf("Failed to parse flags: %w", err)
 	}
 	// Convert memory limits to bytes.
 	minMemoryTotal = minMemoryTotal * units.GiB
 	maxMemoryTotal = maxMemoryTotal * units.GiB
 
-	parsedGpuTotal, err := parseMultipleGpuLimits(*gpuTotal)
+	parsedGpuTotal, err := parseMultipleGpuLimits(p.gpuTotal)
 	if err != nil {
-		klog.Fatalf("Failed to parse flags: %v", err)
+		return config.AutoscalingOptions{}, fmt.Errorf("Failed to parse flags: %w", err)
 	}
 
 	var parsedSchedConfig *scheduler_config.KubeSchedulerConfiguration
 	// if scheduler config flag was set by the user
-	if pflag.CommandLine.Changed(config.SchedulerConfigFileFlag) {
-		parsedSchedConfig, err = scheduler_util.ConfigFromPath(*schedulerConfigFile)
-	}
-	if err != nil {
-		klog.Fatalf("Failed to get scheduler config: %v", err)
-	}
-
-	if pflag.CommandLine.Changed("drain-priority-config") && pflag.CommandLine.Changed("max-graceful-termination-sec") {
-		klog.Fatalf("Invalid configuration, could not use --drain-priority-config together with --max-graceful-termination-sec")
-	}
-
-	var drainPriorityConfigMap []kubelet_config.ShutdownGracePeriodByPodPriority
-	if pflag.CommandLine.Changed("drain-priority-config") {
-		drainPriorityConfigMap = parseShutdownGracePeriodsAndPriorities(*drainPriorityConfig)
-		if len(drainPriorityConfigMap) == 0 {
-			klog.Fatalf("Invalid configuration, parsing --drain-priority-config")
+	if p.schedulerConfigFile != "" {
+		parsedSchedConfig, err = scheduler_util.ConfigFromPath(p.schedulerConfigFile)
+		if err != nil {
+			return config.AutoscalingOptions{}, fmt.Errorf("Failed to get scheduler config: %w", err)
 		}
 	}
 
-	if *predicateParallelism < 1 {
-		klog.Fatalf("Invalid value for --predicate-parallelism flag: %d", *predicateParallelism)
+	if p.drainPriorityConfig != "" && p.maxGracefulTerminationSec != MaxGracefulTerminationSecDefault {
+		return config.AutoscalingOptions{}, fmt.Errorf("Invalid configuration, could not use --drain-priority-config together with --max-graceful-termination-sec")
 	}
 
-	if !ptr.Deref(enableDynamicResourceAllocation, false) {
-		klog.Fatalf("--enable-dynamic-resource-allocation flag must be true: %t", ptr.Deref(enableDynamicResourceAllocation, false))
+	var drainPriorityConfigMap []kubelet_config.ShutdownGracePeriodByPodPriority
+	if p.drainPriorityConfig != "" {
+		drainPriorityConfigMap = parseShutdownGracePeriodsAndPriorities(p.drainPriorityConfig)
+		if len(drainPriorityConfigMap) == 0 {
+			return config.AutoscalingOptions{}, fmt.Errorf("Invalid configuration, parsing --drain-priority-config")
+		}
 	}
 
-	if *scaleDownEnabled == false {
+	if p.o.PredicateParallelism < 1 {
+		return config.AutoscalingOptions{}, fmt.Errorf("Invalid value for --predicate-parallelism flag: %d", p.o.PredicateParallelism)
+	}
+
+	if p.o.DynamicResourceAllocationEnabled == false {
+		return config.AutoscalingOptions{}, fmt.Errorf("--enable-dynamic-resource-allocation flag must be true: %t", p.o.DynamicResourceAllocationEnabled)
+	}
+
+	allowedSchedulers, err := parseAllowedSchedulers(p.allowedSchedulers, p.bypassedSchedulers)
+	if err != nil {
+		return config.AutoscalingOptions{}, err
+	}
+
+	if p.o.ScaleDownEnabled == false {
 		klog.Warningf("--scale-down-enabled flag is deprecated and will be removed in a future release")
 	}
 
-	maxStartupTime := *maxStartupTimeFlag
-	maxHealthCheckTimeout := max(*maxInactivityTimeFlag, *maxFailingTimeFlag, maxStartupTime)
-	if maxStartupTime < maxHealthCheckTimeout {
+	maxHealthCheckTimeout := max(p.o.MaxInactivityTime, p.o.MaxFailingTime, p.o.MaxStartupTime)
+	if p.o.MaxStartupTime < maxHealthCheckTimeout {
 		klog.Warningf("--max-startup-time needs to be at least as high as --max-failing-time and --max-inactivity, overriding it to the highest value out of them: %v", maxHealthCheckTimeout)
-		maxStartupTime = maxHealthCheckTimeout
+		p.o.MaxStartupTime = maxHealthCheckTimeout
 	}
 
-	var verbosity int = *schedulerVerbosity
+	var verbosity int = p.schedulerVerbosity
 	if vFlag := flag.CommandLine.Lookup("v"); vFlag != nil {
 		if v, err := strconv.Atoi(vFlag.Value.String()); err == nil {
 			verbosity = v
 		}
 	}
 
-	if verbosity < *schedulerVerbosity {
+	if verbosity < p.schedulerVerbosity {
 		klog.Warningf("--scheduler-verbosity should be at most as high as -v flag, overriding it to: %d", verbosity)
-		*schedulerVerbosity = verbosity
+		p.schedulerVerbosity = verbosity
 	}
 
-	return config.AutoscalingOptions{
-		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
-			ScaleDownUtilizationThreshold:    *scaleDownUtilizationThreshold,
-			ScaleDownGpuUtilizationThreshold: *scaleDownGpuUtilizationThreshold,
-			ScaleDownUnneededTime:            *scaleDownUnneededTime,
-			ScaleDownUnreadyTime:             *scaleDownUnreadyTime,
-			IgnoreDaemonSetsUtilization:      *ignoreDaemonSetsUtilization,
-			MaxNodeProvisionTime:             *maxNodeProvisionTime,
-			MaxNodeStartupTime:               *maxNodeStartupTime,
-		},
-		CloudConfig:                      *cloudConfig,
-		CloudProviderName:                *cloudProviderFlag,
-		NodeGroupAutoDiscovery:           *nodeGroupAutoDiscoveryFlag,
-		MaxTotalUnreadyPercentage:        *maxTotalUnreadyPercentage,
-		OkTotalUnreadyCount:              *okTotalUnreadyCount,
-		ScaleUpFromZero:                  *scaleUpFromZero,
-		ParallelScaleUp:                  *parallelScaleUp,
-		SalvoScaleUp:                     *salvoScaleUp,
-		SalvoScaleUpBudget:               *salvoScaleUpBudget,
-		EstimatorName:                    *estimatorFlag,
-		ExpanderNames:                    *expanderFlag,
-		GRPCExpanderCert:                 *grpcExpanderCert,
-		GRPCExpanderURL:                  *grpcExpanderURL,
-		IgnoreMirrorPodsUtilization:      *ignoreMirrorPodsUtilization,
-		MaxBulkSoftTaintCount:            *maxBulkSoftTaintCount,
-		MaxBulkSoftTaintTime:             *maxBulkSoftTaintTime,
-		MaxGracefulTerminationSec:        *maxGracefulTerminationFlag,
-		MaxPodEvictionTime:               *maxPodEvictionTime,
-		MaxNodesTotal:                    *maxNodesTotal,
-		MaxCoresTotal:                    maxCoresTotal,
-		MinCoresTotal:                    minCoresTotal,
-		MaxMemoryTotal:                   maxMemoryTotal,
-		MinMemoryTotal:                   minMemoryTotal,
-		GpuTotal:                         parsedGpuTotal,
-		NodeGroups:                       *nodeGroupsFlag,
-		EnforceNodeGroupMinSize:          *enforceNodeGroupMinSize,
-		ScaleDownDelayAfterAdd:           *scaleDownDelayAfterAdd,
-		ScaleDownDelayTypeLocal:          *scaleDownDelayTypeLocal,
-		ScaleDownDelayAfterDelete:        *scaleDownDelayAfterDelete,
-		ScaleDownDelayAfterFailure:       *scaleDownDelayAfterFailure,
-		ScaleDownEnabled:                 *scaleDownEnabled,
-		ScaleDownUnreadyEnabled:          *scaleDownUnreadyEnabled,
-		ScaleDownNonEmptyCandidatesCount: *scaleDownNonEmptyCandidatesCount,
-		ScaleDownCandidatesPoolRatio:     *scaleDownCandidatesPoolRatio,
-		ScaleDownCandidatesPoolMinCount:  *scaleDownCandidatesPoolMinCount,
-		DrainPriorityConfig:              drainPriorityConfigMap,
-		SchedulerConfig:                  parsedSchedConfig,
-		WriteStatusConfigMap:             *writeStatusConfigMapFlag,
-		StatusConfigMapName:              *statusConfigMapName,
-		BalanceSimilarNodeGroups:         *balanceSimilarNodeGroupsFlag,
-		ConfigNamespace:                  *namespace,
-		ClusterName:                      *clusterName,
-		UnremovableNodeRecheckTimeout:    *unremovableNodeRecheckTimeout,
-		ExpendablePodsPriorityCutoff:     *expendablePodsPriorityCutoff,
-		Regional:                         *regional,
-		NewPodScaleUpDelay:               *newPodScaleUpDelay,
-		StartupTaints:                    append(*ignoreTaintsFlag, *startupTaintsFlag...),
-		StartupTaintPrefixes:             *startupTaintPrefixesFlag,
-		StatusTaints:                     *statusTaintsFlag,
-		BalancingExtraIgnoredLabels:      *balancingIgnoreLabelsFlag,
-		BalancingLabels:                  *balancingLabelsFlag,
-		KubeClientOpts: config.KubeClientOptions{
-			Master:          *kubernetes,
-			KubeConfigPath:  *kubeConfigFile,
-			APIContentType:  *kubeAPIContentType,
-			KubeClientBurst: int(*kubeClientBurst),
-			KubeClientQPS:   float32(*kubeClientQPS),
-		},
-		NodeDeletionDelayTimeout: *nodeDeletionDelayTimeout,
-		AWSUseStaticInstanceList: *awsUseStaticInstanceList,
-		ScaleFromUnschedulable:   *scaleFromUnschedulable,
-		SchedulerVerbosityOffset: verbosity - *schedulerVerbosity,
-		GCEOptions: config.GCEOptions{
-			ConcurrentRefreshes:            *concurrentGceRefreshes,
-			MigInstancesMinRefreshWaitTime: *gceMigInstancesMinRefreshWaitTime,
-			LocalSSDDiskSizeProvider:       localssdsize.NewSimpleLocalSSDProvider(),
-			BulkMigInstancesListingEnabled: *bulkGceMigInstancesListingEnabled,
-		},
-		ClusterAPICloudConfigAuthoritative: *clusterAPICloudConfigAuthoritative,
-		CordonNodeBeforeTerminate:          *cordonNodeBeforeTerminate,
-		DaemonSetEvictionForEmptyNodes:     *daemonSetEvictionForEmptyNodes,
-		DaemonSetEvictionForOccupiedNodes:  *daemonSetEvictionForOccupiedNodes,
-		UserAgent:                          *userAgent,
-		InitialNodeGroupBackoffDuration:    *initialNodeGroupBackoffDuration,
-		MaxNodeGroupBackoffDuration:        *maxNodeGroupBackoffDuration,
-		NodeGroupBackoffResetTimeout:       *nodeGroupBackoffResetTimeout,
-		MaxScaleDownParallelism:            *maxScaleDownParallelismFlag,
-		MaxDrainParallelism:                *maxDrainParallelismFlag,
-		RecordDuplicatedEvents:             *recordDuplicatedEvents,
-		MaxNodesPerScaleUp:                 *maxNodesPerScaleUp,
-		MaxNodeGroupBinpackingDuration:     *maxNodeGroupBinpackingDuration,
-		MaxBinpackingTime:                  *maxBinpackingTimeFlag,
-		FastpathBinpackingEnabled:          *fastpathBinpackingEnabled,
-		NodeDeletionBatcherInterval:        *nodeDeletionBatcherInterval,
-		SkipNodesWithSystemPods:            *skipNodesWithSystemPods,
-		SkipNodesWithLocalStorage:          *skipNodesWithLocalStorage,
-		MinReplicaCount:                    *minReplicaCount,
-		BspDisruptionTimeout:               *bspDisruptionTimeout,
-		NodeDeleteDelayAfterTaint:          *nodeDeleteDelayAfterTaint,
-		ScaleDownSimulationTimeout:         *scaleDownSimulationTimeout,
-		SkipNodesWithCustomControllerPods:  *skipNodesWithCustomControllerPods,
-		NodeGroupSetRatios: config.NodeGroupDifferenceRatios{
-			MaxCapacityMemoryDifferenceRatio: *maxCapacityMemoryDifferenceRatio,
-			MaxAllocatableDifferenceRatio:    *maxAllocatableDifferenceRatio,
-			MaxFreeDifferenceRatio:           *maxFreeDifferenceRatio,
-		},
-		DynamicNodeDeleteDelayAfterTaintEnabled:      *dynamicNodeDeleteDelayAfterTaintEnabled,
-		BypassedSchedulers:                           scheduler_util.SchedulersMap(*bypassedSchedulers),
-		AllowedSchedulers:                            parseAllowedSchedulers(*allowedSchedulers, *bypassedSchedulers),
-		ProvisioningRequestEnabled:                   *provisioningRequestsEnabled,
-		AsyncNodeGroupsEnabled:                       *asyncNodeGroupsEnabled,
-		ProvisioningRequestInitialBackoffTime:        *provisioningRequestInitialBackoffTime,
-		ProvisioningRequestMaxBackoffTime:            *provisioningRequestMaxBackoffTime,
-		ProvisioningRequestMaxBackoffCacheSize:       *provisioningRequestMaxBackoffCacheSize,
-		CheckCapacityBatchProcessing:                 *checkCapacityBatchProcessing,
-		CheckCapacityProvisioningRequestMaxBatchSize: *checkCapacityProvisioningRequestMaxBatchSize,
-		CheckCapacityProvisioningRequestBatchTimebox: *checkCapacityProvisioningRequestBatchTimebox,
-		ForceDeleteLongUnregisteredNodes:             *forceDeleteLongUnregisteredNodes,
-		ForceDeleteFailedNodes:                       *forceDeleteFailedNodes,
-		DynamicResourceAllocationEnabled:             *enableDynamicResourceAllocation,
-		CSINodeAwareSchedulingEnabled:                *enableCSINodeAwareScheduling,
-		PredicateParallelism:                         *predicateParallelism,
-		CheckCapacityProcessorInstance:               *checkCapacityProcessorInstance,
-		MaxInactivityTime:                            *maxInactivityTimeFlag,
-		MaxFailingTime:                               *maxFailingTimeFlag,
-		MaxStartupTime:                               maxStartupTime,
-		DebuggingSnapshotEnabled:                     *debuggingSnapshotEnabled,
-		EnableProfiling:                              *enableProfiling,
-		Address:                                      *address,
-		EmitPerNodeGroupMetrics:                      *emitPerNodeGroupMetrics,
-		FrequentLoopsEnabled:                         *frequentLoopsEnabled,
-		ScanInterval:                                 *scanInterval,
-		ForceDaemonSets:                              *forceDaemonSets,
-		NodeInfoCacheExpireTime:                      *nodeInfoCacheExpireTime,
-		ProactiveScaleupEnabled:                      *proactiveScaleupEnabled,
-		PodInjectionLimit:                            *podInjectionLimit,
-		NodeDeletionCandidateTTL:                     *nodeDeletionCandidateTTL,
-		CapacitybufferControllerEnabled:              *capacitybufferControllerEnabled,
-		CapacitybufferPodInjectionEnabled:            *capacitybufferPodInjectionEnabled,
-		CapacityBufferPodDryRunEnabled:               *capacityBufferPodDryRunEnabled,
-		NodeRemovalLatencyTrackingEnabled:            *nodeRemovalLatencyTrackingEnabled,
-		MaxNodeSkipEvalTimeTrackerEnabled:            *maxNodeSkipEvalTimeTrackerEnabled,
-		CapacityQuotasEnabled:                        *capacityQuotasEnabled,
-		ScaleUpSimulationForSkippedNodeGroupsEnabled: *scaleUpSimulationForSkippedNodeGroupsEnabled,
-		PendingPodsBatchingTimeout:                   *pendingPodsBatchingTimeout,
-		GracefulDegradationEnabled:                   *enableGracefulDegradation,
-	}
+	p.o.AllowedSchedulers = allowedSchedulers
+	p.o.BypassedSchedulers = scheduler_util.SchedulersMap(p.bypassedSchedulers)
+	p.o.StartupTaints = slices.Concat(p.ignoreTaints, p.startupTaints)
+	p.o.MaxGracefulTerminationSec = p.maxGracefulTerminationSec
+	p.o.NodeGroupAutoDiscovery = p.nodeGroupAutodiscovery
+	p.o.DrainPriorityConfig = drainPriorityConfigMap
+	p.o.NodeGroups = p.nodeGroups
+	p.o.StatusTaints = p.statusTaints
+	p.o.MinCoresTotal = minCoresTotal
+	p.o.MaxCoresTotal = maxCoresTotal
+	p.o.MinMemoryTotal = minMemoryTotal
+	p.o.MaxMemoryTotal = maxMemoryTotal
+	p.o.GpuTotal = parsedGpuTotal
+	p.o.SchedulerConfig = parsedSchedConfig
+	p.o.KubeClientOpts.KubeClientQPS = float32(p.kubeClientQPS)
+	p.o.StartupTaintPrefixes = p.startupTaintPrefixes
+	p.o.BalancingExtraIgnoredLabels = p.balancingIgnoreLabels
+	p.o.BalancingLabels = p.balancingLabels
+	p.o.SchedulerVerbosityOffset = verbosity - p.schedulerVerbosity
+
+	p.o.GCEOptions.LocalSSDDiskSizeProvider = localssdsize.NewSimpleLocalSSDProvider()
+
+	return p.o, nil
 }
 
 func minMaxFlagString(min, max int64) string {
@@ -523,7 +383,7 @@ func parseMinMaxFlag(flag string) (int64, int64, error) {
 	return min, max, nil
 }
 
-func parseMultipleGpuLimits(flags MultiStringFlag) ([]config.GpuLimits, error) {
+func parseMultipleGpuLimits(flags []string) ([]config.GpuLimits, error) {
 	parsedFlags := make([]config.GpuLimits, 0, len(flags))
 	for _, flag := range flags {
 		parsedFlag, err := parseSingleGpuLimit(flag)
@@ -599,17 +459,17 @@ func parseShutdownGracePeriodsAndPriorities(priorityGracePeriodStr string) []kub
 	return priorityGracePeriodMap
 }
 
-func parseAllowedSchedulers(allowedSchedulers, bypassedSchedulers []string) map[string]bool {
+func parseAllowedSchedulers(allowedSchedulers, bypassedSchedulers []string) (map[string]bool, error) {
 	allowedSchedulersMap := scheduler_util.SchedulersMap(allowedSchedulers)
 	if len(allowedSchedulers) == 0 {
-		return allowedSchedulersMap
+		return allowedSchedulersMap, nil
 	}
 	bypassedSchedulersMap := scheduler_util.SchedulersMap(bypassedSchedulers)
 
 	for scheduler := range bypassedSchedulersMap {
 		if found := allowedSchedulersMap[scheduler]; !found {
-			klog.Fatalf("Invalid configuration. --bypassed-scheduler-names should be a subset of --allowed-scheduler-names. %s not included in --allowed-scheduler-names", scheduler)
+			return nil, fmt.Errorf("Invalid configuration. --bypassed-scheduler-names should be a subset of --allowed-scheduler-names. %s not included in --allowed-scheduler-names", scheduler)
 		}
 	}
-	return allowedSchedulersMap
+	return allowedSchedulersMap, nil
 }

--- a/pkg/config/flags/flags_test.go
+++ b/pkg/config/flags/flags_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/klog/v2"
 	kubelet_config "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 
@@ -138,8 +139,8 @@ func TestParseShutdownGracePeriodsAndPriorities(t *testing.T) {
 			name:  "parsable input",
 			input: "1:2,3:4",
 			want: []kubelet_config.ShutdownGracePeriodByPodPriority{
-				{Priority: 1, ShutdownGracePeriodSeconds: 2},
-				{Priority: 3, ShutdownGracePeriodSeconds: 4},
+				{1, 2},
+				{3, 4},
 			},
 		},
 	}
@@ -194,13 +195,408 @@ func TestCreateAutoscalingOptions(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			pflag.CommandLine = pflag.NewFlagSet("test", pflag.ExitOnError)
 			pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+			f := &AutoscalingFlags{}
+			f.AddFlags(pflag.CommandLine)
 			err := pflag.CommandLine.Parse(tc.flags)
 			if err != nil {
 				t.Errorf("pflag.CommandLine.Parse() got unexpected error: %v", err)
 			}
 
-			gotOptions := createAutoscalingOptions()
+			gotOptions, err := f.Options()
+			if err != nil {
+				t.Fatalf("Options() got unexpected error: %v", err)
+			}
 			tc.wantOptionsAsserter(t, gotOptions)
+		})
+	}
+}
+
+func TestAutoscalingFlagsAllPossible(t *testing.T) {
+	tests := map[string]struct {
+		Flags    []string
+		Validate func(t *testing.T, opts config.AutoscalingOptions)
+	}{
+		"MaxStartupTime_Defaulting_MaxFailingTime": {
+			Flags: []string{
+				"--max-inactivity=10m",
+				"--max-failing-time=15m",
+				"--max-startup-time=5m",
+			},
+			Validate: func(t *testing.T, opts config.AutoscalingOptions) {
+				if opts.MaxStartupTime != 15*time.Minute {
+					t.Errorf("got max startup time: %v, want %v", opts.MaxStartupTime, 15*time.Minute)
+				}
+			},
+		},
+		"MaxStartupTime_Defaulting_MaxInactivityTime": {
+			Flags: []string{
+				"--max-inactivity=15m",
+				"--max-failing-time=10m",
+				"--max-startup-time=5m",
+			},
+			Validate: func(t *testing.T, opts config.AutoscalingOptions) {
+				if opts.MaxStartupTime != 15*time.Minute {
+					t.Errorf("got max startup time: %v, want %v", opts.MaxStartupTime, 15*time.Minute)
+				}
+			},
+		},
+		"MaxStartupTime_NoDefaulting": {
+			Flags: []string{
+				"--max-inactivity=10m",
+				"--max-failing-time=10m",
+				"--max-startup-time=15m",
+			},
+			Validate: func(t *testing.T, opts config.AutoscalingOptions) {
+				if opts.MaxStartupTime != 15*time.Minute {
+					t.Errorf("got max startup time: %v, want %v", opts.MaxStartupTime, 15*time.Minute)
+				}
+			},
+		},
+		"AllPossibleFlagsSet": {
+			Flags: []string{
+				"--cluster-name=my-cluster",
+				"--address=:8086",
+				"--kubernetes=https://apiserver",
+				"--kubeconfig=/etc/kubeconfig",
+				"--kube-api-content-type=application/json",
+				"--kube-client-burst=50",
+				"--kube-client-qps=25.5",
+				"--cloud-config=/etc/cloud.conf",
+				"--cloud-provider=gce",
+				"--namespace=custom-ns",
+				"--enforce-node-group-min-size=true",
+				"--scale-down-unready-enabled=false",
+				"--scale-down-delay-after-add=5m",
+				"--scale-down-delay-type-local=true",
+				"--scale-down-delay-after-delete=1m",
+				"--scale-down-delay-after-failure=2m",
+				"--scale-down-unneeded-time=3m",
+				"--scale-down-unready-time=4m",
+				"--scale-down-utilization-threshold=0.4",
+				"--scale-down-gpu-utilization-threshold=0.3",
+				"--scale-down-non-empty-candidates-count=25",
+				"--scale-down-candidates-pool-ratio=0.2",
+				"--scale-down-candidates-pool-min-count=100",
+				"--node-deletion-delay-timeout=1m",
+				"--node-deletion-batcher-interval=10s",
+				"--scan-interval=5s",
+				"--max-nodes-total=100",
+				"--max-bulk-soft-taint-count=5",
+				"--max-bulk-soft-taint-time=1s",
+				"--max-total-unready-percentage=30",
+				"--ok-total-unready-count=5",
+				"--scale-up-from-zero=false",
+				"--parallel-scale-up=true",
+				"--max-node-provision-time=10m",
+				"--max-node-startup-time=10m",
+				"--max-pod-eviction-time=1m",
+				"--estimator=binpacking",
+				"--expander=least-waste",
+				"--grpc-expander-cert=/path/to/cert",
+				"--grpc-expander-url=https://grpc",
+				"--ignore-daemonsets-utilization=true",
+				"--ignore-mirror-pods-utilization=true",
+				"--write-status-configmap=false",
+				"--status-config-map-name=custom-status",
+				"--max-inactivity=5m",
+				"--max-binpacking-time=2m",
+				"--max-failing-time=5m",
+				"--max-startup-time=10m",
+				"--balance-similar-node-groups=true",
+				"--unremovable-node-recheck-timeout=2m",
+				"--expendable-pods-priority-cutoff=0",
+				"--regional=true",
+				"--new-pod-scale-up-delay=1m",
+				"--scale-from-unschedulable=true",
+				"--profiling=true",
+				"--clusterapi-cloud-config-authoritative=true",
+				"--cordon-node-before-terminating=false",
+				"--daemonset-eviction-for-empty-nodes=true",
+				"--daemonset-eviction-for-occupied-nodes=false",
+				"--user-agent=custom-ca",
+				"--emit-per-nodegroup-metrics=true",
+				"--debugging-snapshot-enabled=true",
+				"--node-info-cache-expire-time=24h",
+				"--initial-node-group-backoff-duration=1m",
+				"--max-node-group-backoff-duration=10m",
+				"--node-group-backoff-reset-timeout=1h",
+				"--max-scale-down-parallelism=5",
+				"--max-drain-parallelism=2",
+				"--record-duplicated-events=true",
+				"--max-nodes-per-scaleup=500",
+				"--max-nodegroup-binpacking-duration=5s",
+				"--fastpath-binpacking-enabled=true",
+				"--skip-nodes-with-system-pods=false",
+				"--skip-nodes-with-local-storage=false",
+				"--skip-nodes-with-custom-controller-pods=false",
+				"--min-replica-count=1",
+				"--blocking-system-pod-distruption-timeout=30m",
+				"--node-delete-delay-after-taint=2s",
+				"--scale-down-simulation-timeout=10s",
+				"--memory-difference-ratio=0.02",
+				"--max-free-difference-ratio=0.03",
+				"--max-allocatable-difference-ratio=0.04",
+				"--force-ds=true",
+				"--dynamic-node-delete-delay-after-taint-enabled=true",
+				"--enable-provisioning-requests=true",
+				"--provisioning-request-initial-backoff-time=2m",
+				"--provisioning-request-max-backoff-time=15m",
+				"--provisioning-request-max-backoff-cache-size=500",
+				"--frequent-loops-enabled=false",
+				"--async-node-groups=true",
+				"--enable-proactive-scaleup=true",
+				"--salvo-scale-up=true",
+				"--salvo-scale-up-budget=30s",
+				"--scaleup-simulation-for-skipped-node-groups-enabled=true",
+				"--bulk-mig-instances-listing-enabled=true",
+				"--gce-concurrent-refreshes=2",
+				"--gce-mig-instances-min-refresh-wait-time=2s",
+				"--aws-use-static-instance-list=true",
+				"--balancing-label=app",
+				"--startup-taint-prefix=transient",
+				"--pod-injection-limit=1000",
+				"--check-capacity-batch-processing=true",
+				"--check-capacity-provisioning-request-max-batch-size=5",
+				"--check-capacity-provisioning-request-batch-timebox=5s",
+				"--force-delete-unregistered-nodes=true",
+				"--force-delete-failed-nodes=true",
+				"--enable-csi-node-aware-scheduling=true",
+				"--predicate-parallelism=8",
+				"--check-capacity-processor-instance=inst",
+				"--node-deletion-candidate-ttl=1m",
+				"--capacity-buffer-controller-enabled=true",
+				"--capacity-buffer-pod-injection-enabled=true",
+				"--capacity-buffer-pod-dry-run-enabled=false",
+				"--node-removal-latency-tracking-enabled=true",
+				"--max-node-skip-eval-time-tracker-enabled=true",
+				"--capacity-quotas-enabled=true",
+				"--cores-total=2:100",
+				"--memory-total=4:200",
+				"--gpu-total=nvidia:1:10",
+				"--max-graceful-termination-sec=300",
+				"--pending-pods-batching-timeout=5s",
+				"--enable-graceful-degradation=true",
+			},
+			Validate: func(t *testing.T, opts config.AutoscalingOptions) {
+				assert.Equal(t, "my-cluster", opts.ClusterName)
+				assert.Equal(t, ":8086", opts.Address)
+				assert.Equal(t, "https://apiserver", opts.KubeClientOpts.Master)
+				assert.Equal(t, "/etc/kubeconfig", opts.KubeClientOpts.KubeConfigPath)
+				assert.Equal(t, "application/json", opts.KubeClientOpts.APIContentType)
+				assert.Equal(t, 50, opts.KubeClientOpts.KubeClientBurst)
+				assert.Equal(t, float32(25.5), opts.KubeClientOpts.KubeClientQPS)
+				assert.Equal(t, "/etc/cloud.conf", opts.CloudConfig)
+				assert.Equal(t, "gce", opts.CloudProviderName)
+				assert.Equal(t, "custom-ns", opts.ConfigNamespace)
+				assert.True(t, opts.EnforceNodeGroupMinSize)
+				assert.False(t, opts.ScaleDownUnreadyEnabled)
+				assert.Equal(t, 5*time.Minute, opts.ScaleDownDelayAfterAdd)
+				assert.True(t, opts.ScaleDownDelayTypeLocal)
+				assert.Equal(t, 1*time.Minute, opts.ScaleDownDelayAfterDelete)
+				assert.Equal(t, 2*time.Minute, opts.ScaleDownDelayAfterFailure)
+				assert.Equal(t, 3*time.Minute, opts.NodeGroupDefaults.ScaleDownUnneededTime)
+				assert.Equal(t, 4*time.Minute, opts.NodeGroupDefaults.ScaleDownUnreadyTime)
+				assert.Equal(t, 0.4, opts.NodeGroupDefaults.ScaleDownUtilizationThreshold)
+				assert.Equal(t, 0.3, opts.NodeGroupDefaults.ScaleDownGpuUtilizationThreshold)
+				assert.Equal(t, 25, opts.ScaleDownNonEmptyCandidatesCount)
+				assert.Equal(t, 0.2, opts.ScaleDownCandidatesPoolRatio)
+				assert.Equal(t, 100, opts.ScaleDownCandidatesPoolMinCount)
+				assert.Equal(t, 1*time.Minute, opts.NodeDeletionDelayTimeout)
+				assert.Equal(t, 10*time.Second, opts.NodeDeletionBatcherInterval)
+				assert.Equal(t, 5*time.Second, opts.ScanInterval)
+				assert.Equal(t, 100, opts.MaxNodesTotal)
+				assert.Equal(t, 5, opts.MaxBulkSoftTaintCount)
+				assert.Equal(t, 1*time.Second, opts.MaxBulkSoftTaintTime)
+				assert.Equal(t, float64(30), opts.MaxTotalUnreadyPercentage)
+				assert.Equal(t, 5, opts.OkTotalUnreadyCount)
+				assert.False(t, opts.ScaleUpFromZero)
+				assert.True(t, opts.ParallelScaleUp)
+				assert.Equal(t, 10*time.Minute, opts.NodeGroupDefaults.MaxNodeProvisionTime)
+				assert.Equal(t, 10*time.Minute, opts.NodeGroupDefaults.MaxNodeStartupTime)
+				assert.Equal(t, 1*time.Minute, opts.MaxPodEvictionTime)
+				assert.Equal(t, "binpacking", opts.EstimatorName)
+				assert.Equal(t, "least-waste", opts.ExpanderNames)
+				assert.Equal(t, "/path/to/cert", opts.GRPCExpanderCert)
+				assert.Equal(t, "https://grpc", opts.GRPCExpanderURL)
+				assert.True(t, opts.NodeGroupDefaults.IgnoreDaemonSetsUtilization)
+				assert.True(t, opts.IgnoreMirrorPodsUtilization)
+				assert.False(t, opts.WriteStatusConfigMap)
+				assert.Equal(t, "custom-status", opts.StatusConfigMapName)
+				assert.Equal(t, 10*time.Minute, opts.MaxStartupTime) // Overridden by max-startup-time (10m) >= MaxInactivity (5m) and MaxFailing (5m)
+				assert.True(t, opts.BalanceSimilarNodeGroups)
+				assert.Equal(t, 2*time.Minute, opts.UnremovableNodeRecheckTimeout)
+				assert.Equal(t, 0, opts.ExpendablePodsPriorityCutoff)
+				assert.True(t, opts.Regional)
+				assert.Equal(t, 1*time.Minute, opts.NewPodScaleUpDelay)
+				assert.True(t, opts.ScaleFromUnschedulable)
+				assert.True(t, opts.EnableProfiling)
+				assert.True(t, opts.ClusterAPICloudConfigAuthoritative)
+				assert.False(t, opts.CordonNodeBeforeTerminate)
+				assert.True(t, opts.DaemonSetEvictionForEmptyNodes)
+				assert.False(t, opts.DaemonSetEvictionForOccupiedNodes)
+				assert.Equal(t, "custom-ca", opts.UserAgent)
+				assert.True(t, opts.EmitPerNodeGroupMetrics)
+				assert.True(t, opts.DebuggingSnapshotEnabled)
+				assert.Equal(t, 24*time.Hour, opts.NodeInfoCacheExpireTime)
+				assert.Equal(t, 1*time.Minute, opts.InitialNodeGroupBackoffDuration)
+				assert.Equal(t, 10*time.Minute, opts.MaxNodeGroupBackoffDuration)
+				assert.Equal(t, 1*time.Hour, opts.NodeGroupBackoffResetTimeout)
+				assert.Equal(t, 5, opts.MaxScaleDownParallelism)
+				assert.Equal(t, 2, opts.MaxDrainParallelism)
+				assert.True(t, opts.RecordDuplicatedEvents)
+				assert.Equal(t, 500, opts.MaxNodesPerScaleUp)
+				assert.Equal(t, 5*time.Second, opts.MaxNodeGroupBinpackingDuration)
+				assert.True(t, opts.FastpathBinpackingEnabled)
+				assert.False(t, opts.SkipNodesWithSystemPods)
+				assert.False(t, opts.SkipNodesWithLocalStorage)
+				assert.False(t, opts.SkipNodesWithCustomControllerPods)
+				assert.Equal(t, 1, opts.MinReplicaCount)
+				assert.Equal(t, 30*time.Minute, opts.BspDisruptionTimeout)
+				assert.Equal(t, 2*time.Second, opts.NodeDeleteDelayAfterTaint)
+				assert.Equal(t, 10*time.Second, opts.ScaleDownSimulationTimeout)
+				assert.Equal(t, 0.02, opts.NodeGroupSetRatios.MaxCapacityMemoryDifferenceRatio)
+				assert.Equal(t, 0.03, opts.NodeGroupSetRatios.MaxFreeDifferenceRatio)
+				assert.Equal(t, 0.04, opts.NodeGroupSetRatios.MaxAllocatableDifferenceRatio)
+				assert.True(t, opts.ForceDaemonSets)
+				assert.True(t, opts.DynamicNodeDeleteDelayAfterTaintEnabled)
+				assert.True(t, opts.ProvisioningRequestEnabled)
+				assert.Equal(t, 2*time.Minute, opts.ProvisioningRequestInitialBackoffTime)
+				assert.Equal(t, 15*time.Minute, opts.ProvisioningRequestMaxBackoffTime)
+				assert.Equal(t, 500, opts.ProvisioningRequestMaxBackoffCacheSize)
+				assert.False(t, opts.FrequentLoopsEnabled)
+				assert.True(t, opts.AsyncNodeGroupsEnabled)
+				assert.True(t, opts.ProactiveScaleupEnabled)
+				assert.True(t, opts.SalvoScaleUp)
+				assert.Equal(t, 30*time.Second, opts.SalvoScaleUpBudget)
+				assert.True(t, opts.ScaleUpSimulationForSkippedNodeGroupsEnabled)
+				assert.True(t, opts.GCEOptions.BulkMigInstancesListingEnabled)
+				assert.Equal(t, 2, opts.GCEOptions.ConcurrentRefreshes)
+				assert.Equal(t, 2*time.Second, opts.GCEOptions.MigInstancesMinRefreshWaitTime)
+				assert.True(t, opts.AWSUseStaticInstanceList)
+				assert.Equal(t, []string{"app"}, opts.BalancingLabels)
+				assert.Equal(t, []string{"transient"}, opts.StartupTaintPrefixes)
+				assert.Equal(t, 1000, opts.PodInjectionLimit)
+				assert.True(t, opts.CheckCapacityBatchProcessing)
+				assert.Equal(t, 5, opts.CheckCapacityProvisioningRequestMaxBatchSize)
+				assert.Equal(t, 5*time.Second, opts.CheckCapacityProvisioningRequestBatchTimebox)
+				assert.True(t, opts.ForceDeleteLongUnregisteredNodes)
+				assert.True(t, opts.ForceDeleteFailedNodes)
+				assert.True(t, opts.CSINodeAwareSchedulingEnabled)
+				assert.Equal(t, 8, opts.PredicateParallelism)
+				assert.Equal(t, "inst", opts.CheckCapacityProcessorInstance)
+				assert.Equal(t, 1*time.Minute, opts.NodeDeletionCandidateTTL)
+				assert.True(t, opts.CapacitybufferControllerEnabled)
+				assert.True(t, opts.CapacitybufferPodInjectionEnabled)
+				assert.False(t, opts.CapacityBufferPodDryRunEnabled)
+				assert.True(t, opts.NodeRemovalLatencyTrackingEnabled)
+				assert.True(t, opts.MaxNodeSkipEvalTimeTrackerEnabled)
+				assert.True(t, opts.CapacityQuotasEnabled)
+				assert.Equal(t, int64(2), opts.MinCoresTotal)
+				assert.Equal(t, int64(100), opts.MaxCoresTotal)
+				assert.Equal(t, int64(4*1024*1024*1024), opts.MinMemoryTotal)
+				assert.Equal(t, int64(200*1024*1024*1024), opts.MaxMemoryTotal)
+				assert.Equal(t, []config.GpuLimits{{"nvidia", 1, 10}}, opts.GpuTotal)
+				assert.Equal(t, 300, opts.MaxGracefulTerminationSec)
+				assert.Equal(t, 5*time.Second, opts.PendingPodsBatchingTimeout)
+				assert.True(t, opts.GracefulDegradationEnabled)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			f := &AutoscalingFlags{}
+			f.AddFlags(fs)
+			err := fs.Parse(tc.Flags)
+			if err != nil {
+				t.Fatalf("unexpected Parse error: %v", err)
+			}
+
+			opts, err := f.Options()
+			if err != nil {
+				t.Fatalf("unexpected Options error: %v", err)
+			}
+
+			tc.Validate(t, opts)
+		})
+	}
+}
+
+func TestSchedulerVerbosityFlag(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	// klog flags registration is required because we use -v flag
+	// value in order to resolve and validate scheduler verbosity value.
+	// Sadly this requires adding the global flag set to our test flag set
+	// due to the way how current --verbosity handles the flag lookup.
+	klog.InitFlags(flag.CommandLine)
+	fs.AddGoFlagSet(flag.CommandLine)
+
+	f := &AutoscalingFlags{}
+	f.AddFlags(fs)
+	err := fs.Parse([]string{"-v=5", "--scheduler-verbosity=1"})
+	if err != nil {
+		t.Fatalf("unexpected Parse error: %v", err)
+	}
+
+	opts, err := f.Options()
+	if err != nil {
+		t.Fatalf("unexpected Options error: %v", err)
+	}
+
+	// Recreate global flag set so that race condition is shorter in time
+	flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError)
+
+	assert.Equal(t, 4, opts.SchedulerVerbosityOffset)
+}
+
+func TestAutoscalingFlagsValidationEdgeCases(t *testing.T) {
+	tests := map[string]struct {
+		Flags   []string
+		WantErr bool
+	}{
+		"ValidMinimal": {
+			Flags:   []string{},
+			WantErr: false,
+		},
+		"DrainPriorityMutualExclusivity": {
+			Flags:   []string{"--drain-priority-config=1000:10", "--max-graceful-termination-sec=300"},
+			WantErr: true,
+		},
+		"InvalidPredicateParallelism": {
+			Flags:   []string{"--predicate-parallelism=0"},
+			WantErr: true,
+		},
+		"InvalidDRA": {
+			Flags:   []string{"--enable-dynamic-resource-allocation=false"},
+			WantErr: true,
+		},
+		"BypassedSchedulerSubset": {
+			Flags:   []string{"--allowed-scheduler-names=default-scheduler", "--bypassed-scheduler-names=custom-scheduler"},
+			WantErr: true,
+		},
+		"InvalidCoresTotal": {
+			Flags:   []string{"--cores-total=10:5"},
+			WantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			f := &AutoscalingFlags{}
+			f.AddFlags(fs)
+			err := fs.Parse(tc.Flags)
+			if err != nil {
+				t.Fatalf("unexpected Parse error: %v", err)
+			}
+			_, err = f.Options()
+			if tc.WantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -96,9 +96,7 @@ func registerSignalHandlers(autoscaler core.Autoscaler) {
 	}()
 }
 
-func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter) {
-	autoscalingOpts := flags.AutoscalingOptions()
-
+func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter, autoscalingOpts config.AutoscalingOptions) {
 	metrics.RegisterAll(autoscalingOpts.EmitPerNodeGroupMetrics)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -219,11 +217,16 @@ func main() {
 	// Must be called before kube_flag.InitFlags() to ensure leader election flags are parsed and available.
 	componentopts.BindLeaderElectionFlags(&leaderElection, pflag.CommandLine)
 
+	autoscalingFlags := &flags.AutoscalingFlags{}
+	autoscalingFlags.AddFlags(pflag.CommandLine)
 	logsapi.AddFlags(loggingConfig, pflag.CommandLine)
 	featureGate.AddFlag(pflag.CommandLine)
 	kube_flag.InitFlags()
 
-	autoscalingOpts := flags.AutoscalingOptions()
+	autoscalingOpts, err := autoscalingFlags.Options()
+	if err != nil {
+		klog.Fatalf("Failed to parse flags: %v", err)
+	}
 
 	// The DRA feature controls whether the DRA scheduler plugin is selected in scheduler framework. The local DRA flag controls whether
 	// DRA logic is enabled in Cluster Autoscaler. The 2 values should be in sync - enabling DRA logic in CA without selecting the DRA scheduler
@@ -271,7 +274,7 @@ func main() {
 	}()
 
 	if !leaderElection.LeaderElect {
-		run(healthCheck, debuggingSnapshotter)
+		run(healthCheck, debuggingSnapshotter, autoscalingOpts)
 	} else {
 		id, err := os.Hostname()
 		if err != nil {
@@ -311,7 +314,7 @@ func main() {
 				OnStartedLeading: func(_ context.Context) {
 					// Since we are committing a suicide after losing
 					// mastership, we can safely ignore the argument.
-					run(healthCheck, debuggingSnapshotter)
+					run(healthCheck, debuggingSnapshotter, autoscalingOpts)
 				},
 				OnStoppedLeading: func() {
 					klog.Fatalf("lost master")


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:

* Move flags initialization from global space to an on-demand function to produce the autoscaling options;
* Add tests which verify that everything parses correctly and tests for edge cases in argument parsing;

This direction is on the same line as making cluster autoscaler a library in the long-run, current approach makes it infeasible for forks to properly extend and control their CLI arguments, with this patch - it's now possible without loosing anything else.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
