### PR TITLE
Add more DRA benchmarks

### DIFF
--- a/pkg/estimator/binpacking_estimator_dra_benchmark_test.go
+++ b/pkg/estimator/binpacking_estimator_dra_benchmark_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuretesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/predicate"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/store"
+	drasnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/snapshot"
+	drautils "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/utils"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+
+	. "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+const (
+	draBenchmarkDriver          = "driver.example.com"
+	draBenchmarkDeviceClass     = "gpu"
+	draBenchmarkDevicesPerNode  = 8
+	draBenchmarkPredicateWorker = 4 // Matches the --predicate-parallelism default.
+)
+
+// draBenchmarkSlice builds the ResourceSlice advertising a node's devices.
+func draBenchmarkSlice(nodeName string, devices int) *resourceapi.ResourceSlice {
+	deviceList := make([]resourceapi.Device, devices)
+	for i := 0; i < devices; i++ {
+		deviceList[i] = resourceapi.Device{Name: fmt.Sprintf("gpu-%d", i)}
+	}
+	return &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-" + nodeName, UID: types.UID("slice-" + nodeName)},
+		Spec: resourceapi.ResourceSliceSpec{
+			NodeName: &nodeName,
+			Driver:   draBenchmarkDriver,
+			Pool:     resourceapi.ResourcePool{Name: nodeName, ResourceSliceCount: 1},
+			Devices:  deviceList,
+		},
+	}
+}
+
+// draBenchmarkClaim builds an unallocated ResourceClaim asking for a single device.
+func draBenchmarkClaim(name string) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name)},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{Requests: []resourceapi.DeviceRequest{{
+				Name: "req",
+				Exactly: &resourceapi.ExactDeviceRequest{
+					DeviceClassName: draBenchmarkDeviceClass,
+					Selectors: []resourceapi.DeviceSelector{{CEL: &resourceapi.CELDeviceSelector{
+						Expression: fmt.Sprintf(`device.driver == "%s"`, draBenchmarkDriver),
+					}}},
+					AllocationMode: resourceapi.DeviceAllocationModeExactCount,
+					Count:          1,
+				},
+			}}},
+		},
+	}
+}
+
+// draBenchmarkAllocatedClaim marks the claim as already holding one device of the node's pool,
+// standing in for a claim of a pod that is already running.
+func draBenchmarkAllocatedClaim(claim *resourceapi.ResourceClaim, nodeName string, deviceIndex int) *resourceapi.ResourceClaim {
+	return drautils.TestClaimWithAllocation(claim, &resourceapi.AllocationResult{
+		NodeSelector: &apiv1.NodeSelector{NodeSelectorTerms: []apiv1.NodeSelectorTerm{{
+			MatchFields: []apiv1.NodeSelectorRequirement{{
+				Key: "metadata.name", Operator: apiv1.NodeSelectorOpIn, Values: []string{nodeName},
+			}},
+		}}},
+		Devices: resourceapi.DeviceAllocationResult{Results: []resourceapi.DeviceRequestAllocationResult{{
+			Request: "req", Driver: draBenchmarkDriver, Pool: nodeName, Device: fmt.Sprintf("gpu-%d", deviceIndex),
+		}}},
+	})
+}
+
+// BenchmarkBinpackingEstimateDRA measures one scale-up estimation - what Cluster Autoscaler
+// runs for a single node group in ComputeExpansionOption - against a cluster that already
+// carries a lot of DRA workload.
+//
+// The cluster is shaped like a GPU fleet: every node advertises devices through a
+// ResourceSlice, and part of the fleet is already consumed by allocated ResourceClaims, so the
+// DRA snapshot holds nodes*claimsPerNode of them.
+//
+// The pending pods deliberately own *unallocated* claims. That is what makes this benchmark
+// representative: with pre-allocated claims the scheduler reuses the existing allocation and
+// never runs the structured allocator, so the whole PreFilter path that gathers the allocated
+// state of every claim is skipped and the benchmark stops measuring the interesting part.
+//
+// Note that a real Cluster Autoscaler loop pays this once per candidate node group, so the
+// numbers here have to be multiplied by the number of node groups being considered.
+func BenchmarkBinpackingEstimateDRA(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, feature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
+
+	for _, scenario := range []struct {
+		name          string
+		nodes         int
+		claimsPerNode int
+		pendingPods   int
+	}{
+		{"nodes=1000/claims=4000/pendingPods=200", 1000, 4, 200},
+		{"nodes=5000/claims=20000/pendingPods=500", 5000, 4, 500},
+	} {
+		b.Run(scenario.name, func(b *testing.B) {
+			deviceClasses := map[string]*resourceapi.DeviceClass{
+				draBenchmarkDeviceClass: {ObjectMeta: metav1.ObjectMeta{Name: draBenchmarkDeviceClass, UID: "gpu-class"}},
+			}
+
+			// The existing fleet, with part of its devices already handed out.
+			existingNodes := make([]*framework.NodeInfo, scenario.nodes)
+			allocatedClaims := make([]*resourceapi.ResourceClaim, 0, scenario.nodes*scenario.claimsPerNode)
+			for nodeIndex := 0; nodeIndex < scenario.nodes; nodeIndex++ {
+				nodeName := fmt.Sprintf("node-%d", nodeIndex)
+				node := makeNode(16000, 64000, 110, nodeName, "zone-a")
+				slice := draBenchmarkSlice(nodeName, draBenchmarkDevicesPerNode)
+				existingNodes[nodeIndex] = framework.NewNodeInfo(node, []*resourceapi.ResourceSlice{slice})
+
+				for claimIndex := 0; claimIndex < scenario.claimsPerNode; claimIndex++ {
+					claim := draBenchmarkClaim(fmt.Sprintf("running-%d-%d", nodeIndex, claimIndex))
+					allocatedClaims = append(allocatedClaims, draBenchmarkAllocatedClaim(claim, nodeName, claimIndex))
+				}
+			}
+
+			// The template of the node group being scaled up. The estimator sanitizes it per
+			// added node, so each new node gets its own device pool.
+			nodeTemplate := framework.NewNodeInfo(
+				makeNode(16000, 64000, 110, "template", "zone-a"),
+				[]*resourceapi.ResourceSlice{draBenchmarkSlice("template", draBenchmarkDevicesPerNode)},
+			)
+
+			// The pods waiting for capacity, each owning an unallocated claim.
+			pendingPods := make([]*apiv1.Pod, scenario.pendingPods)
+			pendingClaims := make([]*resourceapi.ResourceClaim, scenario.pendingPods)
+			for podIndex := 0; podIndex < scenario.pendingPods; podIndex++ {
+				claim := draBenchmarkClaim(fmt.Sprintf("pending-%d", podIndex))
+				pod := BuildTestPod(
+					fmt.Sprintf("pending-pod-%d", podIndex), 500, 1000,
+					WithNamespace("default"),
+					WithResourceClaim(claim.Name, claim.Name, ""),
+				)
+				pendingClaims[podIndex] = drautils.TestClaimWithPodOwnership(pod, claim)
+				pendingPods[podIndex] = pod
+			}
+			podEquivalenceGroups := []PodEquivalenceGroup{{Pods: pendingPods}}
+
+			var estimatedNodes int
+			var estimatedPods []*apiv1.Pod
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Building the snapshot is not what's being measured here, and the estimation
+				// mutates it, so every iteration gets a fresh one with the timer stopped.
+				b.StopTimer()
+				fwHandle, err := framework.NewTestFrameworkHandle()
+				if err != nil {
+					b.Fatalf("NewTestFrameworkHandle(): unexpected error: %v", err)
+				}
+				clusterSnapshot := predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle, true, draBenchmarkPredicateWorker, false, 0 /* schedulerVerbosityOffset */)
+
+				draSnapshot := drasnapshot.NewSnapshot(nil, nil, nil, deviceClasses)
+				if err := draSnapshot.AddClaims(allocatedClaims); err != nil {
+					b.Fatalf("AddClaims(): unexpected error for allocated claims: %v", err)
+				}
+				if err := draSnapshot.AddClaims(pendingClaims); err != nil {
+					b.Fatalf("AddClaims(): unexpected error for pending claims: %v", err)
+				}
+				if err := clusterSnapshot.SetClusterState(context.Background(), nil, nil, draSnapshot, nil); err != nil {
+					b.Fatalf("SetClusterState(): unexpected error: %v", err)
+				}
+				for _, nodeInfo := range existingNodes {
+					if err := clusterSnapshot.AddNodeInfo(nodeInfo.DeepCopy()); err != nil {
+						b.Fatalf("AddNodeInfo(): unexpected error: %v", err)
+					}
+				}
+
+				limiter := NewThresholdBasedEstimationLimiter([]Threshold{NewStaticThreshold(1000, time.Duration(0))})
+				estimator := NewBinpackingNodeEstimator(clusterSnapshot, limiter, NewDecreasingPodOrderer(), nil /* EstimationContext */, nil /* EstimationAnalyserFunc */, false)
+				b.StartTimer()
+
+				estimatedNodes, estimatedPods = estimator.Estimate(context.Background(), podEquivalenceGroups, nodeTemplate, nil)
+			}
+			b.StopTimer()
+
+			// A run that places nothing would measure the wrong thing entirely.
+			if estimatedNodes == 0 || len(estimatedPods) == 0 {
+				b.Fatalf("Estimate(): expected pods to be placed on new nodes, got %d nodes and %d pods", estimatedNodes, len(estimatedPods))
+			}
+		})
+	}
+}

