### PR TITLE
Mark all pod groups unschedulable when no scale-up options are available

### DIFF
--- a/pkg/core/scaleup/orchestrator/orchestrator.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator.go
@@ -1102,6 +1102,7 @@ func (o *ScaleUpOrchestrator) prepareScaleUp(ctx context.Context, args scaleUpCt
 
 	if len(options) == 0 {
 		logger.V(1).Info("No expansion options")
+		args.podEquivalenceGroups = markAllGroupsAsUnschedulable(args.podEquivalenceGroups, NoScaleUpOptionsAvailableReason)
 		return scaleUpPlan{}, o.noOptionsAvailableStatus(ctx, args), nil
 	}
 

--- a/pkg/core/scaleup/orchestrator/rejectedreasons.go
+++ b/pkg/core/scaleup/orchestrator/rejectedreasons.go
@@ -40,4 +40,6 @@ var (
 	// ScaleUpExecutionErrorReason means the node groups were considered as a scale-up candidates but the scale-up
 	// execution failed.
 	ScaleUpExecutionErrorReason = NewRejectedReasons("scale-up execution failed")
+	// NoScaleUpOptionsAvailableReason means no node groups were considered as a scale-up candidates.
+	NoScaleUpOptionsAvailableReason = NewRejectedReasons("no scale-up options available")
 )


### PR DESCRIPTION
When prepareScaleUp finds no expansion options (len(options) == 0), mark the pod equivalence groups as unschedulable with NoScaleUpOptionsAvailableReason before returning the status. This ensures that unschedulable reasons are properly populated in the ScaleUpStatus.
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
When `prepareScaleUp` finds no expansion options (`len(options) == 0`), it previously returned `noOptionsAvailableStatus` without marking the pod equivalence groups as unschedulable. As a result, the unschedulable reasons for remaining pods were not properly populated in the `ScaleUpStatus`.
This PR introduces `NoScaleUpOptionsAvailableReason` and marks all pod equivalence groups with this reason when no expansion options are available, ensuring accurate scale-up status reporting.
#### Which issue(s) this PR fixes:
Fixes #
#### Special notes for your reviewer:
This aligns the `len(options) == 0` branch with the other early exits in `prepareScaleUp` (such as `ExpansionOptionsFilteredOutReason`), ensuring that `podEquivalenceGroups` are consistently marked before computing `ScaleUpStatus`.
#### Does this PR introduce a user-facing change?
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

