### PR TITLE
feat: Affinity cache performance improvements

### DIFF
--- a/pkg/core/bench/benchmark_runonce_test.go
+++ b/pkg/core/bench/benchmark_runonce_test.go
@@ -513,6 +513,32 @@ func setupScaleUpDRA(nodes int) func(*integration.FakeSet) error {
 	}
 }
 
+// setupScaleUpAntiAffinity prepares a scenario that triggers a scale-up for the specified number
+// of nodes by creating one unschedulable pod per node, all with required hostname anti-affinity
+// to each other. Scheduling each pod reads and updates the affinity cache.
+func setupScaleUpAntiAffinity(nodes int) func(*integration.FakeSet) error {
+	return func(clusterFakes *integration.FakeSet) error {
+		nTemplate := BuildTestNode("n-template", nodeCPU, nodeMem)
+		SetNodeReadyState(nTemplate, true, time.Now())
+
+		clusterFakes.CloudProvider.AddNodeGroup(ngName,
+			testprovider.WithTemplate(framework.NewNodeInfo(nTemplate, nil)),
+			testprovider.WithNGSize(0, maxNGSize),
+		)
+
+		antiAffinityLabels := map[string]string{"app": "anti-affinity-app"}
+		for i := range nodes {
+			podName := fmt.Sprintf("pod-aa-%d", i)
+			cpu := int64(nodeCPU / 10)
+			mem := int64(nodeMem / 10)
+			pod := BuildTestPod(podName, cpu, mem, MarkUnschedulable(),
+				WithLabels(antiAffinityLabels), WithPodHostnameAntiAffinity(antiAffinityLabels))
+			clusterFakes.K8s.AddPod(pod)
+		}
+		return nil
+	}
+}
+
 // setupScaleDown60Percent prepares a scenario where the workload is reduced such
 // that it fits on 40% of the existing nodes, triggering a 60% scale-down.
 // Each node starts with 40 pods, each consuming 1% of the node's resources,
@@ -543,6 +569,50 @@ func setupScaleDown60Percent(nodesCount int) func(*integration.FakeSet) error {
 			clusterFakes.K8s.AddPod(pod)
 		}
 
+		return nil
+	}
+}
+
+// setupScaleDownAntiAffinity prepares a scale-down scenario where every 10th node hosts a
+// non-evictable pod with required hostname anti-affinity, so the affinity cache is used for
+// every pod rescheduled during drain simulation.
+func setupScaleDownAntiAffinity(nodesCount int) func(*integration.FakeSet) error {
+	return func(clusterFakes *integration.FakeSet) error {
+		nTemplate := BuildTestNode("n-template", nodeCPU, nodeMem)
+		SetNodeReadyState(nTemplate, true, time.Now())
+
+		ng := clusterFakes.CloudProvider.AddNodeGroup(ngName,
+			testprovider.WithNodes(nTemplate, nodesCount),
+			testprovider.WithNGSize(0, maxNGSize),
+		)
+
+		// Create 40 pods per node.
+		// Each pod uses 1% of a node's resources, leading to 40% utilization.
+		for i := range nodesCount * 40 {
+			podName := fmt.Sprintf("pod-%d", i)
+			nodeName := fmt.Sprintf("%s-node-%d", ng.Id(), i%nodesCount)
+			cpu := int64(nodeCPU / 100)
+			mem := int64(nodeMem / 100)
+			pod := BuildTestPod(podName, cpu, mem)
+			pod.Spec.NodeName = nodeName
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
+			pod.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "true"
+			clusterFakes.K8s.AddPod(pod)
+		}
+
+		// Anti-affinity pods use 20% of node resources and aren't safe-to-evict,
+		// so their nodes are never scaled down.
+		antiAffinityLabels := map[string]string{"app": "anti-affinity-app"}
+		for i := 0; i < nodesCount; i += 10 {
+			podName := fmt.Sprintf("pod-aa-%d", i)
+			nodeName := fmt.Sprintf("%s-node-%d", ng.Id(), i)
+			pod := BuildTestPod(podName, int64(nodeCPU/5), int64(nodeMem/5),
+				WithLabels(antiAffinityLabels), WithPodHostnameAntiAffinity(antiAffinityLabels))
+			pod.Spec.NodeName = nodeName
+			clusterFakes.K8s.AddPod(pod)
+		}
 		return nil
 	}
 }
