### PR TITLE
Move the RegisterScaleUp metric calls to NodeGroupChangeMetricsProducer.

### DIFF
--- a/pkg/clusterstate/clusterstate_test.go
+++ b/pkg/clusterstate/clusterstate_test.go
@@ -1978,6 +1978,10 @@ type mockMetrics struct {
 	mock.Mock
 }
 
+func (m *mockMetrics) RegisterScaleUp(delta int, gpuResourceName, gpuType, draDriverName string) {
+	m.Called(delta, gpuResourceName, gpuType, draDriverName)
+}
+
 func (m *mockMetrics) RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType, draDrivers string) {
 	m.Called(reason, gpuResourceName, gpuType, draDrivers)
 }

--- a/pkg/clusterstate/clusterstate_test.go
+++ b/pkg/clusterstate/clusterstate_test.go
@@ -2339,7 +2339,7 @@ func withNotifiedScaleUpFailuresRegistry(r *scaleupfailures.Registry) Option {
 // withMetrics sets the metrics for the ClusterStateRegistry.
 func withMetrics(m *mockMetrics, cloudProvider cloudprovider.CloudProvider) Option {
 	return func(o *options) {
-		metricProducer := nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, m)
+		metricProducer := nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, m, &emptyTemplateNodeInfoRegistry{})
 		o.scaleStateNotifier.Register(metricProducer)
 	}
 }

--- a/pkg/core/scaleup/orchestrator/async_initializer.go
+++ b/pkg/core/scaleup/orchestrator/async_initializer.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroups"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroupset"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/status"
-	"sigs.k8s.io/cluster-autoscaler/pkg/simulator"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/taints"
@@ -113,16 +112,8 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 		s.emitScaleUpStatus(&status.ScaleUpStatus{}, errors.ToAutoscalerError(errors.InternalError, result.Error))
 		return
 	}
-	mainCreatedNodeGroup := result.CreationResult.MainCreatedNodeGroup
-	// If possible replace candidate node-info with node info based on crated node group. The latter
-	// one should be more in line with nodes which will be created by node group.
-	nodeInfo, aErr := simulator.SanitizedTemplateNodeInfoFromNodeGroup(mainCreatedNodeGroup, s.daemonSets, s.taintConfig)
-	if aErr != nil {
-		klog.Warningf("Cannot build node info for newly created main node group %s. Using fallback. Error: %v", mainCreatedNodeGroup.Id(), aErr)
-		nodeInfo = s.nodeInfo
-	}
 
-	scaleUpInfos, nodeInfos := s.prepareScaleUps(result, nodeInfo)
+	scaleUpInfos := s.prepareScaleUps(result)
 
 	if len(scaleUpInfos) == 0 {
 		klog.Infof("Scale-up for node group %s is already finished or no new scale-ups are needed.", s.nodeGroup.Id())
@@ -130,7 +121,7 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 	}
 
 	klog.Infof("Starting scale-up for async created node groups. Scale ups: %v", scaleUpInfos)
-	err, failedNodeGroups := s.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, time.Now(), s.atomicScaleUp)
+	err, failedNodeGroups := s.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, time.Now(), s.atomicScaleUp)
 	if err != nil {
 		var failedNodeGroupIds []string
 		for _, failedNodeGroup := range failedNodeGroups {
@@ -153,11 +144,10 @@ func (s *AsyncNodeGroupInitializer) InitializeNodeGroup(result nodegroups.AsyncN
 	}, nil)
 }
 
