### PR TITLE
[feature]: DeleteNodes in batches instead of one by one

### DIFF
--- a/pkg/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_controller.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -793,7 +794,7 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 	return providerIDs, nil
 }
 
-func (c *machineController) nodeGroups() ([]cloudprovider.NodeGroup, error) {
+func (c *machineController) nodeGroups(nodeDeletionBatcherInterval time.Duration) ([]cloudprovider.NodeGroup, error) {
 	scalableResources, err := c.listScalableResources()
 	if err != nil {
 		return nil, err
@@ -802,7 +803,7 @@ func (c *machineController) nodeGroups() ([]cloudprovider.NodeGroup, error) {
 	nodegroups := make([]cloudprovider.NodeGroup, 0, len(scalableResources))
 
 	for _, r := range scalableResources {
-		ng, err := newNodeGroupFromScalableResource(c, r)
+		ng, err := newNodeGroupFromScalableResource(c, r, nodeDeletionBatcherInterval)
 		if err != nil {
 			return nil, err
 		}
@@ -822,7 +823,7 @@ func (c *machineController) nodeGroups() ([]cloudprovider.NodeGroup, error) {
 	return nodegroups, nil
 }
 
-func (c *machineController) nodeGroupForNode(node *corev1.Node) (*nodegroup, error) {
+func (c *machineController) nodeGroupForNode(node *corev1.Node, nodeDeletionBatcherInterval time.Duration) (*nodegroup, error) {
 	scalableResource, err := c.findScalableResourceByProviderID(normalizedProviderString(node.Spec.ProviderID))
 	if err != nil {
 		return nil, err
@@ -838,7 +839,7 @@ func (c *machineController) nodeGroupForNode(node *corev1.Node) (*nodegroup, err
 		return nil, nil
 	}
 
-	nodegroup, err := newNodeGroupFromScalableResource(c, scalableResource)
+	nodegroup, err := newNodeGroupFromScalableResource(c, scalableResource, nodeDeletionBatcherInterval)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build nodegroup for node %q: %v", node.Name, err)
 	}

--- a/pkg/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -418,7 +418,7 @@ func TestControllerLookupNodeGroupForNonExistentNode(t *testing.T) {
 		node := testConfig.nodes[0].DeepCopy()
 		node.Spec.ProviderID = "does-not-exist"
 
-		ng, err := controller.nodeGroupForNode(node)
+		ng, err := controller.nodeGroupForNode(node, defaultNodeDeletionBatcherInterval)
 
 		// Looking up a node that doesn't exist doesn't generate an
 		// error. But, equally, the ng should actually be nil.
@@ -469,7 +469,7 @@ func TestControllerNodeGroupForNodeWithMissingMachineOwner(t *testing.T) {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 
-		ng, err := controller.nodeGroupForNode(testConfig.nodes[0])
+		ng, err := controller.nodeGroupForNode(testConfig.nodes[0], defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -525,7 +525,7 @@ func TestControllerNodeGroupForNodeWithMissingSetMachineOwner(t *testing.T) {
 		t.Fatalf("unexpected error updating machine, got %v", err)
 	}
 
-	ng, err := controller.nodeGroupForNode(testConfig.nodes[0])
+	ng, err := controller.nodeGroupForNode(testConfig.nodes[0], defaultNodeDeletionBatcherInterval)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -541,7 +541,7 @@ func TestControllerNodeGroupForNodeWithPositiveScalingBounds(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		ng, err := controller.nodeGroupForNode(testConfig.nodes[0])
+		ng, err := controller.nodeGroupForNode(testConfig.nodes[0], defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -579,7 +579,7 @@ func TestControllerNodeGroupForNodeWithPositiveScalingBounds(t *testing.T) {
 func TestControllerNodeGroups(t *testing.T) {
 	assertNodegroupLen := func(t *testing.T, controller *testMachineController, expected int) {
 		t.Helper()
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -687,7 +687,7 @@ func TestControllerNodeGroups(t *testing.T) {
 	if err := controller.AddTestConfigs(machineSetConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := controller.nodeGroups(); err == nil {
+	if _, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval); err == nil {
 		t.Fatalf("expected an error")
 	}
 
@@ -702,7 +702,7 @@ func TestControllerNodeGroups(t *testing.T) {
 	if err := controller.AddTestConfigs(machineDeploymentConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := controller.nodeGroups(); err == nil {
+	if _, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval); err == nil {
 		t.Fatalf("expected an error")
 	}
 }
@@ -737,7 +737,7 @@ func TestControllerNodeGroupsNodeCount(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfigs...)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -863,7 +863,7 @@ func TestControllerMachineSetNodeNamesWithoutLinkage(t *testing.T) {
 		}
 	}
 
-	nodegroups, err := controller.nodeGroups()
+	nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -905,7 +905,7 @@ func TestControllerMachineSetNodeNamesUsingProviderID(t *testing.T) {
 	defer controller.Stop()
 	controller.AddTestConfigs(testConfig)
 
-	nodegroups, err := controller.nodeGroups()
+	nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -962,7 +962,7 @@ func TestControllerMachineSetNodeNamesUsingStatusNodeRefName(t *testing.T) {
 		}
 	}
 
-	nodegroups, err := controller.nodeGroups()
+	nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1654,7 +1654,7 @@ func Test_machineController_nodeGroupForNode(t *testing.T) {
 			c.AddTestConfigs(allTestConfigs...)
 			c.autoDiscoverySpecs = tc.autoDiscoverySpecs
 
-			got, err := c.nodeGroupForNode(tc.node)
+			got, err := c.nodeGroupForNode(tc.node, defaultNodeDeletionBatcherInterval)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("nodeGroupForNode() error = %v, wantErr %v", err, tc.wantErr)
 				return
@@ -1793,7 +1793,7 @@ func Test_machineController_nodeGroups(t *testing.T) {
 			c.AddTestConfigs(allTestConfigs...)
 			c.autoDiscoverySpecs = tc.autoDiscoverySpecs
 
-			got, err := c.nodeGroups()
+			got, err := c.nodeGroups(defaultNodeDeletionBatcherInterval)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("nodeGroups() error = %v, wantErr %v", err, tc.wantErr)
 				return

--- a/pkg/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -46,8 +46,9 @@ const (
 )
 
 type nodegroup struct {
-	machineController *machineController
-	scalableResource  *unstructuredScalableResource
+	machineController           *machineController
+	scalableResource            *unstructuredScalableResource
+	nodeDeletionBatcherInterval time.Duration
 }
 
 var _ cloudprovider.NodeGroup = (*nodegroup)(nil)
@@ -118,7 +119,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 
 	// Step 1: Verify all nodes belong to this node group.
 	for _, node := range nodes {
-		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node)
+		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node, ng.nodeDeletionBatcherInterval)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				klog.Warningf("Node group not found for node %q, skipping verification: %v", node.Spec.ProviderID, err)
@@ -147,7 +148,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// if no per-node Machine can be resolved, fall back to replica decrement
 	// after verifying the node belongs to the MachinePool providerID list.
 	for _, node := range nodes {
-		nodeGroup, err := ng.machineController.nodeGroupForNode(node)
+		nodeGroup, err := ng.machineController.nodeGroupForNode(node, ng.nodeDeletionBatcherInterval)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				klog.Warningf("Node group not found for node %q, skipping deletion: %v", node.Spec.ProviderID, err)
@@ -586,7 +587,7 @@ func (ng *nodegroup) IsMachineDeploymentAndRollingOut() (bool, error) {
 	return false, nil
 }
 
-func newNodeGroupFromScalableResource(controller *machineController, unstructuredScalableResource *unstructured.Unstructured) (*nodegroup, error) {
+func newNodeGroupFromScalableResource(controller *machineController, unstructuredScalableResource *unstructured.Unstructured, nodeDeletionBatcherInterval time.Duration) (*nodegroup, error) {
 	// Ensure that the resulting node group would be allowed based on the autodiscovery specs if defined
 	if !controller.allowedByAutoDiscoverySpecs(unstructuredScalableResource) {
 		return nil, nil
@@ -619,8 +620,9 @@ func newNodeGroupFromScalableResource(controller *machineController, unstructure
 	}
 
 	return &nodegroup{
-		machineController: controller,
-		scalableResource:  scalableResource,
+		machineController:           controller,
+		scalableResource:            scalableResource,
+		nodeDeletionBatcherInterval: nodeDeletionBatcherInterval,
 	}, nil
 }
 

--- a/pkg/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -99,6 +99,11 @@ func (ng *nodegroup) AtomicIncreaseSize(delta int) error {
 	return cloudprovider.ErrNotImplemented
 }
 
+type markedForDeletion struct {
+	nodegroup *nodegroup
+	machine   *unstructured.Unstructured
+}
+
 // DeleteNodes deletes nodes from this node group. Error is returned
 // either on failure or if the given node doesn't belong to this node
 // group. This function should wait until node group size is updated.
@@ -147,6 +152,8 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// and decrease the replica count by 1. For MachinePool-backed node groups,
 	// if no per-node Machine can be resolved, fall back to replica decrement
 	// after verifying the node belongs to the MachinePool providerID list.
+	toDelete := make([]markedForDeletion, 0, len(nodes))
+
 	for _, node := range nodes {
 		nodeGroup, err := ng.machineController.nodeGroupForNode(node, ng.nodeDeletionBatcherInterval)
 		if err != nil {
@@ -210,8 +217,26 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 			return err
 		}
 
-		if err := nodeGroup.scalableResource.SetSize(replicas - 1); err != nil {
-			_ = nodeGroup.scalableResource.UnmarkMachineForDeletion(machine)
+		toDelete = append(toDelete, markedForDeletion{
+			nodegroup: nodeGroup,
+			machine:   machine,
+		})
+	}
+
+	if ng.nodeDeletionBatcherInterval != 0 {
+		if err := ng.scalableResource.SetSize(replicas - len(toDelete)); err != nil {
+			for _, deletion := range toDelete {
+				_ = deletion.nodegroup.scalableResource.UnmarkMachineForDeletion(deletion.machine)
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	for _, deletion := range toDelete {
+		if err := ng.scalableResource.SetSize(replicas - 1); err != nil {
+			_ = deletion.nodegroup.scalableResource.UnmarkMachineForDeletion(deletion.machine)
 			return err
 		}
 

--- a/pkg/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -39,6 +39,10 @@ import (
 	gpuapis "sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
 )
 
+var (
+	defaultNodeDeletionBatcherInterval = 0 * time.Second
+)
+
 const (
 	testNamespace = "test-namespace"
 )
@@ -128,9 +132,9 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 
 	newNodeGroup := func(controller *testMachineController, testConfig *TestConfig) (*nodegroup, error) {
 		if testConfig.machineDeployment != nil {
-			return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineDeployment)
+			return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineDeployment, defaultNodeDeletionBatcherInterval)
 		}
-		return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineSet)
+		return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineSet, defaultNodeDeletionBatcherInterval)
 	}
 
 	test := func(t *testing.T, tc testCase, testConfig *TestConfig) {
@@ -267,7 +271,7 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -365,7 +369,7 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -529,7 +533,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			}
 		}
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -562,7 +566,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			if u.GetResourceVersion() != scalableResource.GetResourceVersion() {
 				return false, nil
 			}
-			ng, err := newNodeGroupFromScalableResource(controller.machineController, u)
+			ng, err := newNodeGroupFromScalableResource(controller.machineController, u, defaultNodeDeletionBatcherInterval)
 			if err != nil {
 				return true, fmt.Errorf("unexpected error: %v", err)
 			}
@@ -773,7 +777,7 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -861,7 +865,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -958,7 +962,7 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfigs...)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -966,12 +970,12 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 			t.Fatalf("expected %d, got %d", expected, l)
 		}
 
-		ng0, err := controller.nodeGroupForNode(testConfig0.nodes[0])
+		ng0, err := controller.nodeGroupForNode(testConfig0.nodes[0], defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		ng1, err := controller.nodeGroupForNode(testConfig1.nodes[0])
+		ng1, err := controller.nodeGroupForNode(testConfig1.nodes[0], defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1089,7 +1093,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1154,7 +1158,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 		deadlineCtx, deadlineFn := context.WithTimeout(context.Background(), 5*time.Second)
 		defer deadlineFn()
 		if err := wait.PollUntilContextTimeout(deadlineCtx, 100*time.Millisecond, 5*time.Second, true, func(_ context.Context) (bool, error) {
-			nodegroups, err = controller.nodeGroups()
+			nodegroups, err = controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 			if err != nil {
 				return false, err
 			}
@@ -1167,7 +1171,7 @@ func TestNodeGroupDeleteNodesTwice(t *testing.T) {
 			t.Fatalf("unexpected error waiting for nodegroup to be expected size: %v", err)
 		}
 
-		nodegroups, err = controller.nodeGroups()
+		nodegroups, err = controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1260,7 +1264,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1317,7 +1321,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 		nodeToNodeGroup := make(map[*corev1.Node]*nodegroup)
 
 		for _, node := range nodesToBeDeleted {
-			nodeGroup, err := controller.nodeGroupForNode(node)
+			nodeGroup, err := controller.nodeGroupForNode(node, defaultNodeDeletionBatcherInterval)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1330,7 +1334,7 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 			}
 		}
 
-		nodegroups, err = controller.nodeGroups()
+		nodegroups, err = controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1414,7 +1418,7 @@ func TestNodeGroupWithFailedMachine(t *testing.T) {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1770,7 +1774,7 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1961,7 +1965,7 @@ func TestNodeGroupGetOptions(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2121,7 +2125,7 @@ func TestNodeGroupNodesInstancesStatus(t *testing.T) {
 			}
 		}
 
-		nodegroups, err := controller.nodeGroups()
+		nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -49,14 +49,15 @@ const (
 
 func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 	type testCase struct {
-		description string
-		annotations map[string]string
-		errors      bool
-		replicas    int32
-		minSize     int
-		maxSize     int
-		nodeCount   int
-		expectNil   bool
+		description                 string
+		annotations                 map[string]string
+		errors                      bool
+		replicas                    int32
+		minSize                     int
+		maxSize                     int
+		nodeCount                   int
+		expectNil                   bool
+		nodeDeletionBatcherInterval time.Duration
 	}
 
 	var testCases = []testCase{{
@@ -128,13 +129,24 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 		replicas:  1,
 		errors:    false,
 		expectNil: false,
+	}, {
+		description: "no error: min=0, max=1, nodeDeletionBatcherInterval is set",
+		annotations: map[string]string{
+			nodeGroupMaxSizeAnnotationKey: "1",
+		},
+		minSize:                     0,
+		maxSize:                     1,
+		replicas:                    0,
+		errors:                      false,
+		expectNil:                   true,
+		nodeDeletionBatcherInterval: 1 * time.Second,
 	}}
 
-	newNodeGroup := func(controller *testMachineController, testConfig *TestConfig) (*nodegroup, error) {
+	newNodeGroup := func(controller *testMachineController, testConfig *TestConfig, nodeDeletionBatcherInterval time.Duration) (*nodegroup, error) {
 		if testConfig.machineDeployment != nil {
-			return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineDeployment, defaultNodeDeletionBatcherInterval)
+			return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineDeployment, nodeDeletionBatcherInterval)
 		}
-		return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineSet, defaultNodeDeletionBatcherInterval)
+		return newNodeGroupFromScalableResource(controller.machineController, testConfig.machineSet, nodeDeletionBatcherInterval)
 	}
 
 	test := func(t *testing.T, tc testCase, testConfig *TestConfig) {
@@ -142,7 +154,7 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 		defer controller.Stop()
 		controller.AddTestConfigs(testConfig)
 
-		ng, err := newNodeGroup(controller, testConfig)
+		ng, err := newNodeGroup(controller, testConfig, tc.nodeDeletionBatcherInterval)
 		if tc.errors && err == nil {
 			t.Fatal("expected an error")
 		}
@@ -175,6 +187,7 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 
 		expectedID := path.Join(expectedKind, testConfig.spec.namespace, expectedName)
 		expectedDebug := fmt.Sprintf(debugFormat, expectedID, tc.minSize, tc.maxSize, tc.replicas)
+		expectedNodeDeletionBatcherInterval := 1 * time.Second
 
 		if ng.scalableResource.Name() != expectedName {
 			t.Errorf("expected %q, got %q", expectedName, ng.scalableResource.Name())
@@ -198,6 +211,12 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 
 		if ng.Debug() != expectedDebug {
 			t.Errorf("expected %q, got %q", expectedDebug, ng.Debug())
+		}
+
+		if ng.nodeDeletionBatcherInterval != 0 {
+			if ng.nodeDeletionBatcherInterval != expectedNodeDeletionBatcherInterval {
+				t.Errorf("expected %q, got %q", expectedNodeDeletionBatcherInterval, ng.nodeDeletionBatcherInterval)
+			}
 		}
 
 		if exists := ng.Exist(); !exists {
@@ -1396,6 +1415,108 @@ func TestNodeGroupDeleteNodesSequential(t *testing.T) {
 	})
 }
 
+func TestNodeGroupDeleteNodesWithBatcherInterval(t *testing.T) {
+	test := func(t *testing.T, testConfig *TestConfig) {
+		controller := NewTestMachineController(t)
+		defer controller.Stop()
+		controller.AddTestConfigs(testConfig)
+
+		oneSecondNodeDeletionBatcherInterval := 1 * time.Second
+
+		nodegroups, err := controller.nodeGroups(oneSecondNodeDeletionBatcherInterval)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if l := len(nodegroups); l != 1 {
+			t.Fatalf("expected 1 nodegroup, got %d", l)
+		}
+
+		ng := nodegroups[0].(*nodegroup)
+		nodeNames, err := ng.Nodes()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(nodeNames) != len(testConfig.nodes) {
+			t.Fatalf("expected len=%v, got len=%v", len(testConfig.nodes), len(nodeNames))
+		}
+
+		sort.SliceStable(nodeNames, func(i, j int) bool {
+			return nodeNames[i].Id < nodeNames[j].Id
+		})
+
+		for i := range len(nodeNames) {
+			if nodeNames[i].Id != testConfig.nodes[i].Spec.ProviderID {
+				t.Fatalf("expected %q, got %q", testConfig.nodes[i].Spec.ProviderID, nodeNames[i].Id)
+			}
+		}
+
+		if ng.nodeDeletionBatcherInterval != oneSecondNodeDeletionBatcherInterval {
+			t.Fatalf("expected %v, got %v", oneSecondNodeDeletionBatcherInterval, ng.nodeDeletionBatcherInterval)
+		}
+
+		if err := ng.DeleteNodes(testConfig.nodes[5:]); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		for i := 5; i < len(testConfig.machines); i++ {
+			machine, err := controller.managementClient.Resource(controller.machineResource).
+				Namespace(testConfig.spec.namespace).
+				Get(context.TODO(), testConfig.machines[i].GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, found := machine.GetAnnotations()[machineDeleteAnnotationKey]; !found {
+				t.Errorf("expected annotation %q on machine %s", machineDeleteAnnotationKey, machine.GetName())
+			}
+		}
+
+		gvr, err := ng.scalableResource.GroupVersionResource()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		scalableResource, err := ng.machineController.managementScaleClient.Scales(testConfig.spec.namespace).
+			Get(context.TODO(), gvr.GroupResource(), ng.scalableResource.Name(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if scalableResource.Spec.Replicas != 5 {
+			t.Errorf("expected 5, got %v", scalableResource.Spec.Replicas)
+		}
+	}
+
+	// Note: 10 is an upper bound for the number of nodes/replicas
+	// Going beyond 10 will break the sorting that happens in the
+	// test() function because sort.Strings() will not do natural
+	// sorting and the expected semantics in test() will fail.
+
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "10",
+	}
+
+	t.Run("MachineSet", func(t *testing.T) {
+		testConfig := NewTestConfigBuilder().
+			ForMachineSet().
+			WithNodeCount(10).
+			WithAnnotations(annotations).
+			Build()
+		test(t, testConfig)
+	})
+
+	t.Run("MachineDeployment", func(t *testing.T) {
+		testConfig := NewTestConfigBuilder().
+			ForMachineDeployment().
+			WithNodeCount(10).
+			WithAnnotations(annotations).
+			Build()
+		test(t, testConfig)
+	})
+}
+
 func TestNodeGroupWithFailedMachine(t *testing.T) {
 	test := func(t *testing.T, testConfig *TestConfig) {
 		controller := NewTestMachineController(t)
@@ -2305,7 +2426,7 @@ func TestNodeGroupMachinePoolDeleteNodes(t *testing.T) {
 					}
 				}
 
-				nodegroups, err := controller.nodeGroups()
+				nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -2433,7 +2554,7 @@ func TestNodeGroupMachinePoolProviderIDList(t *testing.T) {
 				)
 			}
 
-			nodegroups, err := controller.nodeGroups()
+			nodegroups, err := controller.nodeGroups(defaultNodeDeletionBatcherInterval)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/cloudprovider/clusterapi/clusterapi_processors.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_processors.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clusterapi
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-autoscaler/pkg/context"
@@ -26,13 +28,17 @@ import (
 // ScaleDownNodeUpgradeProcessor is a processor to filter out
 // nodes that are undergoing an upgrade through a MachineDeployment.
 type ScaleDownNodeUpgradeProcessor struct {
-	controller *machineController
+	controller                  *machineController
+	nodeDeletionBatcherInterval time.Duration
 }
 
 // NewScaleDownNodeUpgradeProcessor returns a new ScaleDownNodeUpgradeProcessor for use when
 // registering a new upgrade scale down processor.
-func NewScaleDownNodeUpgradeProcessor(c *machineController) *ScaleDownNodeUpgradeProcessor {
-	return &ScaleDownNodeUpgradeProcessor{controller: c}
+func NewScaleDownNodeUpgradeProcessor(c *machineController, nodeDeletionBatcherInterval time.Duration) *ScaleDownNodeUpgradeProcessor {
+	return &ScaleDownNodeUpgradeProcessor{
+		controller:                  c,
+		nodeDeletionBatcherInterval: nodeDeletionBatcherInterval,
+	}
 }
 
 // GetPodDestinationCandidates returns nodes as is no processing is required here
@@ -48,7 +54,7 @@ func (p *ScaleDownNodeUpgradeProcessor) GetScaleDownCandidates(ctx *context.Auto
 
 	for _, node := range nodes {
 		// check scale down, continue if not good
-		ng, err := p.controller.nodeGroupForNode(node)
+		ng, err := p.controller.nodeGroupForNode(node, p.nodeDeletionBatcherInterval)
 		if err != nil {
 			klog.Warningf("Error while checking node group for node %s: %v", node.Name, err)
 			continue

--- a/pkg/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_provider.go
@@ -19,6 +19,7 @@ package clusterapi
 import (
 	"fmt"
 	"path"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -55,9 +56,10 @@ const (
 var _ cloudprovider.CloudProvider = (*provider)(nil)
 
 type provider struct {
-	controller      *machineController
-	providerName    string
-	resourceLimiter *cloudprovider.ResourceLimiter
+	controller                  *machineController
+	providerName                string
+	resourceLimiter             *cloudprovider.ResourceLimiter
+	nodeDeletionBatcherInterval time.Duration
 }
 
 func (p *provider) Name() string {
@@ -69,7 +71,7 @@ func (p *provider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) 
 }
 
 func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
-	nodegroups, err := p.controller.nodeGroups()
+	nodegroups, err := p.controller.nodeGroups(p.nodeDeletionBatcherInterval)
 	if err != nil {
 		klog.Errorf("error getting node groups: %v", err)
 		return nil
@@ -78,7 +80,7 @@ func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
 }
 
 func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup, error) {
-	ng, err := p.controller.nodeGroupForNode(node)
+	ng, err := p.controller.nodeGroupForNode(node, p.nodeDeletionBatcherInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -153,11 +155,13 @@ func newProvider(
 	name string,
 	rl *cloudprovider.ResourceLimiter,
 	controller *machineController,
+	nodeDeletionBatcherInterval time.Duration,
 ) cloudprovider.CloudProvider {
 	return &provider{
-		providerName:    name,
-		resourceLimiter: rl,
-		controller:      controller,
+		providerName:                name,
+		resourceLimiter:             rl,
+		controller:                  controller,
+		nodeDeletionBatcherInterval: nodeDeletionBatcherInterval,
 	}
 }
 
@@ -219,7 +223,7 @@ func BuildClusterAPI(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeG
 		klog.Fatal(err)
 	}
 
-	scaleDownUpgradeProcessor := NewScaleDownNodeUpgradeProcessor(controller)
+	scaleDownUpgradeProcessor := NewScaleDownNodeUpgradeProcessor(controller, opts.NodeDeletionBatcherInterval)
 	if err := scaledowncandidates.RegisterCombinedScaleDownCandidateProcessor(opts.Processors.ScaleDownNodeProcessor, scaleDownUpgradeProcessor); err != nil {
 		klog.Fatalf("unable to register scale down upgrade processor: %v", err)
 	}
@@ -228,5 +232,5 @@ func BuildClusterAPI(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeG
 		klog.Fatal(err)
 	}
 
-	return newProvider(cloudprovider.ClusterAPIProviderName, rl, controller)
+	return newProvider(cloudprovider.ClusterAPIProviderName, rl, controller, opts.NodeDeletionBatcherInterval)
 }

--- a/pkg/cloudprovider/clusterapi/clusterapi_provider_test.go
+++ b/pkg/cloudprovider/clusterapi/clusterapi_provider_test.go
@@ -33,7 +33,7 @@ func TestProviderConstructorProperties(t *testing.T) {
 	controller := NewTestMachineController(t)
 	defer controller.Stop()
 
-	provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController)
+	provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController, defaultNodeDeletionBatcherInterval)
 	if actual := provider.Name(); actual != cloudprovider.ClusterAPIProviderName {
 		t.Errorf("expected %q, got %q", cloudprovider.ClusterAPIProviderName, actual)
 	}
@@ -123,7 +123,7 @@ func BenchmarkNodeGroups(b *testing.B) {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
-	provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController)
+	provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController, defaultNodeDeletionBatcherInterval)
 	if actual := provider.Name(); actual != cloudprovider.ClusterAPIProviderName {
 		b.Errorf("expected %q, got %q", cloudprovider.ClusterAPIProviderName, actual)
 	}
@@ -260,7 +260,7 @@ func TestNodeGroups(t *testing.T) {
 			}
 		}
 
-		provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController)
+		provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController, defaultNodeDeletionBatcherInterval)
 		if actual := provider.Name(); actual != cloudprovider.ClusterAPIProviderName {
 			t.Errorf("expected %q, got %q", cloudprovider.ClusterAPIProviderName, actual)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR implements the logic to delete multiple nodes if the flag `node-deletion-batcher-interval` is set. If it is, the cloudprovider/clusterapi will try to delete multiple replicas instead of one by one.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
If the flag `node-deletion-batcher-interval` is set and the cloudprovider is clusterapi, the nodes will be deleted in batches instead of one by one
```