### PR TITLE
Fix cluster-autoscaler-status update error when the size of the config map exceeds 1MB limit

### DIFF
--- a/pkg/clusterstate/utils/status.go
+++ b/pkg/clusterstate/utils/status.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"sort"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -39,6 +41,8 @@ const (
 	ConfigMapLastUpdatedKey = "cluster-autoscaler.kubernetes.io/last-updated"
 	// ConfigMapLastUpdateFormat it the timestamp format used for last update annotation in status ConfigMap
 	ConfigMapLastUpdateFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+	// maxStatusBytes is the maximum number of bytes we can write to a config map. The limit comes from 1MB value limit of etcd with a safety buffer.
+	maxStatusBytes = 1000000
 )
 
 // LogEventRecorder records events on some top-level object, to give user (without access to logs) a view of most important CA actions.
@@ -100,9 +104,9 @@ func WriteStatusConfigMap(ctx context.Context, kubeClient kube_client.Interface,
 	var errMsg string
 	maps := kubeClient.CoreV1().ConfigMaps(namespace)
 	configMap, getStatusError = maps.Get(ctx, statusConfigMapName, metav1.GetOptions{})
-	statusYaml, err := yaml.Marshal(status)
+	statusYaml, err := marshalAndTruncateStatus(status, maxStatusBytes)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal status configmap: %v", err)
+		return nil, err
 	}
 	statusMsg := string(statusYaml)
 	if getStatusError == nil {
@@ -156,4 +160,102 @@ func DeleteStatusConfigMap(kubeClient kube_client.Interface, namespace string, s
 		klog.Error("Failed to delete status configmap")
 	}
 	return err
+}
+
+// marshalAndTruncateStatus marshals the ClusterAutoscalerStatus to YAML.
+// If the resulting YAML exceeds maxStatusBytes, it uses binary search
+// to find the maximum number of NodeGroups that can be included without exceeding the limit.
+func marshalAndTruncateStatus(status api.ClusterAutoscalerStatus, maxStatusSize int) ([]byte, error) {
+	statusYaml, err := yaml.Marshal(status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal status configmap: %v", err)
+	}
+
+	if len(statusYaml) <= maxStatusSize || len(status.NodeGroups) == 0 {
+		return statusYaml, nil
+	}
+
+	// Sort NodeGroups to ensure the most important ones are kept if truncation is necessary.
+	// Priority: Unhealthy > ScaleUp Backoff/Error > Active ScaleUp > Active ScaleDown.
+	slices.SortStableFunc(status.NodeGroups, func(a, b api.NodeGroupStatus) int {
+		// Priority 1: Unhealthy NodeGroups
+		aUnhealthy := a.Health.Status == api.ClusterAutoscalerUnhealthy
+		bUnhealthy := b.Health.Status == api.ClusterAutoscalerUnhealthy
+		if aUnhealthy != bUnhealthy {
+			if aUnhealthy {
+				return -1
+			}
+			return 1
+		}
+
+		// Priority 2: ScaleUp is Backoff or Unhealthy
+		aBackoff := a.ScaleUp.Status == api.ClusterAutoscalerBackoff || a.ScaleUp.Status == api.ClusterAutoscalerUnhealthy
+		bBackoff := b.ScaleUp.Status == api.ClusterAutoscalerBackoff || b.ScaleUp.Status == api.ClusterAutoscalerUnhealthy
+		if aBackoff != bBackoff {
+			if aBackoff {
+				return -1
+			}
+			return 1
+		}
+
+		// Priority 3: ScaleUp is InProgress or Needed
+		aActiveScaleUp := a.ScaleUp.Status == api.ClusterAutoscalerInProgress || a.ScaleUp.Status == api.ClusterAutoscalerNeeded
+		bActiveScaleUp := b.ScaleUp.Status == api.ClusterAutoscalerInProgress || b.ScaleUp.Status == api.ClusterAutoscalerNeeded
+		if aActiveScaleUp != bActiveScaleUp {
+			if aActiveScaleUp {
+				return -1
+			}
+			return 1
+		}
+
+		// Priority 4: ScaleDown Candidates Present
+		aActiveScaleDown := a.ScaleDown.Status == api.ClusterAutoscalerCandidatesPresent
+		bActiveScaleDown := b.ScaleDown.Status == api.ClusterAutoscalerCandidatesPresent
+		if aActiveScaleDown != bActiveScaleDown {
+			if aActiveScaleDown {
+				return -1
+			}
+			return 1
+		}
+
+		return 0
+	})
+
+	originalNodeGroups := status.NodeGroups
+	var bestYaml []byte
+	var marshalErr error
+
+	// Search for the first length where the marshaled YAML size strictly exceeds maxStatusBytes.
+	failedLength := sort.Search(len(originalNodeGroups)+1, func(length int) bool {
+		status.NodeGroups = originalNodeGroups[:length]
+		midYaml, err := yaml.Marshal(status)
+		if err != nil {
+			marshalErr = err
+			return true // Treat error as exceeding size to stop expanding
+		}
+
+		if len(midYaml) <= maxStatusSize {
+			bestYaml = midYaml
+			return false // Length fits, try a larger length
+		}
+		return true // Length exceeds limit, try a smaller length
+	})
+
+	if marshalErr != nil {
+		return nil, fmt.Errorf("failed to marshal status configmap during truncation: %v", marshalErr)
+	}
+
+	if failedLength <= len(originalNodeGroups) {
+		finalLength := max(failedLength-1, 0)
+		klog.Infof("Status configmap size limit exceeded. Truncated from %d to %d NodeGroups", len(originalNodeGroups), finalLength)
+	}
+
+	// bestYaml holds the yaml for failedLength - 1.
+	// If even 0 node groups exceeds the limit, bestYaml will be nil.
+	if bestYaml == nil {
+		status.NodeGroups = originalNodeGroups[:0]
+		return yaml.Marshal(status)
+	}
+
+	return bestYaml, nil
 }