-func (s *AsyncNodeGroupInitializer) prepareScaleUps(result nodegroups.AsyncNodeGroupCreationResult, nodeInfo *framework.NodeInfo) ([]nodegroupset.ScaleUpInfo, map[string]*framework.NodeInfo) {
+func (s *AsyncNodeGroupInitializer) prepareScaleUps(result nodegroups.AsyncNodeGroupCreationResult) []nodegroupset.ScaleUpInfo {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	nodeInfos := make(map[string]*framework.NodeInfo)
 	var scaleUpInfos []nodegroupset.ScaleUpInfo
 
 	for _, nodeGroup := range result.CreationResult.AllCreatedNodeGroups() {
@@ -170,7 +160,6 @@ func (s *AsyncNodeGroupInitializer) prepareScaleUps(result nodegroups.AsyncNodeG
 		currentSize := s.processedTargetSizes[upcomingId]
 
 		if delta := targetSize - currentSize; delta > 0 {
-			nodeInfos[nodeGroup.Id()] = nodeInfo
 			scaleUpInfo := nodegroupset.ScaleUpInfo{
 				Group:       nodeGroup,
 				CurrentSize: int(currentSize),
@@ -181,7 +170,7 @@ func (s *AsyncNodeGroupInitializer) prepareScaleUps(result nodegroups.AsyncNodeG
 			s.processedTargetSizes[upcomingId] = targetSize
 		}
 	}
-	return scaleUpInfos, nodeInfos
+	return scaleUpInfos
 }
 
 func (s *AsyncNodeGroupInitializer) emitScaleUpStatus(scaleUpStatus *status.ScaleUpStatus, err errors.AutoscalerError) {

--- a/pkg/core/scaleup/orchestrator/executor.go
+++ b/pkg/core/scaleup/orchestrator/executor.go
@@ -41,6 +41,7 @@ type scaleUpExecutor struct {
 	autoscalingCtx             *ca_context.AutoscalingContext
 	scaleStateNotifier         nodegroupchange.NodeGroupChangeObserver
 	asyncNodeGroupStateChecker asyncnodegroups.AsyncNodeGroupStateChecker
+	metrics                    metricsObserver
 }
 
 // New returns new instance of scale up executor.
@@ -53,7 +54,27 @@ func newScaleUpExecutor(
 		autoscalingCtx:             autoscalingCtx,
 		scaleStateNotifier:         scaleStateNotifier,
 		asyncNodeGroupStateChecker: asyncNodeGroupStateChecker,
+		metrics:                    metrics.DefaultMetrics,
 	}
+}
+
+// newScaleUpExecutorWithMetrics returns new instance of scale up executor with provided metrics.
+func newScaleUpExecutorWithMetrics(
+	autoscalingCtx *ca_context.AutoscalingContext,
+	scaleStateNotifier nodegroupchange.NodeGroupChangeObserver,
+	asyncNodeGroupStateChecker asyncnodegroups.AsyncNodeGroupStateChecker,
+	metrics metricsObserver,
+) *scaleUpExecutor {
+	return &scaleUpExecutor{
+		autoscalingCtx:             autoscalingCtx,
+		scaleStateNotifier:         scaleStateNotifier,
+		asyncNodeGroupStateChecker: asyncNodeGroupStateChecker,
+		metrics:                    metrics,
+	}
+}
+
+type metricsObserver interface {
+	RegisterScaleUp(nodesCount int, gpuResourceName string, gpuType string, draDriverNames string)
 }
 
 // ExecuteScaleUps executes the scale ups, based on the provided scale up infos and options.
@@ -186,7 +207,7 @@ func (e *scaleUpExecutor) executeScaleUp(
 		return nil
 	}
 	e.scaleStateNotifier.RegisterScaleUp(info.Group, increase, time.Now())
-	metrics.RegisterScaleUp(increase, gpuResourceName, gpuType, draDriverNames)
+	e.metrics.RegisterScaleUp(increase, gpuResourceName, gpuType, draDriverNames)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: group %s size set to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
 	return nil

--- a/pkg/core/scaleup/orchestrator/executor.go
+++ b/pkg/core/scaleup/orchestrator/executor.go
@@ -24,16 +24,12 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
-	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
-	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
 	"sigs.k8s.io/cluster-autoscaler/pkg/observers/nodegroupchange"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroups/asyncnodegroups"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroupset"
-	"sigs.k8s.io/cluster-autoscaler/pkg/utils/dynamicresources"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
-	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
 )
 
 // ScaleUpExecutor scales up node groups.
@@ -41,7 +37,6 @@ type scaleUpExecutor struct {
 	autoscalingCtx             *ca_context.AutoscalingContext
 	scaleStateNotifier         nodegroupchange.NodeGroupChangeObserver
 	asyncNodeGroupStateChecker asyncnodegroups.AsyncNodeGroupStateChecker
-	metrics                    metricsObserver
 }
 
 // New returns new instance of scale up executor.
@@ -54,27 +49,7 @@ func newScaleUpExecutor(
 		autoscalingCtx:             autoscalingCtx,
 		scaleStateNotifier:         scaleStateNotifier,
 		asyncNodeGroupStateChecker: asyncNodeGroupStateChecker,
-		metrics:                    metrics.DefaultMetrics,
 	}
-}
-
-// newScaleUpExecutorWithMetrics returns new instance of scale up executor with provided metrics.
-func newScaleUpExecutorWithMetrics(
-	autoscalingCtx *ca_context.AutoscalingContext,
-	scaleStateNotifier nodegroupchange.NodeGroupChangeObserver,
-	asyncNodeGroupStateChecker asyncnodegroups.AsyncNodeGroupStateChecker,
-	metrics metricsObserver,
-) *scaleUpExecutor {
-	return &scaleUpExecutor{
-		autoscalingCtx:             autoscalingCtx,
-		scaleStateNotifier:         scaleStateNotifier,
-		asyncNodeGroupStateChecker: asyncNodeGroupStateChecker,
-		metrics:                    metrics,
-	}
-}
-
-type metricsObserver interface {
-	RegisterScaleUp(nodesCount int, gpuResourceName string, gpuType string, draDriverNames string)
 }
 
 // ExecuteScaleUps executes the scale ups, based on the provided scale up infos and options.
@@ -83,31 +58,23 @@ type metricsObserver interface {
 // If there were multiple concurrent errors one combined error is returned.
 func (e *scaleUpExecutor) ExecuteScaleUps(
 	scaleUpInfos []nodegroupset.ScaleUpInfo,
-	nodeInfos map[string]*framework.NodeInfo,
 	now time.Time,
 	atomic bool,
 ) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
 	options := e.autoscalingCtx.AutoscalingOptions
 	if options.ParallelScaleUp {
-		return e.executeScaleUpsParallel(scaleUpInfos, nodeInfos, now, atomic)
+		return e.executeScaleUpsParallel(scaleUpInfos, now, atomic)
 	}
-	return e.executeScaleUpsSync(scaleUpInfos, nodeInfos, now, atomic)
+	return e.executeScaleUpsSync(scaleUpInfos, now, atomic)
 }
 
 func (e *scaleUpExecutor) executeScaleUpsSync(
 	scaleUpInfos []nodegroupset.ScaleUpInfo,
-	nodeInfos map[string]*framework.NodeInfo,
 	now time.Time,
 	atomic bool,
 ) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
-	availableGPUTypes := e.autoscalingCtx.CloudProvider.GetAvailableGPUTypes()
 	for _, scaleUpInfo := range scaleUpInfos {
-		nodeInfo, ok := nodeInfos[scaleUpInfo.Group.Id()]
-		if !ok {
-			klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", scaleUpInfo.Group.Id())
-			continue
-		}
-		if aErr := e.executeScaleUp(scaleUpInfo, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
+		if aErr := e.executeScaleUp(scaleUpInfo, now, atomic); aErr != nil {
 			return aErr, []cloudprovider.NodeGroup{scaleUpInfo.Group}
 		}
 	}
@@ -116,7 +83,6 @@ func (e *scaleUpExecutor) executeScaleUpsSync(
 
 func (e *scaleUpExecutor) executeScaleUpsParallel(
 	scaleUpInfos []nodegroupset.ScaleUpInfo,
-	nodeInfos map[string]*framework.NodeInfo,
 	now time.Time,
 	atomic bool,
 ) (errors.AutoscalerError, []cloudprovider.NodeGroup) {
@@ -131,16 +97,10 @@ func (e *scaleUpExecutor) executeScaleUpsParallel(
 	errResults := make(chan errResult, scaleUpsLen)
 	var wg sync.WaitGroup
 	wg.Add(scaleUpsLen)
-	availableGPUTypes := e.autoscalingCtx.CloudProvider.GetAvailableGPUTypes()
 	for _, scaleUpInfo := range scaleUpInfos {
 		go func(info nodegroupset.ScaleUpInfo) {
 			defer wg.Done()
-			nodeInfo, ok := nodeInfos[info.Group.Id()]
-			if !ok {
-				klog.Errorf("ExecuteScaleUp: failed to get node info for node group %s", info.Group.Id())
-				return
-			}
-			if aErr := e.executeScaleUp(info, nodeInfo, availableGPUTypes, now, atomic); aErr != nil {
+			if aErr := e.executeScaleUp(info, now, atomic); aErr != nil {
 				errResults <- errResult{err: aErr, info: &info}
 			}
 		}(scaleUpInfo)
@@ -176,14 +136,9 @@ func (e *scaleUpExecutor) increaseSize(nodeGroup cloudprovider.NodeGroup, increa
 
 func (e *scaleUpExecutor) executeScaleUp(
 	info nodegroupset.ScaleUpInfo,
-	nodeInfo *framework.NodeInfo,
-	availableGPUTypes map[string]struct{},
 	now time.Time,
 	atomic bool,
 ) errors.AutoscalerError {
-	gpuConfig := e.autoscalingCtx.CloudProvider.GetNodeGpuConfig(nodeInfo.Node())
-	gpuResourceName, gpuType := gpu.GetGpuInfoForMetrics(gpuConfig, availableGPUTypes, nodeInfo.Node(), nil)
-	draDriverNames := dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	klog.V(0).Infof("Scale-up: setting group %s size to %d", info.Group.Id(), info.NewSize)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: setting group %s size to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
@@ -207,7 +162,6 @@ func (e *scaleUpExecutor) executeScaleUp(
 		return nil
 	}
 	e.scaleStateNotifier.RegisterScaleUp(info.Group, increase, time.Now())
-	e.metrics.RegisterScaleUp(increase, gpuResourceName, gpuType, draDriverNames)
 	e.autoscalingCtx.LogRecorder.Eventf(apiv1.EventTypeNormal, "ScaledUpGroup",
 		"Scale-up: group %s size set to %d instead of %d (max: %d)", info.Group.Id(), info.NewSize, info.CurrentSize, info.MaxSize)
 	return nil

--- a/pkg/core/scaleup/orchestrator/orchestrator.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator.go
@@ -175,7 +175,7 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 
 	// Execute scale up.
 	klog.V(1).Infof("Final scale-up plan: %v", plan.scaleUpInfos)
-	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(plan.scaleUpInfos, nodeInfos, now, allOrNothing)
+	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(plan.scaleUpInfos, now, allOrNothing)
 	if aErr != nil {
 		failedGroupsMap := o.buildFailedGroupsMap(failedNodeGroups, plan.scaleUpInfos)
 		markedEquivalenceGroups := markFailedGroupsAsUnschedulable(podEquivalenceGroups, failedGroupsMap, ScaleUpExecutionErrorReason)
@@ -299,7 +299,7 @@ func (o *ScaleUpOrchestrator) ScaleUpToNodeGroupMinSize(
 	}
 
 	klog.V(1).Infof("ScaleUpToNodeGroupMinSize: final scale-up plan: %v", scaleUpInfos)
-	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, nodeInfos, now, false /* allOrNothing disabled */)
+	aErr, failedNodeGroups := o.scaleUpExecutor.ExecuteScaleUps(scaleUpInfos, now, false /* allOrNothing disabled */)
 	if aErr != nil {
 		return status.UpdateScaleUpError(
 			&status.ScaleUpStatus{

--- a/pkg/core/scaleup/orchestrator/orchestrator_test.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator_test.go
@@ -27,9 +27,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
 	kube_record "k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -2585,4 +2588,66 @@ func TestScaleUpPartialSuccessPopulatesPodsRemainUnschedulableSync(t *testing.T)
 	assert.Contains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p2_2")
 	assert.NotContains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p1_1")
 	assert.NotContains(t, result.ScaleUpStatus.PodsRemainUnschedulable, "p1_2")
+}
+
+func TestScaleUpMetricsEmission(t *testing.T) {
+	now := time.Now()
+	gpuNode := &apiv1.Node{
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			},
+		},
+	}
+	gpuNode.Labels = map[string]string{
+		"TestGPULabel/accelerator": "nvidia-tesla-k80",
+	}
+
+	slices := []*resourceapi.ResourceSlice{
+		{
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver: "dra.net",
+			},
+		},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().WithOnScaleUp(func(id string, delta int) error { return nil }).Build()
+	provider.AddNodeGroup("ng1", 0, 10, 0)
+	provider.SetMachineTemplates(map[string]*framework.NodeInfo{
+		"ng1": framework.NewNodeInfo(gpuNode, slices),
+	})
+
+	options := defaultOptions
+	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
+	podLister := kube_util.NewTestPodLister(nil)
+	listers := kube_util.NewListerRegistry(nil, nil, podLister, nil, nil, nil, nil, nil, nil)
+
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	assert.NoError(t, err)
+
+	mockMetrics := &mockMetrics{}
+	mockMetrics.On("RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net").Return()
+
+	executor := newScaleUpExecutorWithMetrics(&autoscalingCtx, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker, mockMetrics)
+
+	nodeGroup := provider.GetNodeGroup("ng1")
+	nodeInfo := framework.NewNodeInfo(gpuNode, slices)
+
+	err = executor.executeScaleUp(nodegroupset.ScaleUpInfo{
+		Group:       nodeGroup,
+		CurrentSize: 0,
+		NewSize:     2,
+		MaxSize:     10,
+	}, nodeInfo, autoscalingCtx.CloudProvider.GetAvailableGPUTypes(), now, false)
+	assert.NoError(t, err)
+
+	mockMetrics.AssertCalled(t, "RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net")
+}
+
+type mockMetrics struct {
+	mock.Mock
+}
+
+func (m *mockMetrics) RegisterScaleUp(nodesCount int, gpuResourceName string, gpuType string, draDriverNames string) {
+	m.Called(nodesCount, gpuResourceName, gpuType, draDriverNames)
 }

--- a/pkg/core/scaleup/orchestrator/orchestrator_test.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator_test.go
@@ -2628,17 +2628,19 @@ func TestScaleUpMetricsEmission(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net").Return()
 
-	executor := newScaleUpExecutorWithMetrics(&autoscalingCtx, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker, mockMetrics)
+	producer := nodegroupchange.NewNodeGroupChangeMetricsProducer(provider, mockMetrics)
+	processors.ScaleStateNotifier.Register(producer)
+
+	executor := newScaleUpExecutor(&autoscalingCtx, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker)
 
 	nodeGroup := provider.GetNodeGroup("ng1")
-	nodeInfo := framework.NewNodeInfo(gpuNode, slices)
 
 	err = executor.executeScaleUp(nodegroupset.ScaleUpInfo{
 		Group:       nodeGroup,
 		CurrentSize: 0,
 		NewSize:     2,
 		MaxSize:     10,
-	}, nodeInfo, autoscalingCtx.CloudProvider.GetAvailableGPUTypes(), now, false)
+	}, now, false)
 	assert.NoError(t, err)
 
 	mockMetrics.AssertCalled(t, "RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net")
@@ -2646,6 +2648,14 @@ func TestScaleUpMetricsEmission(t *testing.T) {
 
 type mockMetrics struct {
 	mock.Mock
+}
+
+func (m *mockMetrics) RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName string, gpuType string, draDriverNames string) {
+	m.Called(reason, gpuResourceName, gpuType, draDriverNames)
+}
+
+func (m *mockMetrics) RegisterFailedNodeCreations(reason metrics.FailedScaleUpReason, nodesCount int) {
+	m.Called(reason, nodesCount)
 }
 
 func (m *mockMetrics) RegisterScaleUp(nodesCount int, gpuResourceName string, gpuType string, draDriverNames string) {

--- a/pkg/core/scaleup/orchestrator/orchestrator_test.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator_test.go
@@ -1223,7 +1223,7 @@ func runSimpleScaleUpTest(t *testing.T, testConfig *ScaleUpTestConfig) *ScaleUpT
 	assert.NoError(t, err)
 	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
 	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults), autoscalingCtx.TemplateNodeInfoRegistry, clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))
-	processors.ScaleStateNotifier.Register(nodegroupchange.NewNodeGroupChangeMetricsProducer(provider, metrics.DefaultMetrics))
+	processors.ScaleStateNotifier.Register(nodegroupchange.NewNodeGroupChangeMetricsProducer(provider, metrics.DefaultMetrics, autoscalingCtx.TemplateNodeInfoRegistry))
 	clusterState.UpdateNodes(nodes, time.Now())
 	processors.NodeGroupSetProcessor = nodegroupset.NewDefaultNodeGroupSetProcessor([]string{nodeGroupLabel}, config.NodeGroupDifferenceRatios{})
 	if testConfig.EnableAutoprovisioning {
@@ -2628,7 +2628,7 @@ func TestScaleUpMetricsEmission(t *testing.T) {
 	mockMetrics := &mockMetrics{}
 	mockMetrics.On("RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net").Return()
 
-	producer := nodegroupchange.NewNodeGroupChangeMetricsProducer(provider, mockMetrics)
+	producer := nodegroupchange.NewNodeGroupChangeMetricsProducer(provider, mockMetrics, templateNodeInfoRegistry)
 	processors.ScaleStateNotifier.Register(producer)
 
 	executor := newScaleUpExecutor(&autoscalingCtx, processors.ScaleStateNotifier, processors.AsyncNodeGroupStateChecker)

--- a/pkg/core/static_autoscaler.go
+++ b/pkg/core/static_autoscaler.go
@@ -202,7 +202,7 @@ func NewStaticAutoscaler(
 	taintConfig := taints.NewTaintConfig(opts)
 
 	processors.ScaleDownCandidatesNotifier.Register(clusterStateRegistry)
-	processors.ScaleStateNotifier.Register(nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, metrics.DefaultMetrics))
+	processors.ScaleStateNotifier.Register(nodegroupchange.NewNodeGroupChangeMetricsProducer(cloudProvider, metrics.DefaultMetrics, templateNodeInfoRegistry))
 
 	// TODO: Populate the ScaleDownActuator/Planner fields in AutoscalingContext
 	// during the struct creation rather than here.

--- a/pkg/observers/nodegroupchange/scale_state_observer.go
+++ b/pkg/observers/nodegroupchange/scale_state_observer.go
@@ -102,6 +102,7 @@ func NewNodeGroupChangeObserversList() *NodeGroupChangeObserversList {
 }
 
 type metricObserver interface {
+	RegisterScaleUp(delta int, gpuResourceName, gpuType, draDriverName string)
 	RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType, draDriverName string)
 	RegisterFailedNodeCreations(reason metrics.FailedScaleUpReason, nodesCount int)
 }
@@ -113,35 +114,27 @@ type NodeGroupChangeMetricsProducer struct {
 	metrics metricObserver
 }
 
-// RegisterScaleUp calls RegisterScaleUp for each observer.
+// RegisterScaleUp emits the scale up metric.
 func (p *NodeGroupChangeMetricsProducer) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
 	delta int, currentTime time.Time) {
+	gpuResourceName, gpuType, draDriverNames := retrieveMetricsDataFromNodeGroup(nodeGroup, p.cloudProvider)
+	p.metrics.RegisterScaleUp(delta, gpuResourceName, gpuType, draDriverNames)
 }
 
-// RegisterScaleDown calls RegisterScaleDown for each observer.
+// RegisterScaleDown is a no-op for NodeGroupChangeMetricsProducer.
 func (p *NodeGroupChangeMetricsProducer) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
 	nodeName string, currentTime time.Time, expectedDeleteTime time.Time) {
 }
 
 // RegisterFailedScaleUp emits the failed scale up metric.
 func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
-	availableGPUTypes := p.cloudProvider.GetAvailableGPUTypes()
-	gpuResourceName, gpuType, draDriverNames := "", "", ""
-	nodeInfo, err := nodeGroup.TemplateNodeInfo()
-	if err != nil {
-		klog.Warningf("Failed to get template node info for a node group: %s", err)
-	} else if nodeInfo == nil {
-		klog.Warningf("Template node info is nil for node group: %s", nodeGroup.Id())
-	} else {
-		gpuResourceName, gpuType = gpu.GetGpuInfoForMetrics(p.cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
-		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
-	}
+	gpuResourceName, gpuType, draDriverNames := retrieveMetricsDataFromNodeGroup(nodeGroup, p.cloudProvider)
 	reason := metrics.FailedScaleUpReason(errorInfo.ErrorCode)
 	p.metrics.RegisterFailedScaleUp(reason, gpuResourceName, gpuType, draDriverNames)
 	p.metrics.RegisterFailedNodeCreations(reason, delta)
 }
 
-// RegisterFailedScaleDown records failed scale-down for a nodegroup.
+// RegisterFailedScaleDown is a no-op for NodeGroupChangeMetricsProducer.
 func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup,
 	reason string, currentTime time.Time) {
 }
@@ -149,4 +142,19 @@ func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleDown(nodeGroup cloud
 // NewNodeGroupChangeMetricsProducer returns a new NodeGroupChangeMetricsProducer.
 func NewNodeGroupChangeMetricsProducer(cloudProvider cloudprovider.CloudProvider, metrics metricObserver) *NodeGroupChangeMetricsProducer {
 	return &NodeGroupChangeMetricsProducer{cloudProvider: cloudProvider, metrics: metrics}
+}
+
+func retrieveMetricsDataFromNodeGroup(nodeGroup cloudprovider.NodeGroup, cloudProvider cloudprovider.CloudProvider) (string, string, string) {
+	availableGPUTypes := cloudProvider.GetAvailableGPUTypes()
+	gpuResourceName, gpuType, draDriverNames := "", "", ""
+	nodeInfo, err := nodeGroup.TemplateNodeInfo()
+	if err != nil {
+		klog.Warningf("Failed to get template node info for a node group: %s", err)
+	} else if nodeInfo == nil {
+		klog.Warningf("Template node info is nil for node group: %s", nodeGroup.Id())
+	} else {
+		gpuResourceName, gpuType = gpu.GetGpuInfoForMetrics(cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
+		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
+	}
+	return gpuResourceName, gpuType, draDriverNames
 }

--- a/pkg/observers/nodegroupchange/scale_state_observer.go
+++ b/pkg/observers/nodegroupchange/scale_state_observer.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
 	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/dynamicresources"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
 )
@@ -107,17 +108,22 @@ type metricObserver interface {
 	RegisterFailedNodeCreations(reason metrics.FailedScaleUpReason, nodesCount int)
 }
 
+type nodeInfoRegistry interface {
+	GetNodeInfo(id string) (*framework.NodeInfo, bool)
+}
+
 // NodeGroupChangeMetricsProducer is an implementation of NodeGroupChangeObserver for reporting the scale up/down metrics
 type NodeGroupChangeMetricsProducer struct {
 	cloudProvider cloudprovider.CloudProvider
 	// metrics is an instance of metricObserver interface which allows to mock and test the nodegroupchange metrics
-	metrics metricObserver
+	metrics          metricObserver
+	nodeInfoRegistry nodeInfoRegistry
 }
 
 // RegisterScaleUp emits the scale up metric.
 func (p *NodeGroupChangeMetricsProducer) RegisterScaleUp(nodeGroup cloudprovider.NodeGroup,
 	delta int, currentTime time.Time) {
-	gpuResourceName, gpuType, draDriverNames := retrieveMetricsDataFromNodeGroup(nodeGroup, p.cloudProvider)
+	gpuResourceName, gpuType, draDriverNames := retrieveMetricsDataFromNodeGroup(nodeGroup, p.cloudProvider, p.nodeInfoRegistry)
 	p.metrics.RegisterScaleUp(delta, gpuResourceName, gpuType, draDriverNames)
 }
 
@@ -128,7 +134,7 @@ func (p *NodeGroupChangeMetricsProducer) RegisterScaleDown(nodeGroup cloudprovid
 
 // RegisterFailedScaleUp emits the failed scale up metric.
 func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleUp(nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
-	gpuResourceName, gpuType, draDriverNames := retrieveMetricsDataFromNodeGroup(nodeGroup, p.cloudProvider)
+	gpuResourceName, gpuType, draDriverNames := retrieveMetricsDataFromNodeGroup(nodeGroup, p.cloudProvider, p.nodeInfoRegistry)
 	reason := metrics.FailedScaleUpReason(errorInfo.ErrorCode)
 	p.metrics.RegisterFailedScaleUp(reason, gpuResourceName, gpuType, draDriverNames)
 	p.metrics.RegisterFailedNodeCreations(reason, delta)
@@ -140,19 +146,28 @@ func (p *NodeGroupChangeMetricsProducer) RegisterFailedScaleDown(nodeGroup cloud
 }
 
 // NewNodeGroupChangeMetricsProducer returns a new NodeGroupChangeMetricsProducer.
-func NewNodeGroupChangeMetricsProducer(cloudProvider cloudprovider.CloudProvider, metrics metricObserver) *NodeGroupChangeMetricsProducer {
-	return &NodeGroupChangeMetricsProducer{cloudProvider: cloudProvider, metrics: metrics}
+func NewNodeGroupChangeMetricsProducer(cloudProvider cloudprovider.CloudProvider, metrics metricObserver, nodeInfoRegistry nodeInfoRegistry) *NodeGroupChangeMetricsProducer {
+	return &NodeGroupChangeMetricsProducer{cloudProvider: cloudProvider, metrics: metrics, nodeInfoRegistry: nodeInfoRegistry}
 }
 
-func retrieveMetricsDataFromNodeGroup(nodeGroup cloudprovider.NodeGroup, cloudProvider cloudprovider.CloudProvider) (string, string, string) {
+func retrieveMetricsDataFromNodeGroup(nodeGroup cloudprovider.NodeGroup, cloudProvider cloudprovider.CloudProvider, registry nodeInfoRegistry) (string, string, string) {
 	availableGPUTypes := cloudProvider.GetAvailableGPUTypes()
 	gpuResourceName, gpuType, draDriverNames := "", "", ""
-	nodeInfo, err := nodeGroup.TemplateNodeInfo()
-	if err != nil {
-		klog.Warningf("Failed to get template node info for a node group: %s", err)
-	} else if nodeInfo == nil {
-		klog.Warningf("Template node info is nil for node group: %s", nodeGroup.Id())
-	} else {
+	var nodeInfo *framework.NodeInfo
+	var found bool
+	if registry != nil {
+		nodeInfo, found = registry.GetNodeInfo(nodeGroup.Id())
+	}
+	if !found {
+		var err error
+		nodeInfo, err = nodeGroup.TemplateNodeInfo()
+		if err != nil {
+			klog.Warningf("Failed to get template node info for a node group: %s", err)
+		} else if nodeInfo == nil {
+			klog.Warningf("Template node info is nil for node group: %s", nodeGroup.Id())
+		}
+	}
+	if nodeInfo != nil {
 		gpuResourceName, gpuType = gpu.GetGpuInfoForMetrics(cloudProvider.GetNodeGpuConfig(nodeInfo.Node()), availableGPUTypes, nodeInfo.Node(), nodeGroup)
 		draDriverNames = dynamicresources.GetDriverNamesForMetricsCompacted(nodeInfo.LocalResourceSlices)
 	}

--- a/pkg/observers/nodegroupchange/scale_state_observer_test.go
+++ b/pkg/observers/nodegroupchange/scale_state_observer_test.go
@@ -34,6 +34,10 @@ type mockMetrics struct {
 	mock.Mock
 }
 
+func (m *mockMetrics) RegisterScaleUp(delta int, gpuResourceName, gpuType, draDriverName string) {
+	m.Called(delta, gpuResourceName, gpuType, draDriverName)
+}
+
 func (m *mockMetrics) RegisterFailedScaleUp(reason metrics.FailedScaleUpReason, gpuResourceName, gpuType, draDrivers string) {
 	m.Called(reason, gpuResourceName, gpuType, draDrivers)
 }
@@ -114,4 +118,63 @@ func TestRegisterFailedScaleUpCallViaObserversList(t *testing.T) {
 	// Assertions
 	mockMetricsObj.AssertCalled(t, "RegisterFailedScaleUp", metrics.FailedScaleUpReason("TIMEOUT"), "", "", "")
 	mockMetricsObj.AssertCalled(t, "RegisterFailedNodeCreations", metrics.FailedScaleUpReason("TIMEOUT"), 5)
+}
+
+func TestRegisterScaleUpDirectCall(t *testing.T) {
+	now := time.Now()
+	gpuNode := &apiv1.Node{
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			},
+		},
+	}
+	gpuNode.Labels = map[string]string{
+		"TestGPULabel/accelerator": "nvidia-tesla-k80",
+	}
+
+	slices := []*resourceapi.ResourceSlice{
+		{
+			Spec: resourceapi.ResourceSliceSpec{
+				Driver: "dra.net",
+			},
+		},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 1)
+	provider.SetMachineTemplates(map[string]*framework.NodeInfo{
+		"ng1": framework.NewNodeInfo(gpuNode, slices),
+	})
+
+	mockMetricsObj := &mockMetrics{}
+	mockMetricsObj.On("RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net").Return()
+
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj)
+
+	nodeGroup := provider.GetNodeGroup("ng1")
+	producer.RegisterScaleUp(nodeGroup, 2, now)
+
+	mockMetricsObj.AssertCalled(t, "RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net")
+}
+
+func TestRegisterScaleUpCallViaObserversList(t *testing.T) {
+	now := time.Now()
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng2", 1, 10, 1)
+	provider.SetMachineTemplates(map[string]*framework.NodeInfo{})
+
+	mockMetricsObj := &mockMetrics{}
+	mockMetricsObj.On("RegisterScaleUp", 4, "", "", "").Return()
+
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj)
+
+	list := NewNodeGroupChangeObserversList()
+	list.Register(producer)
+
+	nodeGroup := provider.GetNodeGroup("ng2")
+	list.RegisterScaleUp(nodeGroup, 4, now)
+
+	mockMetricsObj.AssertCalled(t, "RegisterScaleUp", 4, "", "", "")
 }

--- a/pkg/observers/nodegroupchange/scale_state_observer_test.go
+++ b/pkg/observers/nodegroupchange/scale_state_observer_test.go
@@ -77,7 +77,7 @@ func TestRegisterFailedScaleUpDirectCall(t *testing.T) {
 	mockMetricsObj.On("RegisterFailedScaleUp", metrics.FailedScaleUpReason("OUT_OF_RESOURCES"), "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net").Return()
 	mockMetricsObj.On("RegisterFailedNodeCreations", metrics.FailedScaleUpReason("OUT_OF_RESOURCES"), 3).Return()
 
-	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj)
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj, nil)
 
 	nodeGroup := provider.GetNodeGroup("ng1")
 	errorInfo := cloudprovider.InstanceErrorInfo{
@@ -102,7 +102,7 @@ func TestRegisterFailedScaleUpCallViaObserversList(t *testing.T) {
 	mockMetricsObj.On("RegisterFailedScaleUp", metrics.FailedScaleUpReason("TIMEOUT"), "", "", "").Return()
 	mockMetricsObj.On("RegisterFailedNodeCreations", metrics.FailedScaleUpReason("TIMEOUT"), 5).Return()
 
-	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj)
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj, nil)
 
 	// Register with ObserversList
 	list := NewNodeGroupChangeObserversList()
@@ -150,7 +150,7 @@ func TestRegisterScaleUpDirectCall(t *testing.T) {
 	mockMetricsObj := &mockMetrics{}
 	mockMetricsObj.On("RegisterScaleUp", 2, "nvidia.com/gpu", "nvidia-tesla-k80", "dra.net").Return()
 
-	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj)
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj, nil)
 
 	nodeGroup := provider.GetNodeGroup("ng1")
 	producer.RegisterScaleUp(nodeGroup, 2, now)
@@ -168,7 +168,7 @@ func TestRegisterScaleUpCallViaObserversList(t *testing.T) {
 	mockMetricsObj := &mockMetrics{}
 	mockMetricsObj.On("RegisterScaleUp", 4, "", "", "").Return()
 
-	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj)
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj, nil)
 
 	list := NewNodeGroupChangeObserversList()
 	list.Register(producer)
@@ -177,4 +177,46 @@ func TestRegisterScaleUpCallViaObserversList(t *testing.T) {
 	list.RegisterScaleUp(nodeGroup, 4, now)
 
 	mockMetricsObj.AssertCalled(t, "RegisterScaleUp", 4, "", "", "")
+}
+
+type testNodeInfoRegistry struct {
+	nodeInfos map[string]*framework.NodeInfo
+}
+
+func (r *testNodeInfoRegistry) GetNodeInfo(id string) (*framework.NodeInfo, bool) {
+	ni, found := r.nodeInfos[id]
+	return ni, found
+}
+
+func TestRegisterScaleUpUsesNodeInfoRegistry(t *testing.T) {
+	now := time.Now()
+	gpuNode := &apiv1.Node{
+		Status: apiv1.NodeStatus{
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			},
+		},
+	}
+	gpuNode.Labels = map[string]string{
+		"TestGPULabel/accelerator": "nvidia-tesla-v100",
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 1)
+
+	registry := &testNodeInfoRegistry{
+		nodeInfos: map[string]*framework.NodeInfo{
+			"ng1": framework.NewNodeInfo(gpuNode, nil),
+		},
+	}
+
+	mockMetricsObj := &mockMetrics{}
+	mockMetricsObj.On("RegisterScaleUp", 1, "nvidia.com/gpu", "nvidia-tesla-v100", "").Return()
+
+	producer := NewNodeGroupChangeMetricsProducer(provider, mockMetricsObj, registry)
+
+	nodeGroup := provider.GetNodeGroup("ng1")
+	producer.RegisterScaleUp(nodeGroup, 1, now)
+
+	mockMetricsObj.AssertCalled(t, "RegisterScaleUp", 1, "nvidia.com/gpu", "nvidia-tesla-v100", "")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is a copy of a [PR](https://github.com/kubernetes/autoscaler/pull/9667) from the old repo. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
During the implementation I figured out that we do not have a single test which covers the `RegisterScaleUp` metric emission. So I decided to have commits as follows:
1. Introduced unit tests which will check that the metric calls did actually happen (apparently we had only one place in `scaleUpExecutor`). Ensure that the metric is correctly called in there.
2. Moved the metric generation into `NodeGroupChangeMetricsProducer` and adjusted a little bit the test to the new implementation - double checked it by checking that tests from point 1 are still passing.
That is the reason that you will see some lines introduced in commit 1 getting deleted in commit 2. 
3. Added the `TemplateNodeInfoRegistry` as a param of `NodeGroupChangeMetricsProducer` to use up-to-date labels in the metric calls. More info in [here](https://github.com/kubernetes/autoscaler/pull/9667#issuecomment-5141883508)

Also since now metric is emitted from a single place -`NodeGroupChangeMetricsProducer` - there is no need to pass `nodeInfos` around as we already have a logic for `gpu` and `dra` info retrieval in the `NodeGroupChangeMetricsProducer`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```