--- a/pkg/estimator/binpacking_estimator_dra_profiles_test.go
+++ b/pkg/estimator/binpacking_estimator_dra_profiles_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package estimator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuretesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/predicate"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/store"
+	drasnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/snapshot"
+	drautils "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/utils"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+
+	. "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+// The profiles below are modelled on how DRA is actually deployed rather than on
+// what is convenient to generate. Three things drive the shapes:
+//
+//   - A node usually runs more than one driver. A GKE GPU node can publish
+//     ResourceSlices for gpu.nvidia.com, dra.net (NICs) and
+//     compute-domain.nvidia.com at the same time, each with its own pool and
+//     DeviceClass, so "one driver, one class" is the unrealistic case.
+//   - Devices are split across ResourceSlices at ResourceSliceMaxDevices (128),
+//     so a node exposing many small devices - MIG partitions being the obvious
+//     case - publishes several slices rather than one.
+//   - Claims are not uniform. Exclusive whole-GPU requests, fractional MIG
+//     requests, whole-node multi-GPU training requests and claims shared by
+//     several pods all occur, and they exercise different paths in the snapshot.
+//
+// Each profile is a cluster shape; the benchmark runs one scale-up estimation
+// against it, which is what Cluster Autoscaler does per candidate node group.
+
+// draDriverSpec is one driver publishing devices on every node.
+type draDriverSpec struct {
+	driver         string
+	deviceClass    string
+	devicesPerNode int
+	attributesPer  int // extra attributes per device, to give CEL selectors something to match
+}
+
+// draProfile is a cluster shape plus the workload waiting to be scheduled onto it.
+type draProfile struct {
+	name  string
+	nodes int
+
+	drivers []draDriverSpec
+
+	// Existing workload: claims already allocated against the fleet.
+	allocatedClaimsPerNode int
+
+	// Pending workload. Pods either own a claim each (the ResourceClaimTemplate
+	// pattern) or share one claim between podsPerSharedClaim pods.
+	pendingPods        int
+	devicesPerClaim    int
+	podsPerSharedClaim int
+
+	// unallocatedExisting leaves the existing claims unallocated. Deriving from
+	// them costs almost nothing, so there is correspondingly little to save.
+	unallocatedExisting bool
+	// pendingPodsWithoutClaims adds pods that use no DRA at all. The scheduler
+	// skips the DRA PreFilter for them entirely.
+	pendingPodsWithoutClaims int
+}
+
+const (
+	gpuDriver     = "gpu.nvidia.com"
+	gpuClass      = "gpu.nvidia.com"
+	migClass      = "mig.nvidia.com"
+	netDriver     = "dra.net"
+	netClass      = "dra.net"
+	cdDriver      = "compute-domain.nvidia.com"
+	cdChannelName = "compute-domain-default-channel.nvidia.com"
+)
+
+func draProfiles() []draProfile {
+	return []draProfile{
+		{
+			// The common inference shape: 8 whole GPUs per node, one per pod.
+			name:                   "gpu8/exclusive",
+			nodes:                  500,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4}},
+			allocatedClaimsPerNode: 4,
+			pendingPods:            300,
+			devicesPerClaim:        1,
+		},
+		{
+			// Distributed training: a pod takes every GPU on a node. Fewer, much
+			// larger allocations.
+			name:                   "gpu8/wholeNode",
+			nodes:                  500,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4}},
+			allocatedClaimsPerNode: 1,
+			pendingPods:            200,
+			devicesPerClaim:        8,
+		},
+		{
+			// MIG: each of 8 GPUs partitioned 7 ways is 56 devices per node, which
+			// crosses no slice boundary yet but multiplies the device count by 7.
+			name:                   "mig56/fractional",
+			nodes:                  300,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: migClass, devicesPerNode: 56, attributesPer: 5}},
+			allocatedClaimsPerNode: 20,
+			pendingPods:            300,
+			devicesPerClaim:        1,
+		},
+		{
+			// More devices than fit in one ResourceSlice, so the node publishes
+			// several - the shape a large MIG or NIC fleet produces.
+			name:                   "devices256/multiSlice",
+			nodes:                  200,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: migClass, devicesPerNode: 256, attributesPer: 3}},
+			allocatedClaimsPerNode: 40,
+			pendingPods:            200,
+			devicesPerClaim:        1,
+		},
+		{
+			// What a GKE GPU node actually looks like: three drivers, four device
+			// classes, three pools per node.
+			name:  "multiDriver/gpu+net+computeDomain",
+			nodes: 400,
+			drivers: []draDriverSpec{
+				{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4},
+				{driver: netDriver, deviceClass: netClass, devicesPerNode: 4, attributesPer: 6},
+				{driver: cdDriver, deviceClass: cdChannelName, devicesPerNode: 2, attributesPer: 2},
+			},
+			allocatedClaimsPerNode: 4,
+			pendingPods:            250,
+			devicesPerClaim:        1,
+		},
+		{
+			// Several pods against one claim - inference servers with sidecars, or
+			// anything coordinating over a shared device.
+			name:                   "gpu8/sharedClaims",
+			nodes:                  400,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4}},
+			allocatedClaimsPerNode: 4,
+			pendingPods:            240,
+			devicesPerClaim:        1,
+			podsPerSharedClaim:     4,
+		},
+
+		{
+			// A large claim set read only once or twice: 12000 allocated claims
+			// against 3 pending pods. Recomputing walks the claims about as many
+			// times as the tracker builds them, so this shape was expected to
+			// gain little. It still gains, though it is the one profile here
+			// whose allocation count gets worse rather than better.
+			name:                   "gpu8/manyClaimsFewPods",
+			nodes:                  400,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4}},
+			allocatedClaimsPerNode: 30,
+			pendingPods:            3,
+			devicesPerClaim:        1,
+		},
+		{
+			// Claims that are present but unallocated. foreachAllocatedDevice
+			// returns immediately on a nil allocation, so the walk the tracker
+			// removes looks nearly free - but the pending pods still drive the
+			// structured allocator over the whole fleet, and this turns out to
+			// be one of the larger gains here rather than a no-op.
+			name:                   "gpu8/existingUnallocated",
+			nodes:                  400,
+			drivers:                []draDriverSpec{{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4}},
+			allocatedClaimsPerNode: 30,
+			unallocatedExisting:    true,
+			pendingPods:            200,
+			devicesPerClaim:        1,
+		},
+
+		// --- shapes where the maintained state is expected to gain little ---
+		{
+			// A DRA fleet whose pending workload does not use DRA. The DRA
+			// PreFilter short-circuits for pods without claims, so the allocated
+			// state is never asked for.
+			name:                     "noGain/draFleetNonDraPods",
+			nodes:                    400,
+			drivers:                  []draDriverSpec{{driver: gpuDriver, deviceClass: gpuClass, devicesPerNode: 8, attributesPer: 4}},
+			allocatedClaimsPerNode:   30,
+			pendingPodsWithoutClaims: 300,
+		},
+	}
+}
+
+func draProfileDevice(driver string, index, extraAttributes int) resourceapi.Device {
+	attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+		"driverVersion": {StringValue: ptr.To("560.35.03")},
+		"index":         {IntValue: ptr.To(int64(index))},
+	}
+	for a := 0; a < extraAttributes; a++ {
+		attrs[resourceapi.QualifiedName(fmt.Sprintf("attr%d", a))] = resourceapi.DeviceAttribute{
+			StringValue: ptr.To(fmt.Sprintf("value-%d", a)),
+		}
+	}
+	return resourceapi.Device{Name: fmt.Sprintf("%s-dev-%d", driver, index), Attributes: attrs}
+}
+
+// draProfileSlices builds the ResourceSlices one driver publishes for one node,
+// splitting at ResourceSliceMaxDevices the way a real driver does.
+func draProfileSlices(spec draDriverSpec, nodeName string) []*resourceapi.ResourceSlice {
+	devices := make([]resourceapi.Device, spec.devicesPerNode)
+	for i := range devices {
+		devices[i] = draProfileDevice(spec.driver, i, spec.attributesPer)
+	}
+
+	poolName := fmt.Sprintf("%s-%s", nodeName, spec.driver)
+	var slices []*resourceapi.ResourceSlice
+	for start := 0; start < len(devices); start += resourceapi.ResourceSliceMaxDevices {
+		end := min(start+resourceapi.ResourceSliceMaxDevices, len(devices))
+		name := fmt.Sprintf("%s-slice-%d", poolName, len(slices))
+		slices = append(slices, &resourceapi.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name)},
+			Spec: resourceapi.ResourceSliceSpec{
+				NodeName: ptr.To(nodeName),
+				Driver:   spec.driver,
+				Pool:     resourceapi.ResourcePool{Name: poolName, ResourceSliceCount: 1},
+				Devices:  devices[start:end],
+			},
+		})
+	}
+	for _, s := range slices {
+		s.Spec.Pool.ResourceSliceCount = int64(len(slices))
+	}
+	return slices
+}
+
+// draProfileClaim builds an unallocated claim asking for count devices of a class,
+// with a CEL selector so the allocator has to evaluate one per candidate device.
+func draProfileClaim(name, deviceClass, driver string, count int) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name)},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{Requests: []resourceapi.DeviceRequest{{
+				Name: "req",
+				Exactly: &resourceapi.ExactDeviceRequest{
+					DeviceClassName: deviceClass,
+					Selectors: []resourceapi.DeviceSelector{{CEL: &resourceapi.CELDeviceSelector{
+						Expression: fmt.Sprintf(`device.driver == %q`, driver),
+					}}},
+					AllocationMode: resourceapi.DeviceAllocationModeExactCount,
+					Count:          int64(count),
+				},
+			}}},
+		},
+	}
+}
+
+func draProfileAllocated(claim *resourceapi.ResourceClaim, nodeName, driver, pool string, deviceIndexes []int) *resourceapi.ResourceClaim {
+	results := make([]resourceapi.DeviceRequestAllocationResult, 0, len(deviceIndexes))
+	for _, idx := range deviceIndexes {
+		results = append(results, resourceapi.DeviceRequestAllocationResult{
+			Request: "req", Driver: driver, Pool: pool, Device: fmt.Sprintf("%s-dev-%d", driver, idx),
+		})
+	}
+	return drautils.TestClaimWithAllocation(claim, &resourceapi.AllocationResult{
+		NodeSelector: &apiv1.NodeSelector{NodeSelectorTerms: []apiv1.NodeSelectorTerm{{
+			MatchFields: []apiv1.NodeSelectorRequirement{{
+				Key: "metadata.name", Operator: apiv1.NodeSelectorOpIn, Values: []string{nodeName},
+			}},
+		}}},
+		Devices: resourceapi.DeviceAllocationResult{Results: results},
+	})
+}
+
+// BenchmarkBinpackingEstimateDRAProfiles runs one scale-up estimation against a
+// range of realistic DRA cluster shapes. BenchmarkBinpackingEstimateDRA varies
+// scale on a single shape; this varies the shape itself, because the cost of the
+// DRA paths depends on the number of devices and slices and device classes as
+// much as it does on the number of claims.
+func BenchmarkBinpackingEstimateDRAProfiles(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, feature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
+
+	for _, profile := range draProfiles() {
+		b.Run(profile.name, func(b *testing.B) {
+			deviceClasses := map[string]*resourceapi.DeviceClass{}
+			for _, d := range profile.drivers {
+				deviceClasses[d.deviceClass] = &resourceapi.DeviceClass{
+					ObjectMeta: metav1.ObjectMeta{Name: d.deviceClass, UID: types.UID(d.deviceClass)},
+					Spec: resourceapi.DeviceClassSpec{Selectors: []resourceapi.DeviceSelector{{
+						CEL: &resourceapi.CELDeviceSelector{Expression: fmt.Sprintf(`device.driver == %q`, d.driver)},
+					}}},
+				}
+			}
+			primary := profile.drivers[0]
+
+			existingNodes := make([]*framework.NodeInfo, profile.nodes)
+			var allocatedClaims []*resourceapi.ResourceClaim
+			for n := 0; n < profile.nodes; n++ {
+				nodeName := fmt.Sprintf("node-%d", n)
+				var slices []*resourceapi.ResourceSlice
+				for _, d := range profile.drivers {
+					slices = append(slices, draProfileSlices(d, nodeName)...)
+				}
+				existingNodes[n] = framework.NewNodeInfo(makeNode(64000, 256000, 110, nodeName, "zone-a"), slices)
+
+				// Existing allocations consume devices of the primary driver.
+				for c := 0; c < profile.allocatedClaimsPerNode; c++ {
+					claim := draProfileClaim(fmt.Sprintf("running-%d-%d", n, c), primary.deviceClass, primary.driver, 1)
+					if profile.unallocatedExisting {
+						allocatedClaims = append(allocatedClaims, claim)
+						continue
+					}
+					allocatedClaims = append(allocatedClaims,
+						draProfileAllocated(claim, nodeName, primary.driver, fmt.Sprintf("%s-%s", nodeName, primary.driver), []int{c % primary.devicesPerNode}))
+				}
+			}
+
+			nodeTemplate := func() *framework.NodeInfo {
+				var slices []*resourceapi.ResourceSlice
+				for _, d := range profile.drivers {
+					slices = append(slices, draProfileSlices(d, "template")...)
+				}
+				return framework.NewNodeInfo(makeNode(64000, 256000, 110, "template", "zone-a"), slices)
+			}()
+
+			// Pending workload. With podsPerSharedClaim > 0 several pods reference
+			// one claim; otherwise each pod owns its own.
+			var pendingPods []*apiv1.Pod
+			var pendingClaims []*resourceapi.ResourceClaim
+			if profile.podsPerSharedClaim > 0 {
+				shared := (profile.pendingPods + profile.podsPerSharedClaim - 1) / profile.podsPerSharedClaim
+				for s := 0; s < shared; s++ {
+					claim := draProfileClaim(fmt.Sprintf("shared-%d", s), primary.deviceClass, primary.driver, profile.devicesPerClaim)
+					pendingClaims = append(pendingClaims, claim)
+					for p := 0; p < profile.podsPerSharedClaim && len(pendingPods) < profile.pendingPods; p++ {
+						pendingPods = append(pendingPods, BuildTestPod(
+							fmt.Sprintf("pending-%d-%d", s, p), 500, 1000,
+							WithNamespace("default"), WithResourceClaim(claim.Name, claim.Name, "")))
+					}
+				}
+			} else {
+				for p := 0; p < profile.pendingPods; p++ {
+					claim := draProfileClaim(fmt.Sprintf("pending-%d", p), primary.deviceClass, primary.driver, profile.devicesPerClaim)
+					pod := BuildTestPod(fmt.Sprintf("pending-%d", p), 500, 1000,
+						WithNamespace("default"), WithResourceClaim(claim.Name, claim.Name, ""))
+					pendingClaims = append(pendingClaims, drautils.TestClaimWithPodOwnership(pod, claim))
+					pendingPods = append(pendingPods, pod)
+				}
+			}
+			for p := 0; p < profile.pendingPodsWithoutClaims; p++ {
+				pendingPods = append(pendingPods,
+					BuildTestPod(fmt.Sprintf("plain-%d", p), 500, 1000, WithNamespace("default")))
+			}
+			podEquivalenceGroups := []PodEquivalenceGroup{{Pods: pendingPods}}
+
+			var estimatedNodes int
+			var estimatedPods []*apiv1.Pod
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				fwHandle, err := framework.NewTestFrameworkHandle()
+				if err != nil {
+					b.Fatalf("NewTestFrameworkHandle(): unexpected error: %v", err)
+				}
+				clusterSnapshot := predicate.NewPredicateSnapshot(store.NewBasicSnapshotStore(), fwHandle, true, draBenchmarkPredicateWorker, false, 0 /* schedulerVerbosityOffset */)
+
+				draSnapshot := drasnapshot.NewSnapshot(nil, nil, nil, deviceClasses)
+				if err := draSnapshot.AddClaims(allocatedClaims); err != nil {
+					b.Fatalf("AddClaims(): unexpected error for allocated claims: %v", err)
+				}
+				if err := draSnapshot.AddClaims(pendingClaims); err != nil {
+					b.Fatalf("AddClaims(): unexpected error for pending claims: %v", err)
+				}
+				if err := clusterSnapshot.SetClusterState(context.Background(), nil, nil, draSnapshot, nil); err != nil {
+					b.Fatalf("SetClusterState(): unexpected error: %v", err)
+				}
+				for _, nodeInfo := range existingNodes {
+					if err := clusterSnapshot.AddNodeInfo(nodeInfo.DeepCopy()); err != nil {
+						b.Fatalf("AddNodeInfo(): unexpected error: %v", err)
+					}
+				}
+
+				limiter := NewThresholdBasedEstimationLimiter([]Threshold{NewStaticThreshold(1000, time.Duration(0))})
+				estimator := NewBinpackingNodeEstimator(clusterSnapshot, limiter, NewDecreasingPodOrderer(), nil /* EstimationContext */, nil /* EstimationAnalyserFunc */, false)
+				b.StartTimer()
+
+				estimatedNodes, estimatedPods = estimator.Estimate(context.Background(), podEquivalenceGroups, nodeTemplate, nil)
+			}
+			b.StopTimer()
+
+			if estimatedNodes == 0 || len(estimatedPods) == 0 {
+				b.Fatalf("Estimate(): expected pods to be placed on new nodes, got %d nodes and %d pods", estimatedNodes, len(estimatedPods))
+			}
+		})
+	}
+}

