### PR TITLE
[metric]: implement per node group node count metric

### DIFF
--- a/pkg/clusterstate/clusterstate.go
+++ b/pkg/clusterstate/clusterstate.go
@@ -1403,6 +1403,7 @@ func (csr *ClusterStateRegistry) GetScaleUpFailures() map[string][]scaleupfailur
 	return csr.scaleUpFailures.Get()
 }
 
+// GetPerNodeGroupReadiness returns the perNodeGroupReadiness map.
 func (csr *ClusterStateRegistry) GetPerNodeGroupReadiness() map[string]Readiness {
 	return csr.perNodeGroupReadiness
 }

--- a/pkg/clusterstate/clusterstate.go
+++ b/pkg/clusterstate/clusterstate.go
@@ -435,6 +435,7 @@ func (csr *ClusterStateRegistry) UpdateNodes(nodes []*apiv1.Node, currentTime ti
 		currentTime,
 		targetSizes,
 	)
+
 	return nil
 }
 
@@ -1400,6 +1401,10 @@ func FakeNode(instance cloudprovider.Instance, reason string) *apiv1.Node {
 // GetScaleUpFailures returns the scale-up failures map.
 func (csr *ClusterStateRegistry) GetScaleUpFailures() map[string][]scaleupfailures.Record {
 	return csr.scaleUpFailures.Get()
+}
+
+func (csr *ClusterStateRegistry) GetPerNodeGroupReadiness() map[string]Readiness {
+	return csr.perNodeGroupReadiness
 }
 
 func truncateIfExceedMaxLength(s string, maxLength int) string {

--- a/pkg/core/utils/utils.go
+++ b/pkg/core/utils/utils.go
@@ -115,7 +115,12 @@ func UpdateClusterStateMetrics(csr *clusterstate.ClusterStateRegistry) {
 	}
 	metrics.UpdateClusterSafeToAutoscale(csr.IsClusterHealthy())
 	readiness := csr.GetClusterReadiness()
+
 	metrics.UpdateNodesCount(len(readiness.Ready), len(readiness.Unready), len(readiness.NotStarted), len(readiness.Suspended), len(readiness.LongUnregistered), len(readiness.Unregistered))
+
+	for nodeGroupID, readiness := range csr.GetPerNodeGroupReadiness() {
+		metrics.UpdateNodesCountPerNodeGroup(len(readiness.Ready), len(readiness.Unready), len(readiness.NotStarted), len(readiness.Suspended), len(readiness.LongUnregistered), len(readiness.Unregistered), nodeGroupID)
+	}
 }
 
 // GetOldestCreateTime returns oldest creation time out of the pods in the set

--- a/pkg/metrics/legacy_functions.go
+++ b/pkg/metrics/legacy_functions.go
@@ -263,6 +263,7 @@ func UpdateSkippedPodsCount(podsCount int, label string) {
 	DefaultMetrics.UpdateSkippedPodsCount(podsCount, label)
 }
 
+// UpdateNodesCountPerNodeGroup records the number of nodes per node group ID in cluster.
 func UpdateNodesCountPerNodeGroup(ready, unready, starting, suspended, longUnregistered, unregistered int, nodeGroupID string) {
 	DefaultMetrics.UpdateNodesCountPerNodeGroup(ready, unready, starting, suspended, longUnregistered, unregistered, nodeGroupID)
 }

--- a/pkg/metrics/legacy_functions.go
+++ b/pkg/metrics/legacy_functions.go
@@ -262,3 +262,7 @@ func ObserveMaxNodeSkipEvalDurationSeconds(duration time.Duration) {
 func UpdateSkippedPodsCount(podsCount int, label string) {
 	DefaultMetrics.UpdateSkippedPodsCount(podsCount, label)
 }
+
+func UpdateNodesCountPerNodeGroup(ready, unready, starting, suspended, longUnregistered, unregistered int, nodeGroupID string) {
+	DefaultMetrics.UpdateNodesCountPerNodeGroup(ready, unready, starting, suspended, longUnregistered, unregistered, nodeGroupID)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -58,6 +58,8 @@ const (
 	unregisteredLabel     = "unregistered"
 	longUnregisteredLabel = "longUnregistered"
 
+	nodeGroupIDLabel = "node_group_id"
+
 	// Underutilized node was removed because of low utilization
 	Underutilized NodeScaleDownReason = "underutilized"
 	// Empty node was removed
@@ -159,6 +161,7 @@ type caMetrics struct {
 	nodesGroupHealthiness  *k8smetrics.GaugeVec
 	nodeGroupBackOffStatus *k8smetrics.GaugeVec
 	skippedPodsCounts      *k8smetrics.GaugeVec
+	nodesCountPerNodeGroup *k8smetrics.GaugeVec
 
 	// Metrics related to autoscaler execution
 	lastActivity            *k8smetrics.GaugeVec
@@ -308,6 +311,14 @@ func newCaMetrics() *caMetrics {
 				Name:      "node_group_backoff_status",
 				Help:      "Whether or not node group is backoff for not autoscaling. 1 if it is, 0 otherwise.",
 			}, []string{"node_group", "reason"},
+		),
+
+		nodesCountPerNodeGroup: k8smetrics.NewGaugeVec(
+			&k8smetrics.GaugeOpts{
+				Namespace: caNamespace,
+				Name:      "nodes_count_per_node_group",
+				Help:      "Number of nodes per node groups in cluster.",
+			}, []string{"state", "node_group"},
 		),
 
 		/**** Metrics related to autoscaler execution ****/
@@ -604,6 +615,7 @@ func (m *caMetrics) RegisterAll(emitPerNodeGroupMetrics bool) {
 		m.mustRegister(m.nodesGroupTargetSize)
 		m.mustRegister(m.nodesGroupHealthiness)
 		m.mustRegister(m.nodeGroupBackOffStatus)
+		m.mustRegister(m.nodesCountPerNodeGroup)
 	}
 }
 
@@ -936,4 +948,14 @@ func (m *caMetrics) ObserveMaxNodeSkipEvalDurationSeconds(duration time.Duration
 // UpdateSkippedPodsCount records the number of pods skipped when doing scheduling simulations.
 func (m *caMetrics) UpdateSkippedPodsCount(podsCount int, label string) {
 	m.skippedPodsCounts.WithLabelValues(label).Set(float64(podsCount))
+}
+
+// UpdateNodesPerNodeGroupCount records the number of nodes per node group in cluster
+func (m *caMetrics) UpdateNodesCountPerNodeGroup(ready, unready, starting, suspended, longUnregistered, unregistered int, nodeGroupID string) {
+	m.nodesCountPerNodeGroup.WithLabelValues(readyLabel, nodeGroupID).Set(float64(ready))
+	m.nodesCountPerNodeGroup.WithLabelValues(unreadyLabel, nodeGroupID).Set(float64(unready))
+	m.nodesCountPerNodeGroup.WithLabelValues(startingLabel, nodeGroupID).Set(float64(starting))
+	m.nodesCountPerNodeGroup.WithLabelValues(suspendedLabel, nodeGroupID).Set(float64(suspended))
+	m.nodesCountPerNodeGroup.WithLabelValues(longUnregisteredLabel, nodeGroupID).Set(float64(longUnregistered))
+	m.nodesCountPerNodeGroup.WithLabelValues(unregisteredLabel, nodeGroupID).Set(float64(unregistered))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -107,3 +107,20 @@ func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	assert.Equal(t, uint64(1), metric2.Histogram.GetSampleCount())
 	assert.Equal(t, 20.0, metric2.Histogram.GetSampleSum())
 }
+
+func TestUpdateNodesCountPerNodeGroup(t *testing.T) {
+	reg := metrics.NewKubeRegistry()
+	m := newCaMetricsWithRegistry(reg)
+	m.RegisterAll(true)
+
+	nodeGroupID := "node-group-id"
+
+	m.UpdateNodesCountPerNodeGroup(1, 2, 3, 4, 5, 6, nodeGroupID)
+
+	assert.Equal(t, 1, int(testutil.ToFloat64(m.nodesCountPerNodeGroup.GaugeVec.WithLabelValues(readyLabel, nodeGroupID))))
+	assert.Equal(t, 2, int(testutil.ToFloat64(m.nodesCountPerNodeGroup.GaugeVec.WithLabelValues(unreadyLabel, nodeGroupID))))
+	assert.Equal(t, 3, int(testutil.ToFloat64(m.nodesCountPerNodeGroup.GaugeVec.WithLabelValues(startingLabel, nodeGroupID))))
+	assert.Equal(t, 4, int(testutil.ToFloat64(m.nodesCountPerNodeGroup.GaugeVec.WithLabelValues(suspendedLabel, nodeGroupID))))
+	assert.Equal(t, 5, int(testutil.ToFloat64(m.nodesCountPerNodeGroup.GaugeVec.WithLabelValues(longUnregisteredLabel, nodeGroupID))))
+	assert.Equal(t, 6, int(testutil.ToFloat64(m.nodesCountPerNodeGroup.GaugeVec.WithLabelValues(unregisteredLabel, nodeGroupID))))
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Introduce new metric requested by one of the users as POC. If we want to introduce any other metric, feel free to comment here and I can work on this

#### Which issue(s) this PR fixes:
Fixes [#5850](https://github.com/kubernetes/autoscaler/issues/5850) from the old repo

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
a new metric will be created if the flag `emit-per-nodegroup-metrics` is true. The metric `cluster_autoscaler_nodes_count_per_node_group` it has the following labels: 
- node_group=<nodegroup-name>
- state=<node_state>

```

This is how the metric will look like: 
```bash
# TYPE cluster_autoscaler_nodes_count_per_node_group gauge
cluster_autoscaler_nodes_count_per_node_group{node_group="<nodegroup-name>",state="longUnregistered"} 0
cluster_autoscaler_nodes_count_per_node_group{node_group="<nodegroup-name>",state="notStarted"} 0
cluster_autoscaler_nodes_count_per_node_group{node_group="<nodegroup-name>",state="ready"} 4
cluster_autoscaler_nodes_count_per_node_group{node_group="<nodegroup-name>",state="suspended"} 0
cluster_autoscaler_nodes_count_per_node_group{node_group="<nodegroup-name>",state="unready"} 0
cluster_autoscaler_nodes_count_per_node_group{node_group="<nodegroup-name>",state="unregistered"} 0
```
