### PR TITLE
feat: DRA cluster limits

### DIFF
--- a/pkg/config/autoscaling_options.go
+++ b/pkg/config/autoscaling_options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	kubelet_config "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -32,6 +33,25 @@ type GpuLimits struct {
 	Min int64
 	// Upper bound on number of GPUs of given type in cluster
 	Max int64
+}
+
+// DraLimits define lower and upper bound on DRA devices with a certain attribute in cluster.
+type DraLimits struct {
+	// Driver is the name of the DRA plugin driver (e.g. gpu.nvidia.com)
+	Driver string
+	// DeviceAttributeName is the name of attribute with which devices from the driver will be filtered to count.
+	DeviceAttributeName string
+	// DeviceAttributeValue is the value of the device attribute which devices will be filtered by in the driver.
+	DeviceAttributeValue string
+	// Min is the lower bound of the number of devices with the given attribute limitations in cluster.
+	Min int64
+	// Max is the upper bound of the number of devices with the given attribute limitations in cluster.
+	Max int64
+}
+
+// ResourceKey returns the resource key used to identify this DRA limit in the ResourceLimiter.
+func (d DraLimits) ResourceKey() string {
+	return fmt.Sprintf("dra:%s/%s=%s", d.Driver, d.DeviceAttributeName, d.DeviceAttributeValue)
 }
 
 // NodeGroupAutoscalingOptions contain various options to customize how autoscaling of
