### PR TITLE
Patch unkeyed fields used in CLI flags test

### DIFF
--- a/pkg/config/flags/flags_test.go
+++ b/pkg/config/flags/flags_test.go
@@ -139,8 +139,14 @@ func TestParseShutdownGracePeriodsAndPriorities(t *testing.T) {
 			name:  "parsable input",
 			input: "1:2,3:4",
 			want: []kubelet_config.ShutdownGracePeriodByPodPriority{
-				{1, 2},
-				{3, 4},
+				{
+					Priority:                   1,
+					ShutdownGracePeriodSeconds: 2,
+				},
+				{
+					Priority:                   3,
+					ShutdownGracePeriodSeconds: 4,
+				},
 			},
 		},
 	}
@@ -495,7 +501,14 @@ func TestAutoscalingFlagsAllPossible(t *testing.T) {
 				assert.Equal(t, int64(100), opts.MaxCoresTotal)
 				assert.Equal(t, int64(4*1024*1024*1024), opts.MinMemoryTotal)
 				assert.Equal(t, int64(200*1024*1024*1024), opts.MaxMemoryTotal)
-				assert.Equal(t, []config.GpuLimits{{"nvidia", 1, 10}}, opts.GpuTotal)
+				wantLimits := []config.GpuLimits{
+					{
+						GpuType: "nvidia",
+						Min:     1,
+						Max:     10,
+					},
+				}
+				assert.Equal(t, wantLimits, opts.GpuTotal)
 				assert.Equal(t, 300, opts.MaxGracefulTerminationSec)
 				assert.Equal(t, 5*time.Second, opts.PendingPodsBatchingTimeout)
 				assert.True(t, opts.GracefulDegradationEnabled)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

We didn't run tests for https://github.com/kubernetes-sigs/cluster-autoscaler/pull/25 before merge and it broke unit tests on main branch due to linters not being run locally

Failure example:

```
Error: pkg/config/flags/flags_test.go:142:5: k8s.io/kubernetes/pkg/kubelet/apis/config.ShutdownGracePeriodByPodPriority struct literal uses unkeyed fields
Error: pkg/config/flags/flags_test.go:143:5: k8s.io/kubernetes/pkg/kubelet/apis/config.ShutdownGracePeriodByPodPriority struct literal uses unkeyed fields
Error: pkg/config/flags/flags_test.go:498:40: sigs.k8s.io/cluster-autoscaler/pkg/config.GpuLimits struct literal uses unkeyed fields
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
