### PR TITLE
Fix nil-pointer panic in DRA snapshot for untracked pod claims

### DIFF
--- a/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -766,8 +766,8 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 			// Two pods on the same node: podWithClaims owns podOwnedClaim (and references sharedClaim),
 			// and podConsumesOwned references podOwnedClaim directly. Teardown removes the owner's claim
 			// while processing the first pod, so cleanup of the second pod must tolerate the now-missing
-			// reference instead of panicking. podOwnedClaim is reserved for both pods so SetClusterState
-			// accepts the state.
+			// reference instead of panicking. podOwnedClaim is allocated and reserved for both pods to
+			// model the scheduled state.
 			state: snapshotState{
 				nodes:       []*apiv1.Node{node},
 				csiSnapshot: createCSISnapshot(csiNode),

--- a/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -784,7 +784,7 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 				return snapshot.RemoveNodeInfo(node.Name)
 			},
 			// Both pods leave with the node. The pod-owned claim is removed, and the shared claim
-			// stays with the owner's reservation cleared. Before the fix this panics.
+			// stays with the owner's reservation cleared.
 			modifiedState: snapshotState{
 				draSnapshot: drasnapshot.NewSnapshot(
 					map[drasnapshot.ResourceClaimId]*resourceapi.ResourceClaim{

--- a/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
+++ b/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_test.go
@@ -262,6 +262,11 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 	largePod := BuildTestPod("largePod", 999, 999)
 	podWithClaims := BuildTestPod("podWithClaims", 1, 1,
 		WithResourceClaim("claim1", "sharedClaim", ""), WithResourceClaim("claim2", "podOwnedClaim", "podOwnedClaimTemplate"))
+	// podConsumesOwned references podWithClaims' auto-generated podOwnedClaim directly, without
+	// owning it. When both pods are on the same node, teardown removes the owner's claim first, so
+	// cleanup of this pod then finds that reference missing.
+	podConsumesOwned := BuildTestPod("podConsumesOwned", 1, 1,
+		WithResourceClaim("claim1", "podOwnedClaim", ""))
 
 	podOwnedClaim := drautils.TestClaimWithPodOwnership(podWithClaims,
 		&resourceapi.ResourceClaim{
@@ -749,6 +754,37 @@ func validTestCases(t *testing.T, snapshotName string) []modificationTestCase {
 			// LocalResourceSlices for the removed Node should get removed from the DRA snapshot.
 			// The pod-owned claim referenced by a pod from the removed Node should get removed from the DRA snapshot.
 			// The shared claim referenced by a pod from the removed Node should stay in the DRA snapshot, but the pod's reservation should be removed.
+			modifiedState: snapshotState{
+				draSnapshot: drasnapshot.NewSnapshot(
+					map[drasnapshot.ResourceClaimId]*resourceapi.ResourceClaim{
+						drasnapshot.GetClaimId(sharedClaim): drautils.TestClaimWithAllocation(sharedClaim, sharedClaimAlloc),
+					}, nil, nil, deviceClasses),
+			},
+		},
+		{
+			name: "remove nodeInfo where a later pod directly references an earlier pod's owned claim",
+			// Two pods on the same node: podWithClaims owns podOwnedClaim (and references sharedClaim),
+			// and podConsumesOwned references podOwnedClaim directly. Teardown removes the owner's claim
+			// while processing the first pod, so cleanup of the second pod must tolerate the now-missing
+			// reference instead of panicking. podOwnedClaim is reserved for both pods so SetClusterState
+			// accepts the state.
+			state: snapshotState{
+				nodes:       []*apiv1.Node{node},
+				csiSnapshot: createCSISnapshot(csiNode),
+				podsByNode:  map[string][]*apiv1.Pod{node.Name: {withNodeName(podWithClaims, node.Name), withNodeName(podConsumesOwned, node.Name)}},
+				draSnapshot: drasnapshot.NewSnapshot(
+					map[drasnapshot.ResourceClaimId]*resourceapi.ResourceClaim{
+						drasnapshot.GetClaimId(podOwnedClaim): drautils.TestClaimWithPodReservations(drautils.TestClaimWithAllocation(podOwnedClaim, podOwnedClaimAlloc), podWithClaims, podConsumesOwned),
+						drasnapshot.GetClaimId(sharedClaim):   drautils.TestClaimWithPodReservations(drautils.TestClaimWithAllocation(sharedClaim, sharedClaimAlloc), podWithClaims),
+					},
+					map[string][]*resourceapi.ResourceSlice{node.Name: resourceSlices},
+					nil, deviceClasses),
+			},
+			op: func(snapshot clustersnapshot.ClusterSnapshot) error {
+				return snapshot.RemoveNodeInfo(node.Name)
+			},
+			// Both pods leave with the node. The pod-owned claim is removed, and the shared claim
+			// stays with the owner's reservation cleared. Before the fix this panics.
 			modifiedState: snapshotState{
 				draSnapshot: drasnapshot.NewSnapshot(
 					map[drasnapshot.ResourceClaimId]*resourceapi.ResourceClaim{

--- a/pkg/simulator/dynamicresources/snapshot/snapshot.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot.go
@@ -313,8 +313,8 @@ func (s *Snapshot) findPodClaims(pod *apiv1.Pod, ignoreNotTracked bool) ([]*reso
 		return nil, nil
 	}
 
-	result := make([]*resourceapi.ResourceClaim, len(pod.Spec.ResourceClaims))
-	for claimIndex, claimRef := range pod.Spec.ResourceClaims {
+	result := make([]*resourceapi.ResourceClaim, 0, len(pod.Spec.ResourceClaims))
+	for _, claimRef := range pod.Spec.ResourceClaims {
 		claimName := claimRefToName(pod, claimRef)
 		if claimName == "" {
 			if !ignoreNotTracked {
@@ -344,7 +344,7 @@ func (s *Snapshot) findPodClaims(pod *apiv1.Pod, ignoreNotTracked bool) ([]*reso
 			continue
 		}
 
-		result[claimIndex] = claim
+		result = append(result, claim)
 	}
 
 	return result, nil

--- a/pkg/simulator/dynamicresources/snapshot/snapshot.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot.go
@@ -307,7 +307,8 @@ func (s *Snapshot) getDeviceClass(className string) (*resourceapi.DeviceClass, b
 }
 
 // findPodClaims retrieves all ResourceClaim objects referenced by a given pod.
-// If ignoreNotTracked is true, it skips claims not found in the snapshot; otherwise, it returns an error.
+// If ignoreNotTracked is true, claims whose names cannot be resolved or which aren't tracked in the
+// snapshot are skipped; otherwise, an error is returned.
 func (s *Snapshot) findPodClaims(pod *apiv1.Pod, ignoreNotTracked bool) ([]*resourceapi.ResourceClaim, error) {
 	if len(pod.Spec.ResourceClaims) == 0 {
 		return nil, nil

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -75,6 +75,24 @@ var (
 	deviceClass2 = &resourceapi.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "class2", UID: "class2-uid"}}
 )
 
+// TestRemovePodOwnedClaimsMissingClaimNoPanic verifies that RemovePodOwnedClaims does not panic
+// when a Pod references a ResourceClaim that is not present in the snapshot. findPodClaims is
+// called with ignoreNotTracked=true on the RemovePodOwnedClaims path, so an untracked claim must
+// be skipped rather than returned as a nil entry that a later GetClaimId() dereference panics on.
+func TestRemovePodOwnedClaimsMissingClaimNoPanic(t *testing.T) {
+	// pod1 references pod1OwnClaim1 and pod1OwnClaim2; leave pod1OwnClaim2 out of the snapshot so
+	// that findPodClaims(pod1, true) encounters an untracked claim.
+	claims := map[ResourceClaimId]*resourceapi.ResourceClaim{
+		GetClaimId(sharedClaim1):  sharedClaim1.DeepCopy(),
+		GetClaimId(sharedClaim2):  sharedClaim2.DeepCopy(),
+		GetClaimId(pod1OwnClaim1): pod1OwnClaim1.DeepCopy(),
+	}
+	snapshot := NewSnapshot(claims, nil, nil, nil)
+
+	// Before the fix this panics with a nil-pointer dereference in GetClaimId().
+	snapshot.RemovePodOwnedClaims(pod1)
+}
+
 func TestSnapshotResourceClaims(t *testing.T) {
 	pod1NoClaimsInStatus := pod1.DeepCopy()
 	pod1NoClaimsInStatus.Status.ResourceClaimStatuses = nil

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -75,24 +75,6 @@ var (
 	deviceClass2 = &resourceapi.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "class2", UID: "class2-uid"}}
 )
 
-// TestRemovePodOwnedClaimsMissingClaimNoPanic verifies that RemovePodOwnedClaims does not panic
-// when a Pod references a ResourceClaim that is not present in the snapshot. findPodClaims is
-// called with ignoreNotTracked=true on the RemovePodOwnedClaims path, so an untracked claim must
-// be skipped rather than returned as a nil entry that a later GetClaimId() dereference panics on.
-func TestRemovePodOwnedClaimsMissingClaimNoPanic(t *testing.T) {
-	// pod1 references pod1OwnClaim1 and pod1OwnClaim2; leave pod1OwnClaim2 out of the snapshot so
-	// that findPodClaims(pod1, true) encounters an untracked claim.
-	claims := map[ResourceClaimId]*resourceapi.ResourceClaim{
-		GetClaimId(sharedClaim1):  sharedClaim1.DeepCopy(),
-		GetClaimId(sharedClaim2):  sharedClaim2.DeepCopy(),
-		GetClaimId(pod1OwnClaim1): pod1OwnClaim1.DeepCopy(),
-	}
-	snapshot := NewSnapshot(claims, nil, nil, nil)
-
-	// Before the fix this panics with a nil-pointer dereference in GetClaimId().
-	snapshot.RemovePodOwnedClaims(pod1)
-}
-
 func TestSnapshotResourceClaims(t *testing.T) {
 	pod1NoClaimsInStatus := pod1.DeepCopy()
 	pod1NoClaimsInStatus.Status.ResourceClaimStatuses = nil
@@ -223,6 +205,47 @@ func TestSnapshotResourceClaims(t *testing.T) {
 				sharedClaim2, // pod1 reservation removed
 				drautils.TestClaimWithPodReservations(sharedClaim3, pod2), // unchanged
 				pod2OwnClaim1, // unchanged
+			},
+		},
+		{
+			// pod1OwnClaim2 is absent from the snapshot, so findPodClaims skips it on the lenient
+			// path. Cleanup must still remove pod1OwnClaim1 and reach the shared claims that follow
+			// the skipped reference, clearing pod1's reservations there.
+			testName: "RemovePodOwnedClaims(): skips a claim missing from the snapshot and keeps cleaning up",
+			claims: map[ResourceClaimId]*resourceapi.ResourceClaim{
+				GetClaimId(pod1OwnClaim1): pod1OwnClaim1.DeepCopy(),
+				GetClaimId(sharedClaim1):  drautils.TestClaimWithPodReservations(sharedClaim1, pod1),
+				GetClaimId(sharedClaim2):  drautils.TestClaimWithPodReservations(sharedClaim2, pod1),
+			},
+			claimsModFun: func(snapshot *Snapshot) error {
+				snapshot.RemovePodOwnedClaims(pod1)
+				return nil
+			},
+			pod:              pod1,
+			wantPodClaimsErr: cmpopts.AnyError,
+			wantAllClaims: []*resourceapi.ResourceClaim{
+				sharedClaim1, // pod1 reservation removed
+				sharedClaim2, // pod1 reservation removed
+			},
+		},
+		{
+			// pod1's own claims are template-backed and resolve to an empty name once the status is
+			// gone, so findPodClaims skips them on the lenient path. Cleanup must still reach the
+			// directly referenced shared claims that follow, clearing pod1's reservations.
+			testName: "RemovePodOwnedClaims(): skips a claim with an unresolved template name and keeps cleaning up",
+			claims: map[ResourceClaimId]*resourceapi.ResourceClaim{
+				GetClaimId(sharedClaim1): drautils.TestClaimWithPodReservations(sharedClaim1, pod1NoClaimsInStatus),
+				GetClaimId(sharedClaim2): drautils.TestClaimWithPodReservations(sharedClaim2, pod1NoClaimsInStatus),
+			},
+			claimsModFun: func(snapshot *Snapshot) error {
+				snapshot.RemovePodOwnedClaims(pod1NoClaimsInStatus)
+				return nil
+			},
+			pod:              pod1NoClaimsInStatus,
+			wantPodClaimsErr: cmpopts.AnyError,
+			wantAllClaims: []*resourceapi.ResourceClaim{
+				sharedClaim1, // pod1 reservation removed
+				sharedClaim2, // pod1 reservation removed
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`findPodClaims` in the DRA cluster snapshot builds its result slice sized to the number of the Pod's claim references and fills it by index. On the lenient path (`ignoreNotTracked == true`) a claim that has no resolved name, or that is not tracked in the snapshot, is skipped with `continue`, which leaves a `nil` hole at that index. `RemovePodOwnedClaims` is the only caller that uses that path, and it ranges over the returned slice calling `GetClaimId(claim)` on every element. The `nil` hole makes `GetClaimId` dereference a nil `*ResourceClaim`, and the autoscaler panics.

That contradicts the method's own contract: *"This method removes all relevant claims that are in the snapshot, and doesn't error out if any of the claims are missing."* A missing claim is meant to be skipped, not to crash the process.

It is reachable during node teardown. `RemoveNodeInfo` iterates the pods of the node being removed and calls `RemovePodOwnedClaims` for each. When an earlier Pod on the node owns an auto-generated ResourceClaim and a later Pod on the same node references that claim directly, cleanup of the owner removes the claim, so cleanup of the later Pod then finds the reference missing, which is enough to take the autoscaler loop down when CA runs with DRA enabled. Kubernetes permits a direct reference to an auto-generated claim, although it is discouraged because the claim's lifetime stays tied to the owner Pod.

The fix builds the result with a zero-length slice and `append`, so only claims that are actually found are added and there are no `nil` entries:

```go
result := make([]*resourceapi.ResourceClaim, 0, len(pod.Spec.ResourceClaims))
...
result = append(result, claim)
```

The strict callers (`PodClaims`, `ReservePodClaims`, `UnreservePodClaims`, all `ignoreNotTracked == false`) see no change. On that path any missing claim returns early with an error, and when nothing is missing every claim is appended in iteration order, so the returned slice has the same length and order as the old index-filled one. Only the lenient `RemovePodOwnedClaims` path is affected, and it drops the `nil` holes it was never supposed to produce. The consumers of the exported `PodClaims` bear this out: each checks the error first, then either ranges over the slice ([`verifyScheduledPodResourceClaims`](https://github.com/kubernetes-sigs/cluster-autoscaler/blob/ea003e7e16b46d005fb8c13ee24c95b857d2b469/pkg/simulator/clustersnapshot/predicate/predicate_snapshot.go#L449)) or hands it whole to `framework.NewPodInfo`; none index it positionally.

#### Which issue(s) this PR fixes:

Fixes #31

Related: #22

#### Special notes for your reviewer:

The regression tests fail on the current code with `panic: ... nil pointer dereference ... GetClaimId` and pass with the fix. They drive the real `RemovePodOwnedClaims` path with a snapshot missing one of the Pod's referenced claims, assert the final claim state, and check that cleanup still reaches the claims after the skipped reference. One case covers a claim absent from the snapshot, the other an unresolved template name, so both `continue` branches in `findPodClaims` are exercised.

A `PredicateSnapshot`-level case also covers the concrete `RemoveNodeInfo` owner/direct-consumer teardown sequence from #31, and runs through the existing basic and delta snapshot stores with their fork, commit, and revert variants.

#22 currently carries the same `findPodClaims` change as part of its larger ResourceClaimTemplate work. Whichever lands first, the other can drop the overlapping hunk. I am happy to defer to whatever ordering you prefer, or to close this in favor of #22.

I verified `main` only. The same fixed-length implementation exists on the release-1.33 through release-1.36 branches; branch tests were not run, so backport eligibility and workflow are your call.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a nil-pointer panic in cluster-autoscaler's DRA snapshot when removing a node whose Pod references a ResourceClaim that another Pod's cleanup had already removed from the snapshot. Node removal now skips the missing claim instead of crashing the autoscaler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


