### PR TITLE
Make BenchmarkScheduleRevert run correctly

### DIFF
--- a/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
+++ b/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
@@ -279,7 +279,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 		sharedClaim := createTestResourceClaim(devicesPerSlice, 1, driverName, deviceClassName)
 		sharedClaim, satisfied := allocateResourceSlicesForClaim(sharedClaim, nodeName, nodeSlice)
 		if !satisfied {
-			b.Errorf("Error during setup, claim allocation cannot be satistied")
+			b.Fatalf("Error during setup, claim allocation cannot be satisfied")
 		}
 
 		claimsOnNode := make([]*resourceapi.ResourceClaim, maxPodsCount)
@@ -297,7 +297,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 			ownedClaim = drautils.TestClaimWithPodOwnership(pod, ownedClaim)
 			ownedClaim, satisfied := allocateResourceSlicesForClaim(ownedClaim, nodeName, nodeSlice)
 			if !satisfied {
-				b.Errorf("Error during setup, claim allocation cannot be satistied")
+				b.Fatalf("Error during setup, claim allocation cannot be satisfied")
 			}
 
 			podsOnNode[podIndex] = pod
@@ -310,15 +310,26 @@ func BenchmarkScheduleRevert(b *testing.B) {
 		owningPods[nodeIndex] = podsOnNode
 	}
 
