### PR TITLE
Avoid logging negative removal latency in node latency tracker

### DIFF
--- a/pkg/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/pkg/core/scaledown/latencytracker/node_latency_tracker.go
@@ -103,7 +103,7 @@ func (t *NodeLatencyTracker) Process(ctx context.Context, autoscalingCtx *ca_con
 
 	if klog.V(6).Enabled() {
 		for nodeName := range t.unneededNodes {
-			logger.Info("Node remains in unneeded list (not scaled down). Continuing to track latency.", "nodeName", nodeName)
+			logger.V(6).Info("Node remains in unneeded list (not scaled down). Continuing to track latency.", "nodeName", nodeName)
 		}
 	}
 }
@@ -128,13 +128,12 @@ func (t *NodeLatencyTracker) recordAndCleanup(ctx context.Context, nodeName stri
 
 	if latency > 0 {
 		metrics.UpdateScaleDownNodeRemovalLatency(isRemoved, delayReason, latency)
-	} else {
-		logger.V(6).Info("Node was unneeded. Latency is <= 0, skipping metric", "nodeName", nodeName, "duration", duration, "threshold", info.removalThreshold, "latency", latency, "isRemoved", isRemoved, "delayReason", delayReason)
+		if !isRemoved {
+			logger.V(4).Info("Node became needed again", "nodeName", nodeName, "unneededDuration", duration, "delayReason", delayReason, "latency", latency)
+		}
 	}
 	if isRemoved {
 		t.logDeletion(ctx, nodeName, duration, info.removalThreshold, latency)
-	} else {
-		logger.V(4).Info("Node became needed again", "nodeName", nodeName, "unneededDuration", duration, "delayReason", delayReason, "latency", latency)
 	}
 }
 


### PR DESCRIPTION
Do not log negative removal latency when a node is removed from the unneeded list before reaching its removal threshold, as this is normal cluster operation. Also remove the verbose V(6) log for skipped metrics on non-positive latency, and ensure V(6) logging consistency.


#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
When an unneeded node becomes needed again before reaching its removal threshold (`latency <= 0`), the `NodeLatencyTracker` was logging negative latency at `klog.V(4)` (`Node "..." became needed again (unneeded for ...). Blocker: "...". Latency: -X`) and emitting a skipped-metric log at `klog.V(6)`.
Nodes becoming needed again before reaching the removal threshold is normal cluster operation (not a delayed scale-down), so emitting negative removal latency logs creates unnecessary log noise in active clusters.
This PR fixes that by:
- Guarding the `klog.V(4)` log so it only logs when `latency > 0` (when there was an actual delay beyond the threshold before becoming needed again).
- Removing the verbose `klog.V(6)` log for skipped metrics on non-positive latency.
- Ensuring `klog.V(6).Infof` is used consistently within verbosity-guarded blocks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