@@ -120,6 +140,8 @@ type AutoscalingOptions struct {
 	MinMemoryTotal int64
 	// GpuTotal is a list of strings with configuration of min/max limits for different GPUs.
 	GpuTotal []GpuLimits
+	// DraTotal is a list of configurations of the upper & lower bounds on DRA devices by attribute.
+	DraTotal []DraLimits
 	// NodeGroupAutoDiscovery represents one or more definition(s) of node group auto-discovery
 	NodeGroupAutoDiscovery []string
 	// EstimatorName is the estimator used to estimate the number of needed nodes in scale up.

--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -588,7 +588,7 @@ func parseMultipleDraLimits(flags MultiStringFlag) ([]config.DraLimits, error) {
 
 func parseSingleDraLimit(limits string) (config.DraLimits, error) {
 	re := regexp.MustCompile(
-		`^(?P<driver>[a-z0-9.-]+)/(?P<attr>[a-zA-Z_][a-zA-Z0-9_]*)=(?P<val>[^:]+):(?P<min>-?\d+):(?P<max>-?\d+)$`,
+		`^(?P<driver>[a-z0-9.-]+)/(?P<attr>[a-zA-Z_][a-zA-Z0-9_]*)=(?P<val>[^:=/]+):(?P<min>-?\d+):(?P<max>-?\d+)$`,
 	)
 	match := re.FindStringSubmatch(limits)
 	if match == nil {

--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -114,6 +115,7 @@ var (
 	coresTotal                  = flag.String("cores-total", minMaxFlagString(0, config.DefaultMaxClusterCores), "Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
 	memoryTotal                 = flag.String("memory-total", minMaxFlagString(0, config.DefaultMaxClusterMemory), "Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.")
 	gpuTotal                    = multiStringFlag("gpu-total", "Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. CURRENTLY THIS FLAG ONLY WORKS ON GKE.")
+	draTotal                    = multiStringFlag("dra-total", "Minimum and maximum number of different DRA devices by attribute in cluster, in the format <driver>/<attribute-name>=<attribute-value>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times. Only device attributes with string values are matched. CURRENTLY DOES NOT ACCOUNT FOR PARTITIONABLE DEVICES.")
 	cloudProviderFlag           = flag.String("cloud-provider", cloudBuilder.DefaultCloudProvider(),
 		"Cloud provider type. Available values: ["+strings.Join(cloudBuilder.AvailableCloudProviders(), ",")+"]")
 	maxBulkSoftTaintCount      = flag.Int("max-bulk-soft-taint-count", 10, "Maximum number of nodes that can be tainted/untainted PreferNoSchedule at the same time. Set to 0 to turn off such tainting.")
@@ -284,6 +286,11 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		klog.Fatalf("Failed to parse flags: %v", err)
 	}
 
+	parsedDraTotal, err := parseMultipleDraLimits(*draTotal)
+	if err != nil {
+		klog.Fatalf("Failed to parse flags: %v", err)
+	}
+
 	var parsedSchedConfig *scheduler_config.KubeSchedulerConfiguration
 	// if scheduler config flag was set by the user
 	if pflag.CommandLine.Changed(config.SchedulerConfigFileFlag) {
@@ -370,6 +377,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		MaxMemoryTotal:                   maxMemoryTotal,
 		MinMemoryTotal:                   minMemoryTotal,
 		GpuTotal:                         parsedGpuTotal,
+		DraTotal:                         parsedDraTotal,
 		NodeGroups:                       *nodeGroupsFlag,
 		EnforceNodeGroupMinSize:          *enforceNodeGroupMinSize,
 		ScaleDownDelayAfterAdd:           *scaleDownDelayAfterAdd,
@@ -564,6 +572,60 @@ func parseSingleGpuLimit(limits string) (config.GpuLimits, error) {
 		Max:     maxVal,
 	}
 	return parsedGpuLimits, nil
+}
+
+func parseMultipleDraLimits(flags MultiStringFlag) ([]config.DraLimits, error) {
+	parsedFlags := make([]config.DraLimits, 0, len(flags))
+	for _, flag := range flags {
+		parsedFlag, err := parseSingleDraLimit(flag)
+		if err != nil {
+			return nil, err
+		}
+		parsedFlags = append(parsedFlags, parsedFlag)
+	}
+	return parsedFlags, nil
+}
+
+func parseSingleDraLimit(limits string) (config.DraLimits, error) {
+	re := regexp.MustCompile(
+		`^(?P<driver>[a-z0-9.-]+)/(?P<attr>[a-zA-Z_][a-zA-Z0-9_]*)=(?P<val>[^:]+):(?P<min>-?\d+):(?P<max>-?\d+)$`,
+	)
+	match := re.FindStringSubmatch(limits)
+	if match == nil {
+		return config.DraLimits{}, fmt.Errorf("Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"")
+	}
+
+	minStr := match[re.SubexpIndex("min")]
+	minVal, err := strconv.ParseInt(minStr, 10, 64)
+	if err != nil {
+		return config.DraLimits{}, fmt.Errorf("Failed to parse DRA limit - invalid min value %q: %w", minStr, err)
+	}
+
+	maxStr := match[re.SubexpIndex("max")]
+	maxVal, err := strconv.ParseInt(maxStr, 10, 64)
+	if err != nil {
+		return config.DraLimits{}, fmt.Errorf("Failed to parse DRA limit - invalid max value %q: %w", maxStr, err)
+	}
+
+	if minVal < 0 {
+		return config.DraLimits{}, fmt.Errorf("Failed to parse DRA limit - lower limit \"%d\" must be non-negative", minVal)
+	}
+
+	if maxVal < 0 {
+		return config.DraLimits{}, fmt.Errorf("Failed to parse DRA limit - upper limit \"%d\" must be non-negative", maxVal)
+	}
+
+	if minVal > maxVal {
+		return config.DraLimits{}, fmt.Errorf("Failed to parse DRA limit - lower limit \"%d\" is larger than upper limit \"%d\"", minVal, maxVal)
+	}
+
+	return config.DraLimits{
+		Driver:               match[re.SubexpIndex("driver")],
+		DeviceAttributeName:  match[re.SubexpIndex("attr")],
+		DeviceAttributeValue: match[re.SubexpIndex("val")],
+		Min:                  minVal,
+		Max:                  maxVal,
+	}, nil
 }
 
 // parseShutdownGracePeriodsAndPriorities parse priorityGracePeriodStr and returns an array of ShutdownGracePeriodByPodPriority if succeeded.

--- a/pkg/config/flags/flags_test.go
+++ b/pkg/config/flags/flags_test.go
@@ -98,6 +98,92 @@ func TestParseSingleGpuLimit(t *testing.T) {
 	}
 }
 
+func TestParseSingleDraLimit(t *testing.T) {
+	type testcase struct {
+		input                string
+		expectError          bool
+		expectedLimits       config.DraLimits
+		expectedErrorMessage string
+	}
+
+	testcases := []testcase{
+		{
+			input:       "gpu.nvidia.com/productName=A100:0:64",
+			expectError: false,
+			expectedLimits: config.DraLimits{
+				Driver:               "gpu.nvidia.com",
+				DeviceAttributeName:  "productName",
+				DeviceAttributeValue: "A100",
+				Min:                  0,
+				Max:                  64,
+			},
+		},
+		{
+			input:       "driver.example/attr=val:0:0",
+			expectError: false,
+			expectedLimits: config.DraLimits{
+				Driver:               "driver.example",
+				DeviceAttributeName:  "attr",
+				DeviceAttributeValue: "val",
+				Min:                  0,
+				Max:                  0,
+			},
+		},
+		{
+			input:                "gpu.nvidia.com/productName:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "/productName=A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100:abc:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100:-1:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - lower limit \"-1\" must be non-negative",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100:0:-1",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - upper limit \"-1\" must be non-negative",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100:10:1",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - lower limit \"10\" is larger than upper limit \"1\"",
+		},
+		{
+			input:                "not-a-valid-format",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+	}
+
+	for _, testcase := range testcases {
+		limits, err := parseSingleDraLimit(testcase.input)
+		if testcase.expectError {
+			assert.NotNil(t, err)
+			if err != nil {
+				assert.Equal(t, testcase.expectedErrorMessage, err.Error())
+			}
+		} else {
+			assert.Equal(t, testcase.expectedLimits, limits)
+		}
+	}
+}
+
 func TestParseShutdownGracePeriodsAndPriorities(t *testing.T) {
 	testCases := []struct {
 		name  string

--- a/pkg/config/flags/flags_test.go
+++ b/pkg/config/flags/flags_test.go
@@ -169,6 +169,76 @@ func TestParseSingleDraLimit(t *testing.T) {
 			expectError:          true,
 			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
 		},
+		{
+			input:                "gpu.nvidia.com//productName=A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName==A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100:0:64:extra",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/=A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                ":0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100::64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=A100:0:",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/product/Name=A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/product=Name=A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu/nvidia/productName=A100:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=val=with=equals:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
+		{
+			input:                "gpu.nvidia.com/productName=val/with/slashes:0:64",
+			expectError:          true,
+			expectedErrorMessage: "Failed to parse DRA limit - flag does not fit format:\"<driver>/<attribute>=<value>:<min>:<max>\"",
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/pkg/context/autoscaling_context.go
+++ b/pkg/context/autoscaling_context.go
@@ -128,6 +128,12 @@ func NewResourceLimiterFromAutoscalingOptions(options config.AutoscalingOptions)
 		minResources[gpuLimits.GpuType] = gpuLimits.Min
 		maxResources[gpuLimits.GpuType] = gpuLimits.Max
 	}
+
+	for _, draLimits := range options.DraTotal {
+		key := draLimits.ResourceKey()
+		minResources[key] = draLimits.Min
+		maxResources[key] = draLimits.Max
+	}
 	return cloudprovider.NewResourceLimiter(minResources, maxResources)
 }
 

--- a/pkg/context/autoscaling_context_test.go
+++ b/pkg/context/autoscaling_context_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/context/autoscaling_context_test.go
+++ b/pkg/context/autoscaling_context_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+)
+
+func TestNewResourceLimiterFromAutoscalingOptions(t *testing.T) {
+	testCases := []struct {
+		name    string
+		options config.AutoscalingOptions
+		wantMin map[string]int64
+		wantMax map[string]int64
+	}{
+		{
+			name: "cores and memory only",
+			options: config.AutoscalingOptions{
+				MinCoresTotal:  2,
+				MaxCoresTotal:  100,
+				MinMemoryTotal: 1073741824,   // 1 GiB
+				MaxMemoryTotal: 107374182400, // 100 GiB
+			},
+			wantMin: map[string]int64{
+				cloudprovider.ResourceNameCores:  2,
+				cloudprovider.ResourceNameMemory: 1073741824,
+			},
+			wantMax: map[string]int64{
+				cloudprovider.ResourceNameCores:  100,
+				cloudprovider.ResourceNameMemory: 107374182400,
+			},
+		},
+		{
+			name: "with GPU limits",
+			options: config.AutoscalingOptions{
+				MinCoresTotal:  2,
+				MaxCoresTotal:  100,
+				MinMemoryTotal: 1073741824,
+				MaxMemoryTotal: 107374182400,
+				GpuTotal: []config.GpuLimits{
+					{GpuType: "nvidia-tesla-k80", Min: 1, Max: 10},
+				},
+			},
+			wantMin: map[string]int64{
+				cloudprovider.ResourceNameCores:  2,
+				cloudprovider.ResourceNameMemory: 1073741824,
+				"nvidia-tesla-k80":               1,
+			},
+			wantMax: map[string]int64{
+				cloudprovider.ResourceNameCores:  100,
+				cloudprovider.ResourceNameMemory: 107374182400,
+				"nvidia-tesla-k80":               10,
+			},
+		},
+		{
+			name: "with DRA limits",
+			options: config.AutoscalingOptions{
+				MinCoresTotal:  2,
+				MaxCoresTotal:  100,
+				MinMemoryTotal: 1073741824,
+				MaxMemoryTotal: 107374182400,
+				DraTotal: []config.DraLimits{
+					{Driver: "gpu.nvidia.com", DeviceAttributeName: "productName", DeviceAttributeValue: "A100", Min: 0, Max: 64},
+				},
+			},
+			wantMin: map[string]int64{
+				cloudprovider.ResourceNameCores:       2,
+				cloudprovider.ResourceNameMemory:      1073741824,
+				"dra:gpu.nvidia.com/productName=A100": 0, // min=0 is filtered out by NewResourceLimiter, GetMin returns 0 default
+			},
+			wantMax: map[string]int64{
+				cloudprovider.ResourceNameCores:       100,
+				cloudprovider.ResourceNameMemory:      107374182400,
+				"dra:gpu.nvidia.com/productName=A100": 64,
+			},
+		},
+		{
+			name: "with DRA limits non-zero min",
+			options: config.AutoscalingOptions{
+				MinCoresTotal:  2,
+				MaxCoresTotal:  100,
+				MinMemoryTotal: 1073741824,
+				MaxMemoryTotal: 107374182400,
+				DraTotal: []config.DraLimits{
+					{Driver: "gpu.nvidia.com", DeviceAttributeName: "productName", DeviceAttributeValue: "A100", Min: 8, Max: 64},
+				},
+			},
+			wantMin: map[string]int64{
+				cloudprovider.ResourceNameCores:       2,
+				cloudprovider.ResourceNameMemory:      1073741824,
+				"dra:gpu.nvidia.com/productName=A100": 8,
+			},
+			wantMax: map[string]int64{
+				cloudprovider.ResourceNameCores:       100,
+				cloudprovider.ResourceNameMemory:      107374182400,
+				"dra:gpu.nvidia.com/productName=A100": 64,
+			},
+		},
+		{
+			name: "multiple DRA limits",
+			options: config.AutoscalingOptions{
+				MinCoresTotal:  2,
+				MaxCoresTotal:  100,
+				MinMemoryTotal: 1073741824,
+				MaxMemoryTotal: 107374182400,
+				DraTotal: []config.DraLimits{
+					{Driver: "gpu.nvidia.com", DeviceAttributeName: "productName", DeviceAttributeValue: "A100", Min: 8, Max: 64},
+					{Driver: "gpu.nvidia.com", DeviceAttributeName: "productName", DeviceAttributeValue: "H100", Min: 4, Max: 32},
+				},
+			},
+			wantMin: map[string]int64{
+				cloudprovider.ResourceNameCores:       2,
+				cloudprovider.ResourceNameMemory:      1073741824,
+				"dra:gpu.nvidia.com/productName=A100": 8,
+				"dra:gpu.nvidia.com/productName=H100": 4,
+			},
+			wantMax: map[string]int64{
+				cloudprovider.ResourceNameCores:       100,
+				cloudprovider.ResourceNameMemory:      107374182400,
+				"dra:gpu.nvidia.com/productName=A100": 64,
+				"dra:gpu.nvidia.com/productName=H100": 32,
+			},
+		},
+		{
+			name: "GPU and DRA together",
+			options: config.AutoscalingOptions{
+				MinCoresTotal:  2,
+				MaxCoresTotal:  100,
+				MinMemoryTotal: 1073741824,
+				MaxMemoryTotal: 107374182400,
+				GpuTotal: []config.GpuLimits{
+					{GpuType: "nvidia-tesla-k80", Min: 1, Max: 10},
+				},
+				DraTotal: []config.DraLimits{
+					{Driver: "gpu.nvidia.com", DeviceAttributeName: "productName", DeviceAttributeValue: "A100", Min: 8, Max: 64},
+				},
+			},
+			wantMin: map[string]int64{
+				cloudprovider.ResourceNameCores:       2,
+				cloudprovider.ResourceNameMemory:      1073741824,
+				"nvidia-tesla-k80":                    1,
+				"dra:gpu.nvidia.com/productName=A100": 8,
+			},
+			wantMax: map[string]int64{
+				cloudprovider.ResourceNameCores:       100,
+				cloudprovider.ResourceNameMemory:      107374182400,
+				"nvidia-tesla-k80":                    10,
+				"dra:gpu.nvidia.com/productName=A100": 64,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rl := NewResourceLimiterFromAutoscalingOptions(tc.options)
+
+			for resource, expectedMin := range tc.wantMin {
+				assert.Equal(t, expectedMin, rl.GetMin(resource), "GetMin(%s)", resource)
+			}
+			for resource, expectedMax := range tc.wantMax {
+				assert.Equal(t, expectedMax, rl.GetMax(resource), "GetMax(%s)", resource)
+			}
+		})
+	}
+}

--- a/pkg/processors/customresources/dra_processor.go
+++ b/pkg/processors/customresources/dra_processor.go
@@ -19,6 +19,7 @@ package customresources
 import (
 	apiv1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 
@@ -117,10 +118,68 @@ func getNodeInfo(autoscalingCtx *ca_context.AutoscalingContext, ng cloudprovider
 	return ng.TemplateNodeInfo()
 }
 
-// GetNodeResourceTargets returns the resource targets for DRA resource slices, not implemented.
-func (p *DraCustomResourcesProcessor) GetNodeResourceTargets(_ *ca_context.AutoscalingContext, _ *apiv1.Node, _ cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
-	// TODO(DRA): Figure out resource limits for DRA here.
-	return []CustomResourceTarget{}, nil
+// GetNodeResourceTargets returns the count of DRA devices on the node that match each configured DRA limit.
+func (p *DraCustomResourcesProcessor) GetNodeResourceTargets(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, ng cloudprovider.NodeGroup) ([]CustomResourceTarget, errors.AutoscalerError) {
+	draLimits := autoscalingCtx.AutoscalingOptions.DraTotal
+	if len(draLimits) == 0 {
+		return nil, nil
+	}
+
+	slices, err := nodeResourceSlices(autoscalingCtx, node, ng)
+	if err != nil {
+		return nil, errors.ToAutoscalerError(errors.InternalError, err)
+	}
+
+	targets := make([]CustomResourceTarget, 0, len(draLimits))
+	for _, limit := range draLimits {
+		count := countMatchingDraDevices(slices, limit)
+		targets = append(targets, CustomResourceTarget{
+			ResourceType:  limit.ResourceKey(),
+			ResourceCount: count,
+		})
+	}
+	return targets, nil
+}
+
+func nodeResourceSlices(autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node, ng cloudprovider.NodeGroup) ([]*resourceapi.ResourceSlice, error) {
+	if autoscalingCtx.DraProvider != nil {
+		draSnapshot, err := autoscalingCtx.DraProvider.Snapshot()
+		if err != nil {
+			return nil, err
+		}
+		if slices, found := draSnapshot.NodeResourceSlices(node.Name); found {
+			return slices, nil
+		}
+	}
+
+	if ng != nil {
+		nodeInfo, err := getNodeInfo(autoscalingCtx, ng)
+		if err != nil {
+			return nil, err
+		}
+		return nodeInfo.LocalResourceSlices, nil
+	}
+
+	return nil, nil
+}
+
+func countMatchingDraDevices(slices []*resourceapi.ResourceSlice, limit config.DraLimits) int64 {
+	var count int64
+	for _, slice := range slices {
+		if slice.Spec.Driver != limit.Driver {
+			continue
+		}
+		for _, device := range slice.Spec.Devices {
+			attr, ok := device.Attributes[resourceapi.QualifiedName(limit.DeviceAttributeName)]
+			if !ok {
+				continue
+			}
+			if attr.StringValue != nil && *attr.StringValue == limit.DeviceAttributeValue {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 // CleanUp cleans up processor's internal structures.

--- a/pkg/processors/customresources/dra_processor_test.go
+++ b/pkg/processors/customresources/dra_processor_test.go
@@ -25,9 +25,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	v1 "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/store"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/testsnapshot"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/comparator"
+	draprovider "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/provider"
 	drasnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/snapshot"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
@@ -1200,6 +1203,375 @@ func TestDraProcessorResourceComparator(t *testing.T) {
 				assert.Empty(t, mockComparator.reportedTemplateSlices)
 				assert.Empty(t, mockComparator.reportedNodeSlices)
 			}
+		})
+	}
+}
+
+type fakeAllObjectsLister[T any] struct {
+	objects []T
+}
+
+func (l *fakeAllObjectsLister[T]) ListAll() ([]T, error) {
+	return l.objects, nil
+}
+
+func TestCountMatchingDraDevices(t *testing.T) {
+	defaultLimit := config.DraLimits{
+		Driver:               "gpu.nvidia.com",
+		DeviceAttributeName:  "productName",
+		DeviceAttributeValue: "A100",
+	}
+
+	tests := map[string]struct {
+		slices   []*resourceapi.ResourceSlice
+		limit    config.DraLimits
+		expected int64
+	}{
+		"NoSlices": {
+			slices:   nil,
+			limit:    defaultLimit,
+			expected: 0,
+		},
+		"DriverMismatch": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "other.driver",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 0,
+		},
+		"AttributeNameMismatch": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"model": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 0,
+		},
+		"AttributeValueMismatch": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("H100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 0,
+		},
+		"SingleMatch": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 1,
+		},
+		"MultipleMatchesAcrossSlices": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+							{
+								Name: "dev-1",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-2",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+							{
+								Name: "dev-3",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 4,
+		},
+		"MixedMatchNoMatch": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+							{
+								Name: "dev-1",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("H100")},
+								},
+							},
+							{
+								Name: "dev-2",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"model": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 1,
+		},
+		"NonStringAttributeIgnored": {
+			slices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "dev-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: nil},
+								},
+							},
+						},
+					},
+				},
+			},
+			limit:    defaultLimit,
+			expected: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := countMatchingDraDevices(tc.slices, tc.limit)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestGetNodeResourceTargets(t *testing.T) {
+	gpuLimit := config.DraLimits{
+		Driver:               "gpu.nvidia.com",
+		DeviceAttributeName:  "productName",
+		DeviceAttributeValue: "A100",
+	}
+	networkLimit := config.DraLimits{
+		Driver:               "net.example.com",
+		DeviceAttributeName:  "speed",
+		DeviceAttributeValue: "100G",
+	}
+
+	tests := map[string]struct {
+		draLimits       []config.DraLimits
+		nodeSlices      []*resourceapi.ResourceSlice
+		templateSlices  []*resourceapi.ResourceSlice
+		useDraSnapshot  bool
+		expectedTargets []CustomResourceTarget
+	}{
+		"NoDRALimitsConfigured": {
+			draLimits:       nil,
+			expectedTargets: nil,
+		},
+		"DRALimitsWithMatchingDevicesViaDraSnapshot": {
+			draLimits: []config.DraLimits{gpuLimit},
+			nodeSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "gpu-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+							{
+								Name: "gpu-1",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			useDraSnapshot: true,
+			expectedTargets: []CustomResourceTarget{
+				{ResourceType: gpuLimit.ResourceKey(), ResourceCount: 2},
+			},
+		},
+		"DRALimitsFallbackToNodeGroupTemplate": {
+			draLimits: []config.DraLimits{gpuLimit},
+			templateSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "gpu-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+							{
+								Name: "gpu-1",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+							{
+								Name: "gpu-2",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			useDraSnapshot: false,
+			expectedTargets: []CustomResourceTarget{
+				{ResourceType: gpuLimit.ResourceKey(), ResourceCount: 3},
+			},
+		},
+		"MultipleDRALimitsPartialMatch": {
+			draLimits: []config.DraLimits{gpuLimit, networkLimit},
+			templateSlices: []*resourceapi.ResourceSlice{
+				{
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver: "gpu.nvidia.com",
+						Devices: []resourceapi.Device{
+							{
+								Name: "gpu-0",
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"productName": {StringValue: ptr.To("A100")},
+								},
+							},
+						},
+					},
+				},
+			},
+			useDraSnapshot: false,
+			expectedTargets: []CustomResourceTarget{
+				{ResourceType: gpuLimit.ResourceKey(), ResourceCount: 1},
+				{ResourceType: networkLimit.ResourceKey(), ResourceCount: 0},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			node := buildTestNode("node1", true)
+			nodeGroup := "ng1"
+			machineName := fmt.Sprintf("%s_machine_template", nodeGroup)
+
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
+
+			var templateNodeInfo *framework.NodeInfo
+			if tc.templateSlices != nil {
+				templateNodeInfo = framework.NewNodeInfo(buildTestNode("template", true), tc.templateSlices)
+			} else {
+				templateNodeInfo = framework.NewTestNodeInfo(buildTestNode("template", true))
+			}
+
+			provider.AddAutoprovisionedNodeGroup(nodeGroup, 0, 10, 1, machineName)
+			provider.AddNode(nodeGroup, node)
+			provider.SetMachineTemplates(map[string]*framework.NodeInfo{
+				machineName: templateNodeInfo,
+			})
+
+			autoscalingCtx := &ca_context.AutoscalingContext{
+				CloudProvider: provider,
+				TemplateNodeInfoRegistry: newMockTemplateNodeInfoRegistry(map[string]*framework.NodeInfo{
+					nodeGroup: templateNodeInfo,
+				}),
+			}
+			autoscalingCtx.AutoscalingOptions.DraTotal = tc.draLimits
+
+			if tc.useDraSnapshot {
+				nodeName := node.Name
+				for _, s := range tc.nodeSlices {
+					s.Spec.NodeName = &nodeName
+				}
+				autoscalingCtx.DraProvider = draprovider.NewProvider(
+					&fakeAllObjectsLister[*resourceapi.ResourceClaim]{},
+					&fakeAllObjectsLister[*resourceapi.ResourceSlice]{objects: tc.nodeSlices},
+					&fakeAllObjectsLister[*resourceapi.DeviceClass]{},
+				)
+			}
+
+			ng, err := provider.NodeGroupForNode(node)
+			assert.NoError(t, err)
+			assert.NotNil(t, ng)
+
+			processor := DraCustomResourcesProcessor{resourcesComparator: comparator.NewNodeResourcesComparator(noOpMetricsEmitter{})}
+			targets, autoscalerErr := processor.GetNodeResourceTargets(autoscalingCtx, node, ng)
+
+			assert.Nil(t, autoscalerErr)
+			assert.Equal(t, tc.expectedTargets, targets)
 		})
 	}
 }