@@ -757,10 +827,41 @@ func BenchmarkRunOnceScaleUpDRA(b *testing.B) {
 	s.run(b)
 }
 
+func BenchmarkRunOnceScaleUpAntiAffinity(b *testing.B) {
+	s := scenario{
+		setup:  setupScaleUpAntiAffinity(500),
+		verify: verifyTargetSize(500),
+		config: func(opts *config.AutoscalingOptions) {
+			opts.MaxNodesPerScaleUp = maxNGSize
+			opts.ScaleUpFromZero = true
+		},
+	}
+	s.run(b)
+}
+
 func BenchmarkRunOnceScaleDown(b *testing.B) {
 	s := scenario{
 		setup:  setupScaleDown60Percent(2000),
 		verify: verifyToBeDeleted(1200),
+		config: func(opts *config.AutoscalingOptions) {
+			opts.NodeGroupDefaults.ScaleDownUnneededTime = 0
+			opts.MaxScaleDownParallelism = 2000
+			opts.MaxDrainParallelism = 2000
+			opts.ScaleDownDelayAfterAdd = 0
+			opts.ScaleDownEnabled = true
+			opts.ScaleDownNonEmptyCandidatesCount = 2000
+			opts.ScaleDownUnreadyEnabled = true
+			opts.ScaleDownSimulationTimeout = 60 * time.Second
+		},
+	}
+	s.run(b)
+}
+
+func BenchmarkRunOnceScaleDownAntiAffinity(b *testing.B) {
+	s := scenario{
+		setup: setupScaleDownAntiAffinity(1000),
+		// 900 drainable nodes at 40% repack into 360 of them + spare capacity on the anti-affinity nodes -> 580 drained.
+		verify: verifyToBeDeleted(580),
 		config: func(opts *config.AutoscalingOptions) {
 			opts.NodeGroupDefaults.ScaleDownUnneededTime = 0
 			opts.MaxScaleDownParallelism = 2000

--- a/pkg/core/bench/benchmark_runonce_test.go
+++ b/pkg/core/bench/benchmark_runonce_test.go
@@ -35,9 +35,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
 	k8s_testing "k8s.io/client-go/testing"
+	featuretesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -513,26 +516,66 @@ func setupScaleUpDRA(nodes int) func(*integration.FakeSet) error {
 	}
 }
 
-// setupScaleUpAntiAffinity prepares a scenario that triggers a scale-up for the specified number
-// of nodes by creating one unschedulable pod per node, all with required hostname anti-affinity
-// to each other. Scheduling each pod reads and updates the affinity cache.
-func setupScaleUpAntiAffinity(nodes int) func(*integration.FakeSet) error {
+// labelNodeHostnames sets a unique kubernetes.io/hostname label on every existing node, so that
+// hostname-scoped (anti)affinity terms can match on them. Simulated scale-up nodes get theirs
+// from the node template sanitizer.
+func labelNodeHostnames(clusterFakes *integration.FakeSet) {
+	for _, node := range clusterFakes.K8s.Nodes().Items {
+		node.Labels[corev1.LabelHostname] = node.Name
+		clusterFakes.K8s.UpdateNode(&node)
+	}
+}
+
+// setupScaleUpAntiAffinity prepares a large stable cluster with resident anti-affinity pods and
+// a mixed pending burst: schedulable pods that fit on existing free capacity, and spread pods
+// with required hostname anti-affinity to each other that fit only on new nodes. Every simulated
+// placement reads the affinity node lists, and every spread pod placed during binpacking updates
+// them, all against a cluster-sized node list.
+func setupScaleUpAntiAffinity(existingNodes, schedulablePods, spreadPods int) func(*integration.FakeSet) error {
 	return func(clusterFakes *integration.FakeSet) error {
 		nTemplate := BuildTestNode("n-template", nodeCPU, nodeMem)
 		SetNodeReadyState(nTemplate, true, time.Now())
 
-		clusterFakes.CloudProvider.AddNodeGroup(ngName,
-			testprovider.WithTemplate(framework.NewNodeInfo(nTemplate, nil)),
+		ng := clusterFakes.CloudProvider.AddNodeGroup(ngName,
+			testprovider.WithNodes(nTemplate, existingNodes),
 			testprovider.WithNGSize(0, maxNGSize),
 		)
+		labelNodeHostnames(clusterFakes)
 
+		// One filler pod per node at 60% utilisation, leaving 40% free.
+		for i := range existingNodes {
+			podName := fmt.Sprintf("pod-fill-%d", i)
+			pod := BuildTestPod(podName, int64(nodeCPU*6/10), int64(nodeMem*6/10))
+			pod.Spec.NodeName = fmt.Sprintf("%s-node-%d", ng.Id(), i)
+			clusterFakes.K8s.AddPod(pod)
+		}
+
+		// Resident anti-affinity pods on every 20th node keep the affinity node lists non-empty.
 		antiAffinityLabels := map[string]string{"app": "anti-affinity-app"}
-		for i := range nodes {
+		for i := 0; i < existingNodes; i += 20 {
 			podName := fmt.Sprintf("pod-aa-%d", i)
-			cpu := int64(nodeCPU / 10)
-			mem := int64(nodeMem / 10)
-			pod := BuildTestPod(podName, cpu, mem, MarkUnschedulable(),
+			pod := BuildTestPod(podName, int64(nodeCPU/10), int64(nodeMem/10),
 				WithLabels(antiAffinityLabels), WithPodHostnameAntiAffinity(antiAffinityLabels))
+			pod.Spec.NodeName = fmt.Sprintf("%s-node-%d", ng.Id(), i)
+			clusterFakes.K8s.AddPod(pod)
+		}
+
+		// Pending pods at 1% of node resources each. They fit on existing free capacity, so
+		// they are filtered out as schedulable rather than triggering a scale-up.
+		for i := range schedulablePods {
+			podName := fmt.Sprintf("pod-pending-%d", i)
+			pod := BuildTestPod(podName, int64(nodeCPU/100), int64(nodeMem/100), MarkUnschedulable())
+			clusterFakes.K8s.AddPod(pod)
+		}
+
+		// Pending spread pods at 45% of node resources with required hostname anti-affinity to
+		// each other. They don't fit in the 40% free on existing nodes, and the anti-affinity
+		// allows only one per new node, so each spread pod scales up one node.
+		spreadLabels := map[string]string{"app": "spread-app"}
+		for i := range spreadPods {
+			podName := fmt.Sprintf("pod-spread-%d", i)
+			pod := BuildTestPod(podName, int64(nodeCPU*45/100), int64(nodeMem*45/100), MarkUnschedulable(),
+				WithLabels(spreadLabels), WithPodHostnameAntiAffinity(spreadLabels))
 			clusterFakes.K8s.AddPod(pod)
 		}
 		return nil
@@ -573,9 +616,10 @@ func setupScaleDown60Percent(nodesCount int) func(*integration.FakeSet) error {
 	}
 }
 
-// setupScaleDownAntiAffinity prepares a scale-down scenario where every 10th node hosts a
-// non-evictable pod with required hostname anti-affinity, so the affinity cache is used for
-// every pod rescheduled during drain simulation.
+// setupScaleDownAntiAffinity prepares a scale-down scenario on a large cluster where every 10th
+// node hosts a non-evictable pod with required hostname anti-affinity, so the affinity node
+// lists are read and invalidated for every pod rescheduled during drain simulation, against a
+// cluster-sized node list.
 func setupScaleDownAntiAffinity(nodesCount int) func(*integration.FakeSet) error {
 	return func(clusterFakes *integration.FakeSet) error {
 		nTemplate := BuildTestNode("n-template", nodeCPU, nodeMem)
@@ -585,10 +629,11 @@ func setupScaleDownAntiAffinity(nodesCount int) func(*integration.FakeSet) error
 			testprovider.WithNodes(nTemplate, nodesCount),
 			testprovider.WithNGSize(0, maxNGSize),
 		)
+		labelNodeHostnames(clusterFakes)
 
-		// Create 40 pods per node.
-		// Each pod uses 1% of a node's resources, leading to 40% utilization.
-		for i := range nodesCount * 40 {
+		// Create 20 pods per node.
+		// Each pod uses 1% of a node's resources, leading to 20% utilization.
+		for i := range nodesCount * 20 {
 			podName := fmt.Sprintf("pod-%d", i)
 			nodeName := fmt.Sprintf("%s-node-%d", ng.Id(), i%nodesCount)
 			cpu := int64(nodeCPU / 100)
@@ -828,12 +873,14 @@ func BenchmarkRunOnceScaleUpDRA(b *testing.B) {
 }
 
 func BenchmarkRunOnceScaleUpAntiAffinity(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.InterPodAffinityHostnameFastPath, true)
+	const existingNodes = 3000
+	const spreadPods = 500
 	s := scenario{
-		setup:  setupScaleUpAntiAffinity(500),
-		verify: verifyTargetSize(500),
+		setup:  setupScaleUpAntiAffinity(existingNodes, 5000, spreadPods),
+		verify: verifyTargetSize(existingNodes + spreadPods),
 		config: func(opts *config.AutoscalingOptions) {
 			opts.MaxNodesPerScaleUp = maxNGSize
-			opts.ScaleUpFromZero = true
 		},
 	}
 	s.run(b)
@@ -858,10 +905,11 @@ func BenchmarkRunOnceScaleDown(b *testing.B) {
 }
 
 func BenchmarkRunOnceScaleDownAntiAffinity(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.InterPodAffinityHostnameFastPath, true)
 	s := scenario{
-		setup: setupScaleDownAntiAffinity(1000),
-		// 900 drainable nodes at 40% repack into 360 of them + spare capacity on the anti-affinity nodes -> 580 drained.
-		verify: verifyToBeDeleted(580),
+		setup: setupScaleDownAntiAffinity(2000),
+		// 1800 drainable nodes at 20% repack into 240 of them + spare capacity on the anti-affinity nodes -> 1560 drained.
+		verify: verifyToBeDeleted(1560),
 		config: func(opts *config.AutoscalingOptions) {
 			opts.NodeGroupDefaults.ScaleDownUnneededTime = 0
 			opts.MaxScaleDownParallelism = 2000

--- a/pkg/simulator/clustersnapshot/store/delta.go
+++ b/pkg/simulator/clustersnapshot/store/delta.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	apiv1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/klog/v2"
@@ -188,8 +189,97 @@ func (data *internalDeltaSnapshotData) clearPodCaches() {
 	data.havePodsWithAffinity = nil
 	data.havePodsWithRequiredAntiAffinity = nil
 	data.havePodsWithRequiredNonHostScopedAntiAffinity = nil
-	// TODO: update the cache when adding/removing pods instead of invalidating the whole cache
 	data.pvcNamespaceMap = nil
+}
+
+func (data *internalDeltaSnapshotData) addToPodCaches(ni schedulerinterface.NodeInfo, pod *apiv1.Pod) {
+	affinity := pod.Spec.Affinity
+	if affinity == nil {
+		return
+	}
+
+	if data.havePodsWithAffinity != nil && (affinity.PodAffinity != nil || affinity.PodAntiAffinity != nil) {
+		if !nodeInSlice(data.havePodsWithAffinity, ni) {
+			data.havePodsWithAffinity = append(data.havePodsWithAffinity, ni)
+		}
+	}
+
+	if data.havePodsWithRequiredAntiAffinity != nil && affinity.PodAntiAffinity != nil &&
+		len(affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) > 0 {
+		if !nodeInSlice(data.havePodsWithRequiredAntiAffinity, ni) {
+			data.havePodsWithRequiredAntiAffinity = append(data.havePodsWithRequiredAntiAffinity, ni)
+		}
+	}
+
+	// Use the NodeInfo getter here as it only tracks these pods when the
+	// InterPodAffinityHostnameFastPath feature gate is enabled.
+	if data.havePodsWithRequiredNonHostScopedAntiAffinity != nil && len(ni.GetPodsWithRequiredNonHostScopedAntiAffinity()) > 0 {
+		if !nodeInSlice(data.havePodsWithRequiredNonHostScopedAntiAffinity, ni) {
+			data.havePodsWithRequiredNonHostScopedAntiAffinity = append(data.havePodsWithRequiredNonHostScopedAntiAffinity, ni)
+		}
+	}
+}
+
+func (data *internalDeltaSnapshotData) removeFromPodCaches(ni schedulerinterface.NodeInfo) {
+	if data.havePodsWithAffinity != nil && len(ni.GetPodsWithAffinity()) == 0 {
+		data.havePodsWithAffinity = removeNodeFromSlice(data.havePodsWithAffinity, ni)
+	}
+
+	if data.havePodsWithRequiredAntiAffinity != nil && len(ni.GetPodsWithRequiredAntiAffinity()) == 0 {
+		data.havePodsWithRequiredAntiAffinity = removeNodeFromSlice(data.havePodsWithRequiredAntiAffinity, ni)
+	}
+
+	if data.havePodsWithRequiredNonHostScopedAntiAffinity != nil && len(ni.GetPodsWithRequiredNonHostScopedAntiAffinity()) == 0 {
+		data.havePodsWithRequiredNonHostScopedAntiAffinity = removeNodeFromSlice(data.havePodsWithRequiredNonHostScopedAntiAffinity, ni)
+	}
+}
+
+func (data *internalDeltaSnapshotData) replaceNodeInPodCaches(old, new schedulerinterface.NodeInfo) {
+	oldName := old.Node().Name
+	if data.havePodsWithAffinity != nil {
+		for i, ni := range data.havePodsWithAffinity {
+			if ni.Node().Name == oldName {
+				data.havePodsWithAffinity[i] = new
+				break
+			}
+		}
+	}
+	if data.havePodsWithRequiredAntiAffinity != nil {
+		for i, ni := range data.havePodsWithRequiredAntiAffinity {
+			if ni.Node().Name == oldName {
+				data.havePodsWithRequiredAntiAffinity[i] = new
+				break
+			}
+		}
+	}
+	if data.havePodsWithRequiredNonHostScopedAntiAffinity != nil {
+		for i, ni := range data.havePodsWithRequiredNonHostScopedAntiAffinity {
+			if ni.Node().Name == oldName {
+				data.havePodsWithRequiredNonHostScopedAntiAffinity[i] = new
+				break
+			}
+		}
+	}
+}
+
+func nodeInSlice(slice []schedulerinterface.NodeInfo, target schedulerinterface.NodeInfo) bool {
+	targetName := target.Node().Name
+	for _, ni := range slice {
+		if ni.Node().Name == targetName {
+			return true
+		}
+	}
+	return false
+}
+
+func removeNodeFromSlice(slice []schedulerinterface.NodeInfo, target schedulerinterface.NodeInfo) []schedulerinterface.NodeInfo {
+	targetName := target.Node().Name
+	for i, ni := range slice {
+		if ni.Node().Name == targetName {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
 }
 
 func (data *internalDeltaSnapshotData) removeNodeInfo(nodeName string) error {
@@ -237,7 +327,8 @@ func (data *internalDeltaSnapshotData) nodeInfoToModify(nodeName string) (schedu
 		}
 		dni = bni.Snapshot()
 		data.modifiedNodeInfoMap[nodeName] = dni
-		data.clearCaches()
+		data.nodeInfoList = nil
+		data.replaceNodeInPodCaches(bni, dni)
 	}
 	return dni, true
 }
@@ -250,8 +341,8 @@ func (data *internalDeltaSnapshotData) addPodInfo(podInfo schedulerinterface.Pod
 
 	ni.AddPodInfo(podInfo)
 
-	// Maybe consider deleting from the list in the future. Maybe not.
-	data.clearCaches()
+	data.addToPodCaches(ni, podInfo.GetPod())
+	data.pvcNamespaceMap = nil
 	return nil
 }
 
@@ -279,8 +370,9 @@ func (data *internalDeltaSnapshotData) removePod(namespace, name, nodeName strin
 		return fmt.Errorf("pod %s/%s not in snapshot", namespace, name)
 	}
 
-	// Maybe consider deleting from the list in the future. Maybe not.
-	data.clearCaches()
+	data.removeFromPodCaches(ni)
+	data.nodeInfoList = nil
+	data.pvcNamespaceMap = nil
 	return nil
 }
 

--- a/pkg/simulator/clustersnapshot/store/delta.go
+++ b/pkg/simulator/clustersnapshot/store/delta.go
@@ -342,6 +342,8 @@ func (data *internalDeltaSnapshotData) addPodInfo(podInfo schedulerinterface.Pod
 	ni.AddPodInfo(podInfo)
 
 	data.addToPodCaches(ni, podInfo.GetPod())
+	// Invalidate nodeInfoList - keeping it stable makes binpacking scan the full node list for every pod.
+	data.nodeInfoList = nil
 	data.pvcNamespaceMap = nil
 	return nil
 }

--- a/pkg/simulator/clustersnapshot/store/delta_test.go
+++ b/pkg/simulator/clustersnapshot/store/delta_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+func buildCaches(store *DeltaSnapshotStore) {
+	lister := (*deltaSnapshotStoreNodeLister)(store)
+	lister.HavePodsWithAffinityList()
+	lister.HavePodsWithRequiredAntiAffinityList()
+}
+
+func TestPodCacheSurvivesAddWithoutAffinity(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(2)
+	store := NewDeltaSnapshotStore()
+	for _, node := range nodes {
+		require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(node, nil)))
+	}
+
+	buildCaches(store)
+	assert.NotNil(t, store.data.havePodsWithAffinity)
+	assert.NotNil(t, store.data.havePodsWithRequiredAntiAffinity)
+
+	pod := test.BuildTestPod("plain-pod", 100, 100)
+	pod.Spec.NodeName = nodes[0].Name
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod, nil), nodes[0].Name))
+
+	assert.NotNil(t, store.data.havePodsWithAffinity, "cache should not be cleared when adding pod without affinity")
+	assert.NotNil(t, store.data.havePodsWithRequiredAntiAffinity, "cache should not be cleared when adding pod without affinity")
+	assert.Empty(t, store.data.havePodsWithAffinity)
+	assert.Empty(t, store.data.havePodsWithRequiredAntiAffinity)
+}
+
+func TestPodCacheUpdatedOnAffinityPodAdd(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(2)
+	store := NewDeltaSnapshotStore()
+	for _, node := range nodes {
+		require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(node, nil)))
+	}
+
+	buildCaches(store)
+	assert.Empty(t, store.data.havePodsWithAffinity)
+
+	pod := test.BuildTestPod("affinity-pod", 100, 100)
+	pod.Spec.Affinity = &apiv1.Affinity{
+		PodAffinity: &apiv1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+				{TopologyKey: "kubernetes.io/hostname"},
+			},
+		},
+	}
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod, nil), nodes[0].Name))
+
+	assert.NotNil(t, store.data.havePodsWithAffinity)
+	assert.Len(t, store.data.havePodsWithAffinity, 1)
+	assert.Equal(t, nodes[0].Name, store.data.havePodsWithAffinity[0].Node().Name)
+}
+
+func TestPodCacheUpdatedOnRequiredAntiAffinityPodAdd(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(2)
+	store := NewDeltaSnapshotStore()
+	for _, node := range nodes {
+		require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(node, nil)))
+	}
+
+	buildCaches(store)
+	assert.Empty(t, store.data.havePodsWithRequiredAntiAffinity)
+
+	pod := test.BuildTestPod("anti-affinity-pod", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "test"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod, nil), nodes[0].Name))
+
+	assert.NotNil(t, store.data.havePodsWithRequiredAntiAffinity)
+	assert.Len(t, store.data.havePodsWithRequiredAntiAffinity, 1)
+	assert.Equal(t, nodes[0].Name, store.data.havePodsWithRequiredAntiAffinity[0].Node().Name)
+
+	// Should also be in havePodsWithAffinity (PodAntiAffinity counts)
+	assert.Len(t, store.data.havePodsWithAffinity, 1)
+}
+
+func TestPodCacheUpdatedOnPodRemove(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(2)
+	store := NewDeltaSnapshotStore()
+	for _, node := range nodes {
+		require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(node, nil)))
+	}
+
+	pod := test.BuildTestPod("anti-affinity-pod", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "test"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod, nil), nodes[0].Name))
+
+	buildCaches(store)
+	assert.Len(t, store.data.havePodsWithAffinity, 1)
+	assert.Len(t, store.data.havePodsWithRequiredAntiAffinity, 1)
+
+	require.NoError(t, store.RemovePodInfo(pod.Namespace, pod.Name, nodes[0].Name))
+
+	assert.NotNil(t, store.data.havePodsWithAffinity, "cache should not be nil after remove")
+	assert.NotNil(t, store.data.havePodsWithRequiredAntiAffinity, "cache should not be nil after remove")
+	assert.Empty(t, store.data.havePodsWithAffinity)
+	assert.Empty(t, store.data.havePodsWithRequiredAntiAffinity)
+}
+
+func TestPodCacheNotBuiltPrematurely(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(2)
+	store := NewDeltaSnapshotStore()
+	for _, node := range nodes {
+		require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(node, nil)))
+	}
+
+	// Don't build caches - they should be nil
+	assert.Nil(t, store.data.havePodsWithAffinity)
+	assert.Nil(t, store.data.havePodsWithRequiredAntiAffinity)
+
+	pod := test.BuildTestPod("affinity-pod", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "test"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod, nil), nodes[0].Name))
+
+	// Cache should still be nil - not built prematurely
+	assert.Nil(t, store.data.havePodsWithAffinity, "cache should stay nil when not previously built")
+	assert.Nil(t, store.data.havePodsWithRequiredAntiAffinity, "cache should stay nil when not previously built")
+
+	// But when we build it now, it should reflect the added pod
+	buildCaches(store)
+	assert.Len(t, store.data.havePodsWithAffinity, 1)
+	assert.Len(t, store.data.havePodsWithRequiredAntiAffinity, 1)
+}
+
+func TestPodCacheCorrectAfterForkAndAddPod(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(3)
+	store := NewDeltaSnapshotStore()
+	for _, node := range nodes {
+		require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(node, nil)))
+	}
+
+	// Add a pod with affinity to base
+	pod1 := test.BuildTestPod("base-affinity-pod", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "test"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod1, nil), nodes[0].Name))
+	buildCaches(store)
+	assert.Len(t, store.data.havePodsWithAffinity, 1)
+
+	// Fork and add another affinity pod on a different node
+	store.Fork()
+	pod2 := test.BuildTestPod("fork-affinity-pod", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "test2"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod2, nil), nodes[1].Name))
+
+	// The forked layer's cache should reflect both nodes
+	lister := (*deltaSnapshotStoreNodeLister)(store)
+	affinityList, err := lister.HavePodsWithAffinityList()
+	require.NoError(t, err)
+	assert.Len(t, affinityList, 2)
+
+	// Revert and check base is unchanged
+	store.Revert()
+	assert.Len(t, store.data.havePodsWithAffinity, 1)
+	assert.Equal(t, nodes[0].Name, store.data.havePodsWithAffinity[0].Node().Name)
+}
+
+func TestPodCacheNodeNotDuplicatedOnMultipleAdds(t *testing.T) {
+	nodes := clustersnapshot.CreateTestNodes(1)
+	store := NewDeltaSnapshotStore()
+	require.NoError(t, store.StoreNodeInfo(framework.NewNodeInfo(nodes[0], nil)))
+
+	buildCaches(store)
+
+	// Add two affinity pods to the same node
+	pod1 := test.BuildTestPod("affinity-pod-1", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "a"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod1, nil), nodes[0].Name))
+	pod2 := test.BuildTestPod("affinity-pod-2", 100, 100, test.WithPodHostnameAntiAffinity(map[string]string{"app": "b"}))
+	require.NoError(t, store.StorePodInfo(framework.NewPodInfo(pod2, nil), nodes[0].Name))
+
+	assert.Len(t, store.data.havePodsWithAffinity, 1, "node should appear only once even with multiple affinity pods")
+	assert.Len(t, store.data.havePodsWithRequiredAntiAffinity, 1)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Performance improvements for affinity cache. DeltaSnapshotStore no longer clears its affinity-related node caches on every pod add/remove. Instead, it keeps havePodsWithAffinity and havePodsWithRequiredAntiAffinity incrementally up to date, only invalidating pvcNamespaceMap and nodeInfoList when that is actually necessary. It also updates cached NodeInfo references correctly when a base node is snapshotted for mutation.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Migrated from kubernetes/autoscaler#9616 following the Cluster Autoscaler core move to this repository.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
