### PR TITLE
Add skipped node group simulation duration metric

### DIFF
--- a/pkg/core/scaleup/orchestrator/orchestrator.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator.go
@@ -818,7 +818,9 @@ func (o *ScaleUpOrchestrator) GetRemainingPods(egs []*equivalence.PodGroup, node
 		}
 		return remaining
 	}
-	// If ScaleUpSimulationForSkippedNodeGroupsEnabled is true we do the SchedulablePodGroups simulation for the skipped node groups.
+	// If ScaleUpSimulationForSkippedNodeGroupsEnabled is true we perform the SchedulablePodGroups simulation for the skipped node groups.
+	// We will also report how much time does this simulation take.
+	skippedNodeGroupsSimulationStart := time.Now()
 	nonSchedulableEgs := []*equivalence.PodGroup{}
 	for _, eg := range egs {
 		// there is no need to run the simulation for the schedulable pod groups, because for them we still do not return anything.
@@ -826,7 +828,9 @@ func (o *ScaleUpOrchestrator) GetRemainingPods(egs []*equivalence.PodGroup, node
 			nonSchedulableEgs = append(nonSchedulableEgs, eg.Clone())
 		}
 	}
-	return o.getRemainingPodsConsideringSkippedNodeGroups(nonSchedulableEgs, nodeGroups, skipped, nodeInfos)
+	noScaleUpInfosAfterSimulation := o.getRemainingPodsConsideringSkippedNodeGroups(nonSchedulableEgs, nodeGroups, skipped, nodeInfos)
+	metrics.UpdateDurationFromStart(metrics.SkipNodeGroupSimulation, skippedNodeGroupsSimulationStart)
+	return noScaleUpInfosAfterSimulation
 }
 
 func (o *ScaleUpOrchestrator) getRemainingPodsConsideringSkippedNodeGroups(egs []*equivalence.PodGroup, nodeGroups []cloudprovider.NodeGroup, skipped map[string]status.Reasons, nodeInfos map[string]*framework.NodeInfo) []status.NoScaleUpInfo {
@@ -905,6 +909,7 @@ func findSkippedNodeGroupsSatisfyingPodPredicates(eg *equivalence.PodGroup, skip
 		// if a node group is in skipped and for this eg it is not in scheduling errors, it means that it will stay in skipped, because it satisfies the pod predicates.
 		if _, hasPredicateError := eg.SchedulingErrors[skippedNodeGroupId]; !hasPredicateError {
 			matchingNodeGroups[skippedNodeGroupId] = skipReason
+			klog.V(4).Infof("Skipped node group %s satisfies pod predicates of %s pod's equivalence group", skippedNodeGroupId, eg.Pods[0].Name)
 		}
 	}
 	return matchingNodeGroups

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -108,6 +108,7 @@ const (
 	ScaleDownSoftTaintUnneeded FunctionLabel = "scaleDown:softTaintUnneeded"
 	ScaleUp                    FunctionLabel = "scaleUp"
 	BuildPodEquivalenceGroups  FunctionLabel = "scaleUp:buildPodEquivalenceGroups"
+	SkipNodeGroupSimulation    FunctionLabel = "scaleUp:skippedNodeGroupsSimulation"
 	Estimate                   FunctionLabel = "scaleUp:estimate"
 	FindUnneeded               FunctionLabel = "findUnneeded"
 	UpdateState                FunctionLabel = "updateClusterState"


### PR DESCRIPTION
This is a follow up implementation for the Skipped Node groups (NG) simulation [feature](https://github.com/kubernetes/autoscaler/pulls?q=is%3Apr+author%3Ashaikenov+skipped+node+groups)  

The last missing piece is the observability: in this PR I am adding the missing information about how long does these Skipped NG simulations take.

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The flag guarded Skipped NG simulation feature was implemented and tested before. The last missing piece is observability - without it it is quite tricky to understand the real impact of this feature on the scale up duration and here we try to solve this problem.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