--- a/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
+++ b/pkg/simulator/clustersnapshot/predicate/predicate_snapshot_dra_benchmark_test.go
@@ -415,3 +415,117 @@ func BenchmarkScheduleRevert(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkDRAScaleUp models a CA scale-up pass on a DRA cluster that already runs a lot of
+// DRA workload: the snapshot carries backgroundClaims allocated claims, and the pods being
+// placed own UNALLOCATED claims, so the scheduler has to run the structured allocator. That
+// path calls GatherAllocatedState, which walks every claim in the snapshot on every attempt.
+func BenchmarkDRAScaleUp(b *testing.B) {
+	featuretesting.SetFeatureGateDuringTest(b, feature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
+
+	const nodesProbed = 25
+	const podsPerNode = 4
+	const devicesPerSlice = 32
+	const deviceClassName = "defaultClass"
+	const driverName = "driver.foo.com"
+
+	for _, backgroundClaims := range []int{1000, 5000, 20000} {
+		b.Run(fmt.Sprintf("claims=%d", backgroundClaims), func(b *testing.B) {
+			deviceClasses := map[string]*resourceapi.DeviceClass{
+				deviceClassName: {ObjectMeta: metav1.ObjectMeta{Name: deviceClassName, UID: "defaultClassUid"}},
+			}
+
+			// Nodes we will probe, each exposing a slice of free devices.
+			nodeInfos := make([]*framework.NodeInfo, nodesProbed)
+			pendingPods := make([][]*apiv1.Pod, nodesProbed)
+			pendingClaims := make([][]*resourceapi.ResourceClaim, nodesProbed)
+			for nodeIndex := 0; nodeIndex < nodesProbed; nodeIndex++ {
+				node := BuildTestNode(fmt.Sprintf("node-%d", nodeIndex), 10000, 10000)
+				nodeSlice := createTestResourceSlice(node.Name, devicesPerSlice, 1, driverName)
+				nodeInfos[nodeIndex] = framework.NewNodeInfo(node, []*resourceapi.ResourceSlice{nodeSlice})
+
+				pods := make([]*apiv1.Pod, podsPerNode)
+				claims := make([]*resourceapi.ResourceClaim, podsPerNode)
+				for podIndex := 0; podIndex < podsPerNode; podIndex++ {
+					// Deliberately NOT allocated - the scheduler has to allocate it.
+					claim := createTestResourceClaim(1, 1, driverName, deviceClassName)
+					pod := BuildTestPod(
+						fmt.Sprintf("pending-%d-%d", nodeIndex, podIndex),
+						1, 1,
+						WithResourceClaim(claim.Name, claim.Name, ""),
+					)
+					claims[podIndex] = drautils.TestClaimWithPodOwnership(pod, claim)
+					pods[podIndex] = pod
+				}
+				pendingPods[nodeIndex] = pods
+				pendingClaims[nodeIndex] = claims
+			}
+
+			// Claims of DRA workload already running in the cluster. These bulk up the
+			// resourceClaims PatchSet without taking devices from the probed nodes.
+			bgNode := BuildTestNode("bg-node", 10000, 10000)
+			bgSlice := createTestResourceSlice(bgNode.Name, backgroundClaims, 1, driverName)
+			background := make([]*resourceapi.ResourceClaim, backgroundClaims)
+			for i := 0; i < backgroundClaims; i++ {
+				claim := createTestResourceClaim(1, 1, driverName, deviceClassName)
+				allocated, satisfied := allocateResourceSlicesForClaim(claim, bgNode.Name, bgSlice)
+				if !satisfied {
+					b.Fatalf("setup: background claim allocation not satisfied")
+				}
+				background[i] = allocated
+			}
+
+			snapshotFactory := snapshots["basic"]
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				iterNodeInfos := make([]*framework.NodeInfo, nodesProbed)
+				for nodeIndex := range nodeInfos {
+					iterNodeInfos[nodeIndex] = nodeInfos[nodeIndex].DeepCopy()
+				}
+				iterClaims := make([][]*resourceapi.ResourceClaim, nodesProbed)
+				for nodeIndex := range pendingClaims {
+					cs := make([]*resourceapi.ResourceClaim, podsPerNode)
+					for j, c := range pendingClaims[nodeIndex] {
+						cs[j] = c.DeepCopy()
+					}
+					iterClaims[nodeIndex] = cs
+				}
+				b.StartTimer()
+
+				snapshot, err := snapshotFactory()
+				if err != nil {
+					b.Fatalf("failed to create snapshot: %v", err)
+				}
+				draSnapshot := drasnapshot.NewSnapshot(nil, nil, nil, deviceClasses)
+				if err := draSnapshot.AddClaims(background); err != nil {
+					b.Fatalf("failed to add background claims: %v", err)
+				}
+				for nodeIndex := range iterClaims {
+					if err := draSnapshot.AddClaims(iterClaims[nodeIndex]); err != nil {
+						b.Fatalf("failed to add pending claims: %v", err)
+					}
+				}
+				if err := snapshot.SetClusterState(context.Background(), nil, nil, draSnapshot, nil); err != nil {
+					b.Fatalf("failed to set cluster state: %v", err)
+				}
+
+				// Binpacking pass: probe each node, then roll the attempt back.
+				for nodeIndex := 0; nodeIndex < nodesProbed; nodeIndex++ {
+					nodeInfo := iterNodeInfos[nodeIndex]
+					snapshot.Fork()
+					if err := snapshot.AddNodeInfo(nodeInfo); err != nil {
+						b.Fatalf("failed to add node info: %v", err)
+					}
+					for podIndex := 0; podIndex < podsPerNode; podIndex++ {
+						pod := pendingPods[nodeIndex][podIndex]
+						if err := snapshot.SchedulePod(pod, nodeInfo.Node().Name); err != nil {
+							b.Fatalf("failed to schedule %s: %v", pod.Name, err)
+						}
+					}
+					snapshot.Revert()
+				}
+			}
+		})
+	}
+}

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state_benchmark_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state_benchmark_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"fmt"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	drautils "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/utils"
+)
+
+// These benchmarks exist to find where maintaining the allocated state costs
+// more than recomputing it would. Every benchmark elsewhere in the tree is a
+// case the incremental tracker is good at - claims read far more often than they
+// are written - so they say nothing about the cases it is bad at.
+//
+// The tracker trades work on writes for work on reads. It pays, per claim write,
+// for deriving the claim's contribution and recording it; it saves, per read, a
+// walk over every claim. So it loses whenever writes outnumber reads, whenever
+// the claim set is small enough that recomputing was already trivial, or
+// whenever the state is read once and thrown away.
+
+const benchDriver = "driver.example.com"
+
+// Deliberately self-contained: this file has to compile both with and without
+// the incremental tracker, so it cannot lean on helpers that arrive alongside it.
+func benchClaim(namespace, name string, devices ...string) *resourceapi.ResourceClaim {
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(namespace + "/" + name)},
+	}
+	if len(devices) == 0 {
+		return claim
+	}
+	results := make([]resourceapi.DeviceRequestAllocationResult, 0, len(devices))
+	for _, device := range devices {
+		results = append(results, resourceapi.DeviceRequestAllocationResult{
+			Request: "req", Driver: benchDriver, Pool: "pool", Device: device,
+		})
+	}
+	return drautils.TestClaimWithAllocation(claim, &resourceapi.AllocationResult{
+		Devices: resourceapi.DeviceAllocationResult{Results: results},
+	})
+}
+
+func benchAllocatedClaim(index int) *resourceapi.ResourceClaim {
+	return benchClaim("default", fmt.Sprintf("claim-%d", index), fmt.Sprintf("dev-%d", index))
+}
+
+func benchSnapshotWithClaims(count int) (*Snapshot, []ResourceClaimId) {
+	claims := map[ResourceClaimId]*resourceapi.ResourceClaim{}
+	ids := make([]ResourceClaimId, 0, count)
+	for i := 0; i < count; i++ {
+		claim := benchAllocatedClaim(i)
+		claims[GetClaimId(claim)] = claim
+		ids = append(ids, GetClaimId(claim))
+	}
+	return NewSnapshot(claims, nil, nil, nil), ids
+}
+
+// BenchmarkAllocatedStateSingleRead is the worst case for maintaining state: the
+// snapshot is built, the allocated state is read exactly once, and everything is
+// discarded. Recomputing would do one walk; the tracker does the same walk and
+// additionally records what every claim contributed, for a second read that
+// never comes.
+func BenchmarkAllocatedStateSingleRead(b *testing.B) {
+	for _, claims := range []int{100, 5000, 20000} {
+		b.Run(fmt.Sprintf("claims=%d", claims), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				snapshot, _ := benchSnapshotWithClaims(claims)
+				b.StartTimer()
+
+				if _, err := snapshot.ResourceClaims().GatherAllocatedState(); err != nil {
+					b.Fatalf("GatherAllocatedState(): %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkAllocatedStateWriteHeavy inverts the usual ratio: many claim writes
+// against a single read. Every write pays the bookkeeping the tracker needs to
+// make reads cheap, and here that investment is never recovered.
+func BenchmarkAllocatedStateWriteHeavy(b *testing.B) {
+	for _, writes := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("writes=%d", writes), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				snapshot, ids := benchSnapshotWithClaims(writes)
+				// Force the state to exist so writes are actually tracked;
+				// otherwise the lazy build would skip all of them.
+				if _, err := snapshot.ResourceClaims().GatherAllocatedState(); err != nil {
+					b.Fatalf("GatherAllocatedState(): %v", err)
+				}
+				b.StartTimer()
+
+				snapshot.Fork()
+				for j, id := range ids {
+					updated := benchClaim(id.Namespace, id.Name, fmt.Sprintf("dev-%d-v2", j))
+					snapshot.configureResourceClaim(updated)
+				}
+				if _, err := snapshot.ResourceClaims().GatherAllocatedState(); err != nil {
+					b.Fatalf("GatherAllocatedState(): %v", err)
+				}
+				snapshot.Revert()
+			}
+		})
+	}
+}
+
+// BenchmarkAllocatedStateForkRevertChurn hammers Fork/Revert. Reverting a layer
+// makes the tracker re-read every claim the layer touched, where recomputing
+// would simply drop the derived state and rebuild it on demand. With a small
+// claim set that rebuild is trivial, so the bookkeeping has nothing to beat.
+func BenchmarkAllocatedStateForkRevertChurn(b *testing.B) {
+	for _, claims := range []int{0, 10, 1000} {
+		b.Run(fmt.Sprintf("claims=%d", claims), func(b *testing.B) {
+			snapshot, ids := benchSnapshotWithClaims(claims)
+			if _, err := snapshot.ResourceClaims().GatherAllocatedState(); err != nil {
+				b.Fatalf("GatherAllocatedState(): %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				snapshot.Fork()
+				// Touch one claim so the reverted layer is not empty - an empty
+				// layer is a special case both implementations short-circuit.
+				if len(ids) > 0 {
+					id := ids[i%len(ids)]
+					updated := benchClaim(id.Namespace, id.Name, "dev-churn")
+					snapshot.configureResourceClaim(updated)
+				}
+				snapshot.Revert()
+			}
+		})
+	}
+}
+
+// BenchmarkAllocatedStateUnallocatedClaims fills the snapshot with claims that
+// have no allocation. Recomputing over these is nearly free - the derivation
+// returns immediately on a nil allocation - so there is very little for the
+// tracker to save, while it still pays to walk them once at build time.
+func BenchmarkAllocatedStateUnallocatedClaims(b *testing.B) {
+	for _, claims := range []int{5000, 20000} {
+		b.Run(fmt.Sprintf("claims=%d", claims), func(b *testing.B) {
+			claimMap := map[ResourceClaimId]*resourceapi.ResourceClaim{}
+			for i := 0; i < claims; i++ {
+				claim := benchClaim("default", fmt.Sprintf("claim-%d", i))
+				claimMap[GetClaimId(claim)] = claim
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				snapshot := NewSnapshot(claimMap, nil, nil, nil)
+				b.StartTimer()
+
+				// Two reads, the pattern the tracker is meant to win at. Even
+				// here there is almost nothing to win.
+				for r := 0; r < 2; r++ {
+					if _, err := snapshot.ResourceClaims().GatherAllocatedState(); err != nil {
+						b.Fatalf("GatherAllocatedState(): %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSnapshotForkRevertNoDRA covers a snapshot that never touches DRA at
+// all, which is what every non-DRA cluster looks like. Nothing should be derived
+// and nothing should be allocated; this guards against the maintenance
+// machinery leaking cost into clusters that do not use the feature.
+func BenchmarkSnapshotForkRevertNoDRA(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		snapshot := NewSnapshot(nil, nil, nil, nil)
+		b.StartTimer()
+
+		for f := 0; f < 100; f++ {
+			snapshot.Fork()
+			snapshot.Revert()
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
There is currently no benchmark covering DRA scale-up at cluster scale. `BenchmarkRunOnceScaleUpDRA`
in `pkg/core/bench` exercises the whole loop at 500 nodes, and `BenchmarkScheduleRevert` covers
fork/revert on the snapshot, but nothing measures the binpacking estimator against a cluster that
already carries a large amount of DRA workload — which is where the per-attempt cost of gathering
allocated claim state actually shows up.

This leads to #55 which will improve those benchmark results.

This PR adds four groups of benchmarks. No production code changes.
**`BenchmarkBinpackingEstimateDRA`** (`pkg/estimator`) — one `ComputeExpansionOption` pass for a
single node group against an existing GPU fleet, at 1000 nodes/4000 allocated claims/200 pending
pods and 5000 nodes/20000 claims/500 pending pods.
The pending pods deliberately own **unallocated** claims. With pre-allocated claims the scheduler
reuses the existing allocation and never runs the structured allocator, so the PreFilter path that
gathers the allocated state of every claim is skipped entirely and the benchmark stops measuring
the interesting part. Worth keeping in mind when reading the numbers: a real loop pays this once
per candidate node group, so they multiply by the number of groups considered.
**`BenchmarkBinpackingEstimateDRAProfiles`** (`pkg/estimator`) — nine cluster shapes, 200-500 nodes,
modelled on how DRA is deployed rather than on what is convenient to generate:
- `gpu8/exclusive`, `gpu8/wholeNode`, `gpu8/sharedClaims` — whole-GPU, whole-node multi-GPU, and
  claims shared between pods
- `mig56/fractional` — fractional MIG requests
- `devices256/multiSlice` — enough devices to cross `ResourceSliceMaxDevices` (128), so a node
  publishes several slices
- `multiDriver/gpu+net+computeDomain` — three drivers on one node, each with its own pool and
  DeviceClass, as on a GKE GPU node
- `gpu8/manyClaimsFewPods` — a claim-heavy fleet with almost no pending work (12000 allocated
  claims, 3 pending pods), so the state is read only once or twice
- `gpu8/existingUnallocated` — existing claims present but left unallocated
- `noGain/draFleetNonDraPods` — a DRA fleet whose pending workload does not use DRA, where an
  optimisation of this path is expected to buy nothing
**`BenchmarkDRAScaleUp`** (`pkg/simulator/clustersnapshot/predicate`) — 25 probed nodes, 4 pods per
node, against 1000/5000/20000 background allocated claims. Isolates the snapshot-level cost from
the estimator's.
**`BenchmarkAllocatedState*`** and `BenchmarkSnapshotForkRevertNoDRA`
(`pkg/simulator/dynamicresources/snapshot`) — deliberately adversarial micro-benchmarks for anyone
changing how allocated state is derived: a single read then discard, write-heavy against one read,
fork/revert churn, all-unallocated claims, and a snapshot that never touches DRA at all. Every
other benchmark here is a case that caching or incremental maintenance is good at, so on their own
they would only ever show a change in a flattering light. These are the cases where such a change
loses, and the no-DRA one guards against leaking cost into clusters that do not use the feature.
#### Which issue(s) this PR fixes:
N/A
#### Special notes for your reviewer:
#51 (`Make BenchmarkScheduleRevert run correctly`) has merged, and this PR is now rebased on top of
it, so it is down to a single commit. The `predicate_snapshot_dra_benchmark_test.go` change here
sits on that fix.
Run them with:
```
go test -run '^$' -bench 'BenchmarkBinpackingEstimateDRA'  -benchtime=1x  ./pkg/estimator/
go test -run '^$' -bench 'BenchmarkDRAScaleUp'             -benchtime=1x  ./pkg/simulator/clustersnapshot/predicate/
go test -run '^$' -bench 'BenchmarkAllocatedState'         -benchtime=10x ./pkg/simulator/dynamicresources/snapshot/
```
A single pass over all four groups is about 40s on a laptop, so nothing here is expensive to run
locally. Use `-count` rather than a large `-benchtime` for repeat samples on the cluster-scale
ones; the `AllocatedState` set is at microsecond scale and needs a high `-benchtime` before
`benchstat` gets a usable interval out of it.

None of these run in CI — the `ca-benchmark` job is scoped to
`-bench=BenchmarkRunOnce ./pkg/core/bench/...` — so this adds no CI time. I have deliberately not
extended that job here; if you would like these gated too, that seems better as a separate change
to the workflow.

On placement: the `AllocatedState` benchmarks cannot move under `pkg/core/bench` because they
exercise unexported internals of the snapshot package. The estimator and predicate ones could be
relocated if you would rather keep all benchmarks together.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```