-	b.ResetTimer()
 	for snapshotName, snapshotFactory := range snapshots {
 		b.Run(snapshotName, func(b *testing.B) {
 			for cfgName, cfg := range configurations {
 				b.Run(cfgName, func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
+						// AddNodeInfo pushes the claims of the pods already sitting on a NodeInfo
+						// into the DRA snapshot, and SchedulePod adds pods to the NodeInfo it
+						// schedules onto. Reusing the NodeInfos built above would therefore make
+						// the second iteration re-add claims the first one already registered.
+						// Every iteration gets its own copies, built outside the measurement.
+						b.StopTimer()
+						iterNodeInfos := make([]*framework.NodeInfo, cfg.nodesCount)
+						for nodeIndex := 0; nodeIndex < cfg.nodesCount; nodeIndex++ {
+							iterNodeInfos[nodeIndex] = nodeInfos[nodeIndex].DeepCopy()
+						}
+						b.StartTimer()
+
 						snapshot, err := snapshotFactory()
 						if err != nil {
-							b.Errorf("Failed to create a snapshot: %v", err)
+							b.Fatalf("Failed to create a snapshot: %v", err)
 						}
 
 						draSnapshot := drasnapshot.NewSnapshot(
@@ -328,31 +339,38 @@ func BenchmarkScheduleRevert(b *testing.B) {
 							devicesClasses,
 						)
 
-						draSnapshot.AddClaims(sharedClaims)
+						if err := draSnapshot.AddClaims(sharedClaims[:cfg.nodesCount]); err != nil {
+							b.Fatalf("Failed to add shared claims: %v", err)
+						}
 						for nodeIndex := 0; nodeIndex < cfg.nodesCount; nodeIndex++ {
-							draSnapshot.AddClaims(ownedClaims[nodeIndex])
+							if err := draSnapshot.AddClaims(ownedClaims[nodeIndex][:cfg.ownedClaimPods]); err != nil {
+								b.Fatalf("Failed to add owned claims: %v", err)
+							}
 						}
 
 						err = snapshot.SetClusterState(nil, nil, draSnapshot, nil)
 						if err != nil {
-							b.Errorf("Failed to set cluster state: %v", err)
+							b.Fatalf("Failed to set cluster state: %v", err)
 						}
 
 						for nodeIndex := 0; nodeIndex < cfg.nodesCount; nodeIndex++ {
-							nodeInfo := nodeInfos[nodeIndex]
+							nodeInfo := iterNodeInfos[nodeIndex]
 							for i := 0; i < cfg.forks; i++ {
 								snapshot.Fork()
 							}
 
 							err := snapshot.AddNodeInfo(nodeInfo)
 							if err != nil {
-								b.Errorf("Failed to add node info to snapshot: %v", err)
+								b.Fatalf("Failed to add node info to snapshot: %v", err)
 							}
 
 							sharedClaim := sharedClaims[nodeIndex]
 							for podIndex := 0; podIndex < cfg.sharedClaimPods; podIndex++ {
 								pod := BuildTestPod(
-									fmt.Sprintf("pod-%d", podIndex),
+									// The name has to be unique across nodes, otherwise configurations
+									// that commit instead of reverting end up scheduling several pods
+									// with the same key into one snapshot.
+									fmt.Sprintf("shared-pod-%d-%d", nodeIndex, podIndex),
 									1,
 									1,
 									WithResourceClaim(sharedClaim.Name, sharedClaim.Name, ""),
@@ -360,7 +378,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 
 								err := snapshot.SchedulePod(pod, nodeInfo.Node().Name)
 								if err != nil {
-									b.Errorf(
+									b.Fatalf(
 										"Failed to schedule a pod %s to node %s: %v",
 										pod.Name,
 										nodeInfo.Node().Name,
@@ -373,7 +391,7 @@ func BenchmarkScheduleRevert(b *testing.B) {
 								owningPod := owningPods[nodeIndex][podIndex]
 								err := snapshot.SchedulePod(owningPod, nodeInfo.Node().Name)
 								if err != nil {
-									b.Errorf(
+									b.Fatalf(
 										"Failed to schedule a pod %s to node %s: %v",
 										owningPod.Name,
 										nodeInfo.Node().Name,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`BenchmarkScheduleRevert` fails on every run today — this is not just a re-run problem.

`AddNodeInfo` pushes the claims of the pods already on a `NodeInfo` into the DRA snapshot, and
`SchedulePod` adds pods to the `NodeInfo` it schedules onto. The `NodeInfo`s are built once in
setup and shared by every `b.N` iteration and by all 120 sub-benchmarks (60 configurations × 2
snapshot stores). The second pass over them re-adds claims the first pass registered:

```
Failed to add node info: claim default/claim-... already tracked
Failed to schedule pod-0 to node-0: NodeInfo for "node-0": node not found
```

`AddNodeInfo` returns early on that error so the node is never stored, and because the failures
were reported with `b.Errorf` rather than `b.Fatalf`, each one cascaded into a hundred or so
follow-on errors.

On current `main`, a single `-benchtime=1x` pass emits 236,200 error lines (226,600 `node not
found`, 6,400 `already tracked`, 3,200 `Too many pods`) and exactly **one** of the 120
sub-benchmarks reports a timing — the first to run, before the shared state is corrupted. So the
benchmark currently measures almost nothing.

This PR:

- gives each iteration its own copies of the `NodeInfo`s, built outside the measured section
- aborts on the first failure instead of cascading
- makes the shared-claim pod names unique per node — they were all `pod-<index>`, so the
  configurations that commit instead of reverting scheduled several pods with the same key into
  one snapshot
- registers only the claims a configuration actually uses, rather than all of them
- drops the `ResetTimer` that ran before the sub-benchmarks rather than inside them

After the change the package passes in 4.8s with zero errors and all 120 sub-benchmarks report a
timing.

#### Which issue(s) this PR fixes:

N/A - no issue filed for this.

#### Special notes for your reviewer:

Reproduce before and after with:

```
go test -run '^$' -bench BenchmarkScheduleRevert -benchtime=1x ./pkg/simulator/clustersnapshot/predicate/
```

On `main` this exits 1; with this PR it exits 0 and prints 120 results.

Two notes on choices that go slightly beyond the title:

- **`b.Errorf` → `b.Fatalf`.** A benchmark that continues after a failed setup still reports
  ns/op, so a failure surfaces as quietly wrong numbers rather than a failed run. It also fixes a
  latent nil dereference: `snapshotFactory()` returns `(nil, err)`, and the old code carried on to
  call `snapshot.SetClusterState` on the nil value.
- **Per-iteration `DeepCopy`.** This is wrapped in `StopTimer`/`StartTimer`, so the copying is not
  attributed to the measured section.

The benchmark is not part of the `ca-benchmark` CI job, which runs only
`-bench=BenchmarkRunOnce ./pkg/core/bench/...`, so nothing in CI changes as a result of this.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