--- a/pkg/resourcequotas/factory_test.go
+++ b/pkg/resourcequotas/factory_test.go
@@ -170,6 +170,71 @@ func TestNewMaxQuotasTracker(t *testing.T) {
 			},
 		},
 		{
+			name: "dra custom resource allowed operation",
+			crp: &fakeCustomResourcesProcessor{
+				NodeResourceTargets: func(n *apiv1.Node) []customresources.CustomResourceTarget {
+					if n.Name == "n1" {
+						return []customresources.CustomResourceTarget{
+							{
+								ResourceType:  "dra:gpu.nvidia.com/productName=A100",
+								ResourceCount: 4,
+							},
+						}
+					}
+					return nil
+				},
+			},
+			nodes: []*apiv1.Node{
+				test.BuildTestNode("n1", 1000, 2*units.GiB),
+				test.BuildTestNode("n2", 2000, 4*units.GiB),
+				test.BuildTestNode("n3", 3000, 8*units.GiB),
+			},
+			limits: map[string]int64{
+				"cpu":                                 12,
+				"memory":                              32 * units.GiB,
+				"dra:gpu.nvidia.com/productName=A100": 20,
+			},
+			newNode:   test.BuildTestNode("n4", 2000, 4*units.GiB),
+			nodeDelta: 2,
+			wantResult: &CheckDeltaResult{
+				AllowedDelta: 2,
+			},
+		},
+		{
+			name: "dra custom resource exceeded operation",
+			crp: &fakeCustomResourcesProcessor{
+				NodeResourceTargets: func(n *apiv1.Node) []customresources.CustomResourceTarget {
+					if n.Name == "n1" || n.Name == "n4" {
+						return []customresources.CustomResourceTarget{
+							{
+								ResourceType:  "dra:gpu.nvidia.com/productName=A100",
+								ResourceCount: 4,
+							},
+						}
+					}
+					return nil
+				},
+			},
+			nodes: []*apiv1.Node{
+				test.BuildTestNode("n1", 1000, 2*units.GiB),
+				test.BuildTestNode("n2", 2000, 4*units.GiB),
+				test.BuildTestNode("n3", 3000, 8*units.GiB),
+			},
+			limits: map[string]int64{
+				"cpu":                                 12,
+				"memory":                              32 * units.GiB,
+				"dra:gpu.nvidia.com/productName=A100": 4,
+			},
+			newNode:   test.BuildTestNode("n4", 2000, 4*units.GiB),
+			nodeDelta: 1,
+			wantResult: &CheckDeltaResult{
+				AllowedDelta: 0,
+				ExceededQuotas: []ExceededQuota{
+					{ID: "cluster-wide", ExceededResources: []string{"dra:gpu.nvidia.com/productName=A100"}},
+				},
+			},
+		},
+		{
 			name: "node filter config allowed operation",
 			nodeFilter: nodeExcludeFn(func(node *apiv1.Node) bool {
 				return node.Name == "n3"
@@ -390,6 +455,73 @@ func TestNewMinQuotasTracker(t *testing.T) {
 				AllowedDelta: 0,
 				ExceededQuotas: []ExceededQuota{
 					{ID: "min-quota", ExceededResources: []string{"gpu"}},
+				},
+			},
+		},
+		{
+			name: "dra custom resource allowed min operation",
+			crp: &fakeCustomResourcesProcessor{
+				NodeResourceTargets: func(n *apiv1.Node) []customresources.CustomResourceTarget {
+					if n.Name == "n1" || n.Name == "n2" {
+						return []customresources.CustomResourceTarget{
+							{
+								ResourceType:  "dra:gpu.nvidia.com/productName=A100",
+								ResourceCount: 4,
+							},
+						}
+					}
+					return nil
+				},
+			},
+			nodes: []*apiv1.Node{
+				test.BuildTestNode("n1", 1000, 2*units.GiB),
+				test.BuildTestNode("n2", 2000, 4*units.GiB),
+			},
+			quota: &FakeQuota{
+				Name:        "min-quota",
+				AppliesToFn: MatchEveryNode,
+				LimitsVal: map[string]int64{
+					"dra:gpu.nvidia.com/productName=A100": 4,
+				},
+			},
+			newNode:   test.BuildTestNode("n3", 1000, 2*units.GiB),
+			nodeDelta: 1,
+			wantResult: &CheckDeltaResult{
+				AllowedDelta: 1,
+			},
+		},
+		{
+			name: "dra custom resource exceeded min operation",
+			crp: &fakeCustomResourcesProcessor{
+				NodeResourceTargets: func(n *apiv1.Node) []customresources.CustomResourceTarget {
+					if n.Name == "n1" || n.Name == "n2" {
+						return []customresources.CustomResourceTarget{
+							{
+								ResourceType:  "dra:gpu.nvidia.com/productName=A100",
+								ResourceCount: 4,
+							},
+						}
+					}
+					return nil
+				},
+			},
+			nodes: []*apiv1.Node{
+				test.BuildTestNode("n1", 1000, 2*units.GiB),
+				test.BuildTestNode("n2", 2000, 4*units.GiB),
+			},
+			quota: &FakeQuota{
+				Name:        "min-quota",
+				AppliesToFn: MatchEveryNode,
+				LimitsVal: map[string]int64{
+					"dra:gpu.nvidia.com/productName=A100": 8,
+				},
+			},
+			newNode:   test.BuildTestNode("n1", 1000, 2*units.GiB),
+			nodeDelta: 1,
+			wantResult: &CheckDeltaResult{
+				AllowedDelta: 0,
+				ExceededQuotas: []ExceededQuota{
+					{ID: "min-quota", ExceededResources: []string{"dra:gpu.nvidia.com/productName=A100"}},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
cluster autoscaler currently does not have a limit mechanism that'd bound the amount of devices that can be scaled up / down.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/8184

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
a new flag `dra-total` has been added to cluster-autoscaler entrypoint - this flag configures the bounds of DRA autscaling.
The flag is of the format "<driver>/<attribute-name>=<attribute-value>:<min>:<max>" - where driver is the name of the DRA driver, attribute name and attribute value reflect the DRA device attributes by which devices will be selected, and min and max set the lower and upper bounds for autoscaling, f.e.
- "gpu.nvidia.com/productName=A100:16:64" will stop a scaling operation if it will cause the cluster to contain more than 64 or less than 16 DRA device with the gpu.nvidia.com driver and with the productName attribute set to `A100`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
