### PR TITLE
Point verification and testing job to use golang version defined in the go.mod

### DIFF
--- a/.github/workflows/ca-test.yaml
+++ b/.github/workflows/ca-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Apt-get

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Apt-get

--- a/pkg/simulator/framework/delegating_shared_lister.go
+++ b/pkg/simulator/framework/delegating_shared_lister.go
@@ -67,11 +67,12 @@ func (lister *DelegatingSchedulerSharedLister) PodGroupStates() schedulerinterfa
 	return lister.delegate.PodGroupStates()
 }
 
+// CompositePodGroupStates returns a CompositePodGroupStateLister.
 func (lister *DelegatingSchedulerSharedLister) CompositePodGroupStates() schedulerinterface.CompositePodGroupStateLister {
 	return lister.delegate.CompositePodGroupStates()
 }
 
-// CompositePodsGroups returns a CompositePodGroupLister
+// CompositePodGroups returns a CompositePodGroupLister.
 func (lister *DelegatingSchedulerSharedLister) CompositePodGroups() schedulerinterface.CompositePodGroupLister {
 	return lister.delegate.CompositePodGroups()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently verification and testing github actions setup a specific version of the golang to use in the job manifest, this PR changes that to depend purely on the version declared in go.mod in order to avoid version staleness as happened right now for verification job (1.25 defined while 1.26 used in reality)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