--- a/pkg/clusterstate/utils/status_test.go
+++ b/pkg/clusterstate/utils/status_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"sigs.k8s.io/yaml"
+
 	apiv1 "k8s.io/api/core/v1"
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -259,4 +261,123 @@ func TestWriteStatusConfigMapMarshal(t *testing.T) {
 		t.Fatalf("Expected WriteStatusConfigMap not to return error, got: %v", err)
 	}
 	assert.YAMLEq(t, string(want), result.Data["status"])
+}
+
+func TestMarshalAndTruncateStatus(t *testing.T) {
+	testNodeGroups := []api.NodeGroupStatus{
+		// Size when marshalled individually: ~1025 bytes
+		{Name: "ng-1-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}, ScaleUp: api.NodeGroupScaleUpCondition{Status: api.ClusterAutoscalerNoActivity}, ScaleDown: api.ScaleDownCondition{Status: api.ClusterAutoscalerNoCandidates}},
+		// Size when marshalled individually: ~981 bytes
+		{Name: "ng-2-unhealthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerUnhealthy}},
+		// Size when marshalled individually: ~1005 bytes
+		{Name: "ng-3-scaleup-backoff", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}, ScaleUp: api.NodeGroupScaleUpCondition{Status: api.ClusterAutoscalerBackoff}},
+		// Size when marshalled individually: ~1011 bytes
+		{Name: "ng-4-scaleup-inprogress", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}, ScaleUp: api.NodeGroupScaleUpCondition{Status: api.ClusterAutoscalerInProgress}},
+		// Size when marshalled individually: ~1020 bytes
+		{Name: "ng-5-scaledown-candidates", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}, ScaleDown: api.ScaleDownCondition{Status: api.ClusterAutoscalerCandidatesPresent}},
+	}
+
+	testCases := []struct {
+		name                 string
+		nodeGroups           []api.NodeGroupStatus
+		maxSize              int
+		expectedLengths      int
+		expectedNamesInOrder []string
+	}{
+		{
+			// Fits all 5 node groups. Total marshaled size is ~3274 bytes.
+			name:                 "No truncation needed",
+			nodeGroups:           testNodeGroups,
+			maxSize:              100000,
+			expectedLengths:      5,
+			expectedNamesInOrder: []string{"ng-1-healthy", "ng-2-unhealthy", "ng-3-scaleup-backoff", "ng-4-scaleup-inprogress", "ng-5-scaledown-candidates"},
+		},
+		{
+			// Fits exactly 2 node groups (which marshal to ~1544 bytes).
+			// An empty status is ~430 bytes, and each additional group is ~550 bytes.
+			name:                 "Truncation limits to 2 elements",
+			nodeGroups:           testNodeGroups,
+			maxSize:              1600,
+			expectedLengths:      2,
+			expectedNamesInOrder: []string{"ng-2-unhealthy", "ng-3-scaleup-backoff"},
+		},
+		{
+			// Fits exactly 1 node group (which marshals to ~981 bytes).
+			// 2 groups (~1544 bytes) exceeds the 1500 maxSize limit.
+			name:                 "Exactly one NodeGroup fits",
+			nodeGroups:           testNodeGroups,
+			maxSize:              1500,
+			expectedLengths:      1,
+			expectedNamesInOrder: []string{"ng-2-unhealthy"},
+		},
+		{
+			// Fits 0 node groups. Empty status is ~430 bytes, which exceeds the maxSize limit of 10.
+			name:                 "Max size too small for even 0 node groups",
+			nodeGroups:           testNodeGroups,
+			maxSize:              10,
+			expectedLengths:      0,
+			expectedNamesInOrder: []string{},
+		},
+		{
+			// Fits 0 node groups. Total marshaled size is ~430 bytes.
+			name:                 "Empty NodeGroups",
+			nodeGroups:           []api.NodeGroupStatus{},
+			maxSize:              100000,
+			expectedLengths:      0,
+			expectedNamesInOrder: []string{},
+		},
+		{
+			// Fits all 3 node groups. Total marshaled size is ~2047 bytes.
+			name: "Stable sort test: same priority elements retain original order",
+			nodeGroups: []api.NodeGroupStatus{
+				{Name: "ng-a-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}},
+				{Name: "ng-b-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}},
+				{Name: "ng-c-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}},
+			},
+			maxSize:              100000,
+			expectedLengths:      3,
+			expectedNamesInOrder: []string{"ng-a-healthy", "ng-b-healthy", "ng-c-healthy"},
+		},
+		{
+			// Fits exactly 1 node group (which marshals to ~977 bytes).
+			// 2 groups (~1512 bytes) exceeds the 1500 maxSize limit.
+			name: "Stable sort test with truncation",
+			nodeGroups: []api.NodeGroupStatus{
+				{Name: "ng-a-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}},
+				{Name: "ng-b-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}},
+				{Name: "ng-c-healthy", Health: api.NodeGroupHealthCondition{Status: api.ClusterAutoscalerHealthy}},
+			},
+			maxSize:              1500, // fits exactly 1 item based on our byte sizing logic
+			expectedLengths:      1,
+			expectedNamesInOrder: []string{"ng-a-healthy"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testStatus := api.ClusterAutoscalerStatus{
+				NodeGroups: make([]api.NodeGroupStatus, len(tc.nodeGroups)),
+			}
+			copy(testStatus.NodeGroups, tc.nodeGroups)
+
+			b, err := marshalAndTruncateStatus(testStatus, tc.maxSize)
+			assert.NoError(t, err)
+
+			// If the max size is extremely small (like 10), even 0 node groups will exceed it,
+			// but the function should still return the 0-node-group YAML (which is ~430 bytes).
+			// So we only enforce length checks if maxSize is reasonably large.
+			if tc.maxSize >= 500 {
+				assert.True(t, len(b) <= tc.maxSize, "Output YAML size must be under the limit")
+			}
+
+			var out api.ClusterAutoscalerStatus
+			err = yaml.Unmarshal(b, &out)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expectedLengths, len(out.NodeGroups))
+			for i, expectedName := range tc.expectedNamesInOrder {
+				assert.Equal(t, expectedName, out.NodeGroups[i].Name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When there are a lot of node groups, the size of the status config map grows more than 1MB. So CA fails to update the status config map and logs the following error.

```
Failed to write status configmap:
ConfigMap "cluster-autoscaler-status" is invalid: []:
Too long: may not be more than 1048576 bytes
```

This PR truncates the number of node groups from the config map to keep it under 1MB limit

When the size exceeds 1 000 000 Bytes node groups will be sorted in the ordered by state where Unhealthy > ScaleUp Backoff/Error > Active ScaleUp > Active ScaleDown. Maximum number of node groups that can be included within the 1MB limit will be find using binary search.

Alternatives Considered:
- Limit the number of node groups to a const to maintain the total size under 1MB. If we calculate an upper bound it would be around 700 node groups. This calculation includes space for the backoff field which has a error message of up to 500 bytes. This increase the variance of the upper bound and significantly lowerd the worst case node group count. 
- Increasing this 1MB limit is not possible since this comes from the size of value field in etcd.
- Altering the config map format will not solve the problem and may break some customer integrations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If the size of the cluster-autoscaler-status config map grows more than 1 000 000 Bytes list of node groups will be truncated to fit in to 1 000 000 Bytes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
