### PR TITLE
Standardize UnremovableReason strings and scale-down latency metric r…

### DIFF
--- a/pkg/core/scaledown/latencytracker/node_latency_tracker.go
+++ b/pkg/core/scaledown/latencytracker/node_latency_tracker.go
@@ -123,7 +123,11 @@ func (t *NodeLatencyTracker) recordAndCleanup(ctx context.Context, nodeName stri
 
 	delayReason := info.latestDelayReason
 	if delayReason == "" {
-		delayReason = "none"
+		if isRemoved {
+			delayReason = "none"
+		} else {
+			delayReason = "node_became_needed_again"
+		}
 	}
 
 	if latency > 0 {
@@ -177,5 +181,5 @@ func (t *NodeLatencyTracker) updateLatestDelayReasons(ctx context.Context, unrem
 }
 
 func isBlocker(reason simulator.UnremovableReason) bool {
-	return reason != simulator.NoReason && reason != simulator.NotUnneededLongEnough && reason != simulator.NotUnreadyLongEnough
+	return reason != simulator.NotUnneededLongEnough && reason != simulator.NotUnreadyLongEnough
 }

--- a/pkg/core/scaledown/latencytracker/node_latency_tracker_test.go
+++ b/pkg/core/scaledown/latencytracker/node_latency_tracker_test.go
@@ -174,23 +174,23 @@ func TestNodeLatencyTracker_SimulationLoop(t *testing.T) {
 					unneededList:          []string{"node1"},
 					unremovableReason:     map[string]simulator.UnremovableReason{"node1": simulator.BlockedByPod},
 					wantTrackedNodes:      []string{"node1"},
-					wantLatestDelayReason: map[string]string{"node1": "BlockedByPod"},
+					wantLatestDelayReason: map[string]string{"node1": "node_has_unevictable_pods"},
 				},
 				{
 					// Step 3: node1 is still unremovable due to AtomicScaleDownFailed
 					unneededList:          []string{"node1"},
 					unremovableReason:     map[string]simulator.UnremovableReason{"node1": simulator.AtomicScaleDownFailed},
 					wantTrackedNodes:      []string{"node1"},
-					wantLatestDelayReason: map[string]string{"node1": "AtomicScaleDownFailed"},
+					wantLatestDelayReason: map[string]string{"node1": "atomic_node_group_scale_down_failed"},
 				},
 				{
 					// Step 4: node1 is unremovable due to NotUnneededLongEnough (not a blocker)
 					// The latest blocker reason should NOT be overwritten by a non-blocker!
-					// It should remain "AtomicScaleDownFailed".
+					// It should remain "atomic_node_group_scale_down_failed".
 					unneededList:          []string{"node1"},
 					unremovableReason:     map[string]simulator.UnremovableReason{"node1": simulator.NotUnneededLongEnough},
 					wantTrackedNodes:      []string{"node1"},
-					wantLatestDelayReason: map[string]string{"node1": "AtomicScaleDownFailed"},
+					wantLatestDelayReason: map[string]string{"node1": "atomic_node_group_scale_down_failed"},
 				},
 				{
 					// Step 5: node1 is finally deleted

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -93,7 +93,7 @@ func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	m.RegisterAll(false)
 
 	m.UpdateScaleDownNodeRemovalLatency(true, "none", 10*time.Second)
-	m.UpdateScaleDownNodeRemovalLatency(false, "BlockedByPod", 20*time.Second)
+	m.UpdateScaleDownNodeRemovalLatency(false, "node_has_unevictable_pods", 20*time.Second)
 
 	var metric1 dto.Metric
 	err := m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("true", "none").(prometheus.Histogram).Write(&metric1)
@@ -102,7 +102,7 @@ func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	assert.Equal(t, 10.0, metric1.Histogram.GetSampleSum())
 
 	var metric2 dto.Metric
-	err = m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("false", "BlockedByPod").(prometheus.Histogram).Write(&metric2)
+	err = m.scaleDownNodeRemovalLatency.HistogramVec.WithLabelValues("false", "node_has_unevictable_pods").(prometheus.Histogram).Write(&metric2)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), metric2.Histogram.GetSampleCount())
 	assert.Equal(t, 20.0, metric2.Histogram.GetSampleSum())

--- a/pkg/simulator/cluster.go
+++ b/pkg/simulator/cluster.go
@@ -65,45 +65,45 @@ type UnremovableReason int
 func (r UnremovableReason) String() string {
 	switch r {
 	case NoReason:
-		return "NoReason"
+		return "uninitialized_status_reason_bug"
 	case ScaleDownDisabledAnnotation:
-		return "ScaleDownDisabledAnnotation"
+		return "node_has_scale_down_disabled_annotation"
 	case ScaleDownUnreadyDisabled:
-		return "ScaleDownUnreadyDisabled"
+		return "scale_down_unready_disabled"
 	case NotAutoscaled:
-		return "NotAutoscaled"
+		return "not_autoscaled"
 	case NotUnneededLongEnough:
-		return "NotUnneededLongEnough"
+		return "not_unneeded_long_enough"
 	case NotUnreadyLongEnough:
-		return "NotUnreadyLongEnough"
+		return "not_unready_long_enough"
 	case NodeGroupMinSizeReached:
-		return "NodeGroupMinSizeReached"
+		return "node_pool_min_size_limit_reached"
 	case NodeGroupMaxDeletionCountReached:
-		return "NodeGroupMaxDeletionCountReached"
+		return "max_deletion_count_reached"
 	case AtomicScaleDownFailed:
-		return "AtomicScaleDownFailed"
+		return "atomic_node_group_scale_down_failed"
 	case MinimalResourceLimitExceeded:
-		return "MinimalResourceLimitExceeded"
+		return "minimal_resource_limit_exceeded"
 	case CurrentlyBeingDeleted:
-		return "CurrentlyBeingDeleted"
+		return "node_is_already_being_deleted"
 	case NotUnderutilized:
-		return "NotUnderutilized"
+		return "node_utilization_is_above_scale_down_threshold"
 	case NotUnneededOtherReason:
-		return "NotUnneededOtherReason"
+		return "skipped_in_this_autoscaling_loop"
 	case RecentlyUnremovable:
-		return "RecentlyUnremovable"
+		return "node_recently_marked_unremovable"
 	case NoPlaceToMovePods:
-		return "NoPlaceToMovePods"
+		return "no_suitable_node_to_reschedule_pods"
 	case BlockedByPod:
-		return "BlockedByPod"
+		return "node_has_unevictable_pods"
 	case UnexpectedError:
-		return "UnexpectedError"
+		return "internal_autoscaler_error"
 	case NoNodeInfo:
-		return "NoNodeInfo"
+		return "node_not_found_in_cluster_snapshot"
 	case BlockedByOnCompletionPod:
-		return "BlockedByOnCompletionPod"
+		return "node_has_on_completion_pods_running"
 	default:
-		return "Unknown"
+		return "unknown"
 	}
 }
 


### PR DESCRIPTION
Standardize UnremovableReason strings and scale-down latency metric reasons

- Update UnremovableReason.String() to return standardized snake_case reason strings for Prometheus metrics and observability.
- Update NodeLatencyTracker to record "node_became_needed_again" when an unneeded node becomes needed again without a prior blocker.
- Update unit tests in latencytracker and metrics packages to reflect the new standardized reason strings.

#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

This PR changes the string representation of `simulator.UnremovableReason` to make them more user friendly .


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

* This updates the values of the `reason` label on `cluster_autoscaler_unremovable_nodes_count` and the `delay_reason` label on `cluster_autoscaler_node_removal_latency_seconds`.
* Existing dashboards or alerting rules matching on legacy PascalCase strings (e.g., `BlockedByPod`) should be updated to match the new standardized snake_case strings (e.g., `node_has_unevictable_pods`).

#### Does this PR introduce a user-facing change?

```release-note
Standardized `reason` and `delay_reason` Prometheus label values emitted by `cluster_autoscaler_unremovable_nodes_count` and `cluster_autoscaler_node_removal_latency_seconds` to snake_case format.
```