### PR TITLE
DRA allocated state tracking for improved performance and memory usage

### DIFF
--- a/pkg/simulator/common/patchset.go
+++ b/pkg/simulator/common/patchset.go
@@ -222,10 +222,24 @@ func (p *PatchSet[K, V]) InCurrentPatch(key K) bool {
 	return found
 }
 
+// IsForked reports whether there is a layer above the base one, which is exactly when
+// Revert has something to drop. Revert may always be called - without a Fork under it there
+// is simply nothing to discard, so no key's effective value changes.
+//
+// Callers maintaining state derived from the PatchSet need this to tell an unforked
+// PatchSet, where WalkCurrentPatchKeys reports the whole base layer, apart from one whose
+// topmost layer is about to be discarded.
+func (p *PatchSet[K, V]) IsForked() bool {
+	return len(p.patches) > 1
+}
+
 // WalkCurrentPatchKeys calls f for every key modified or deleted in the topmost patch
-// layer, stopping early if f returns false. These are exactly the keys whose effective
-// value can change when the layer is reverted, which lets callers maintaining state
+// layer, stopping early if f returns false. When that layer is about to be reverted these
+// are exactly the keys whose effective value changes, which lets callers maintaining state
 // derived from the PatchSet refresh only what a Revert affects.
+//
+// Note the topmost layer is the base layer on an unforked PatchSet, and Revert does not
+// drop that one - see IsForked, which such a caller has to consult first.
 func (p *PatchSet[K, V]) WalkCurrentPatchKeys(f func(K) bool) {
 	if len(p.patches) == 0 {
 		return

--- a/pkg/simulator/common/patchset.go
+++ b/pkg/simulator/common/patchset.go
@@ -222,6 +222,28 @@ func (p *PatchSet[K, V]) InCurrentPatch(key K) bool {
 	return found
 }
 
+// WalkCurrentPatchKeys calls f for every key modified or deleted in the topmost patch
+// layer, stopping early if f returns false. These are exactly the keys whose effective
+// value can change when the layer is reverted, which lets callers maintaining state
+// derived from the PatchSet refresh only what a Revert affects.
+func (p *PatchSet[K, V]) WalkCurrentPatchKeys(f func(K) bool) {
+	if len(p.patches) == 0 {
+		return
+	}
+
+	currentPatch := p.patches[len(p.patches)-1]
+	for key := range currentPatch.modified {
+		if !f(key) {
+			return
+		}
+	}
+	for key := range currentPatch.deleted {
+		if !f(key) {
+			return
+		}
+	}
+}
+
 // totalKeyCount calculates an approximate total number of key-value
 // pairs across all patches taking the highest number of records possible
 // this calculation does not consider deleted records - thus it is likely

--- a/pkg/simulator/common/patchset_test.go
+++ b/pkg/simulator/common/patchset_test.go
@@ -695,6 +695,9 @@ func TestPatchSetWalkCurrentPatchKeys(t *testing.T) {
 			patchLayers: []map[string]*int{},
 			wantKeys:    map[string]bool{},
 		},
+		// The base layer is the topmost one here, so its keys are reported - but Revert
+		// would not drop it. Callers driving a refresh off this have to check IsForked;
+		// see TestPatchSetIsForked.
 		"SingleLayer": {
 			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
 			wantKeys:    map[string]bool{"a": true, "b": true},
@@ -743,6 +746,48 @@ func TestPatchSetWalkCurrentPatchKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPatchSetIsForked pins down that IsForked tracks exactly the condition under which
+// Revert drops a layer, across the Fork/Commit/Revert cycle. Callers maintaining derived
+// state use it to skip work for a Revert that is about to change nothing.
+func TestPatchSetIsForked(t *testing.T) {
+	patchset := buildTestPatchSet(t, []map[string]*int{{"base": ptr.To(0)}})
+
+	assertForked := func(step string, want bool) {
+		t.Helper()
+		if got := patchset.IsForked(); got != want {
+			t.Errorf("%s: IsForked() = %v, want %v", step, got, want)
+		}
+	}
+
+	// The base layer alone is not a fork, and Revert leaves it alone.
+	assertForked("base only", false)
+	patchset.Revert()
+	assertForked("after Revert on the base layer", false)
+	if got := patchset.AsMap(); !maps.Equal(got, map[string]int{"base": 0}) {
+		t.Errorf("Revert on the base layer changed the contents: got %v", got)
+	}
+
+	patchset.Fork()
+	assertForked("after Fork", true)
+
+	// Both ways of collapsing a layer take it back to unforked.
+	patchset.Revert()
+	assertForked("after Revert", false)
+
+	patchset.Fork()
+	patchset.Commit()
+	assertForked("after Commit", false)
+
+	// Nesting: only the outermost layer being gone makes it unforked again.
+	patchset.Fork()
+	patchset.Fork()
+	assertForked("after two Forks", true)
+	patchset.Revert()
+	assertForked("after one of two Reverts", true)
+	patchset.Revert()
+	assertForked("after both Reverts", false)
 }
 
 func TestPatchSetWalkCurrentPatchKeysEarlyStop(t *testing.T) {

--- a/pkg/simulator/common/patchset_test.go
+++ b/pkg/simulator/common/patchset_test.go
@@ -686,6 +686,84 @@ func TestPatchSetCache(t *testing.T) {
 	}
 }
 
+func TestPatchSetWalkCurrentPatchKeys(t *testing.T) {
+	tests := map[string]struct {
+		patchLayers []map[string]*int
+		wantKeys    map[string]bool
+	}{
+		"EmptyPatchSet": {
+			patchLayers: []map[string]*int{},
+			wantKeys:    map[string]bool{},
+		},
+		"SingleLayer": {
+			patchLayers: []map[string]*int{{"a": ptr.To(1), "b": ptr.To(2)}},
+			wantKeys:    map[string]bool{"a": true, "b": true},
+		},
+		"TopLayerEmpty": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2)},
+				{}},
+			wantKeys: map[string]bool{},
+		},
+		"TopLayerOnly_LowerLayersIgnored": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2)},
+				{"c": ptr.To(3)}},
+			wantKeys: map[string]bool{"c": true},
+		},
+		"ModificationsAndDeletions": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2)},
+				{"c": ptr.To(3), "b": nil}},
+			wantKeys: map[string]bool{"c": true, "b": true},
+		},
+		"OnlyDeletions": {
+			patchLayers: []map[string]*int{
+				{"a": ptr.To(1), "b": ptr.To(2)},
+				{"a": nil, "b": nil}},
+			wantKeys: map[string]bool{"a": true, "b": true},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			patchset := buildTestPatchSet(t, test.patchLayers)
+
+			gotKeys := map[string]bool{}
+			patchset.WalkCurrentPatchKeys(func(key string) bool {
+				if gotKeys[key] {
+					t.Errorf("WalkCurrentPatchKeys(): key %q visited more than once", key)
+				}
+				gotKeys[key] = true
+				return true
+			})
+
+			if !maps.Equal(gotKeys, test.wantKeys) {
+				t.Errorf("WalkCurrentPatchKeys() visited %v, want %v", gotKeys, test.wantKeys)
+			}
+		})
+	}
+}
+
+func TestPatchSetWalkCurrentPatchKeysEarlyStop(t *testing.T) {
+	// Modifications and deletions are walked as two separate ranges, so stopping has to
+	// be honoured in both - a key in either one is enough to end the walk.
+	patchset := buildTestPatchSet(t, []map[string]*int{
+		{"base": ptr.To(0)},
+		{"m1": ptr.To(1), "m2": ptr.To(2), "d1": nil, "d2": nil},
+	})
+
+	visited := 0
+	patchset.WalkCurrentPatchKeys(func(string) bool {
+		visited++
+		return false
+	})
+
+	if visited != 1 {
+		t.Errorf("WalkCurrentPatchKeys() visited %d keys after the callback returned false, want 1", visited)
+	}
+}
+
 func buildTestPatchSet[K comparable, V any](t *testing.T, patchLayers []map[K]*V) *PatchSet[K, V] {
 	t.Helper()
 

--- a/pkg/simulator/dynamicresources/snapshot/snapshot.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot.go
@@ -293,10 +293,15 @@ func (s *Snapshot) Revert() {
 	// is the case for the whole life of a snapshot whenever DRA is disabled -
 	// going through allocationTracker() here would build a tracker just to ask
 	// whether it exists.
+	//
+	// IsForked is the other half of the guard. Without a Fork under it there is no layer
+	// to drop, so PatchSet.Revert is a no-op and no claim changes - but the topmost layer
+	// is then the base layer holding every claim in the snapshot, and walking it would
+	// refresh all of them to discover that nothing moved.
 	trackerBuilt := s.allocatedState != nil && s.allocatedState.isBuilt()
 
 	var revertedClaimIds []ResourceClaimId
-	if trackerBuilt {
+	if trackerBuilt && s.resourceClaims.IsForked() {
 		s.resourceClaims.WalkCurrentPatchKeys(func(claimId ResourceClaimId) bool {
 			revertedClaimIds = append(revertedClaimIds, claimId)
 			return true

--- a/pkg/simulator/dynamicresources/snapshot/snapshot.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot.go
@@ -48,6 +48,47 @@ type Snapshot struct {
 	resourceClaims *common.PatchSet[ResourceClaimId, *resourceapi.ResourceClaim]
 	resourceSlices *common.PatchSet[string, []*resourceapi.ResourceSlice]
 	deviceClasses  *common.PatchSet[string, *resourceapi.DeviceClass]
+
+	// allocatedState is derived from resourceClaims and maintained as they change, so
+	// that the scheduler can be answered without walking every claim on every attempt.
+	// Access it through allocationTracker(), never directly - a Snapshot can be built as
+	// a struct literal (see CloneTestSnapshot) and leave this nil.
+	//
+	// Every write to resourceClaims has to go through setResourceClaim/deleteResourceClaim
+	// to keep this in sync.
+	allocatedState *allocatedStateTracker
+}
+
+// allocationTracker returns the tracker holding the state derived from the ResourceClaims,
+// creating it if needed.
+func (s *Snapshot) allocationTracker() *allocatedStateTracker {
+	if s.allocatedState == nil {
+		s.allocatedState = newAllocatedStateTracker()
+	}
+	return s.allocatedState
+}
+
+// walkResourceClaims iterates over all effective ResourceClaims in the Snapshot.
+func (s *Snapshot) walkResourceClaims(f func(*resourceapi.ResourceClaim) bool) {
+	for _, claim := range s.listResourceClaims() {
+		if !f(claim) {
+			return
+		}
+	}
+}
+
+// setResourceClaim adds or updates a ResourceClaim in the current patch layer, keeping the
+// derived allocated state in sync.
+func (s *Snapshot) setResourceClaim(claimId ResourceClaimId, claim *resourceapi.ResourceClaim) {
+	s.resourceClaims.SetCurrent(claimId, claim)
+	s.allocationTracker().apply(claimId, claim)
+}
+
+// deleteResourceClaim marks a ResourceClaim as deleted in the current patch layer, keeping
+// the derived allocated state in sync.
+func (s *Snapshot) deleteResourceClaim(claimId ResourceClaimId) {
+	s.resourceClaims.DeleteCurrent(claimId)
+	s.allocationTracker().withdraw(claimId)
 }
 
 // nonNodeLocalResourceSlicesIdentifier is a special key used in the resourceSlices patchSet
@@ -117,7 +158,7 @@ func (s *Snapshot) AddClaims(newClaims []*resourceapi.ResourceClaim) error {
 	}
 
 	for _, claim := range newClaims {
-		s.resourceClaims.SetCurrent(GetClaimId(claim), claim)
+		s.setResourceClaim(GetClaimId(claim), claim)
 	}
 
 	return nil
@@ -144,13 +185,13 @@ func (s *Snapshot) RemovePodOwnedClaims(ctx context.Context, pod *apiv1.Pod) {
 		// TODO(autoscaler/issues/9570): KEP-5729 changed IsForPod to be able to work
 		// with pod groups, re-evaluate whether they need to be considered here.
 		if err := resourceclaim.IsForPod(pod, claim, false); err == nil {
-			s.resourceClaims.DeleteCurrent(claimId)
+			s.deleteResourceClaim(claimId)
 			continue
 		}
 
 		claim := s.ensureClaimWritable(claim)
 		drautils.ClearPodReservationInPlace(claim, pod)
-		s.resourceClaims.SetCurrent(claimId, claim)
+		s.setResourceClaim(claimId, claim)
 	}
 }
 
@@ -175,7 +216,7 @@ func (s *Snapshot) ReservePodClaims(pod *apiv1.Pod) error {
 		claimId := GetClaimId(claim)
 		claim := s.ensureClaimWritable(claim)
 		drautils.AddPodReservationInPlace(claim, pod)
-		s.resourceClaims.SetCurrent(claimId, claim)
+		s.setResourceClaim(claimId, claim)
 	}
 
 	return nil
@@ -200,7 +241,7 @@ func (s *Snapshot) UnreservePodClaims(pod *apiv1.Pod) error {
 			drautils.DeallocateClaimInPlace(claim)
 		}
 
-		s.resourceClaims.SetCurrent(claimId, claim)
+		s.setResourceClaim(claimId, claim)
 	}
 	return nil
 }
@@ -233,14 +274,42 @@ func (s *Snapshot) Commit() {
 	s.deviceClasses.Commit()
 	s.resourceClaims.Commit()
 	s.resourceSlices.Commit()
+	// The effective value of every claim is unchanged by a Commit, so the derived
+	// allocated state stays valid.
 }
 
 // Revert removes the topmost patch layer for all resource types, discarding
 // any modifications or deletions recorded there.
 func (s *Snapshot) Revert() {
+	// A Revert changes the effective value of exactly the claims recorded in the layer
+	// being dropped, without any of them going through setResourceClaim. Collect them
+	// first, then re-read them once the layer is gone.
+	//
+	// This walks the dropped layer a second time, so it is O(P) in the size of that layer.
+	// PatchSet.Revert is already O(P), so the operation stays in the same complexity class
+	// and only picks up a larger constant.
+	//
+	// Skipped entirely when nothing has been derived from the claims yet, which
+	// is the case for the whole life of a snapshot whenever DRA is disabled -
+	// going through allocationTracker() here would build a tracker just to ask
+	// whether it exists.
+	trackerBuilt := s.allocatedState != nil && s.allocatedState.isBuilt()
+
+	var revertedClaimIds []ResourceClaimId
+	if trackerBuilt {
+		s.resourceClaims.WalkCurrentPatchKeys(func(claimId ResourceClaimId) bool {
+			revertedClaimIds = append(revertedClaimIds, claimId)
+			return true
+		})
+	}
+
 	s.deviceClasses.Revert()
 	s.resourceClaims.Revert()
 	s.resourceSlices.Revert()
+
+	if trackerBuilt {
+		s.allocatedState.refresh(revertedClaimIds, s.getResourceClaim)
+	}
 }
 
 // Fork adds a new, empty patch layer to the top of the stack for all
@@ -250,6 +319,7 @@ func (s *Snapshot) Fork() {
 	s.deviceClasses.Fork()
 	s.resourceClaims.Fork()
 	s.resourceSlices.Fork()
+	// An empty layer changes nothing, so the derived allocated state stays valid.
 }
 
 // listDeviceClasses retrieves all effective DeviceClasses from the snapshot.
@@ -278,7 +348,7 @@ func (s *Snapshot) listResourceClaims() []*resourceapi.ResourceClaim {
 // This is typically used internally when a claim's state (like allocation) changes.
 func (s *Snapshot) configureResourceClaim(claim *resourceapi.ResourceClaim) {
 	claimId := ResourceClaimId{Name: claim.Name, Namespace: claim.Namespace}
-	s.resourceClaims.SetCurrent(claimId, claim)
+	s.setResourceClaim(claimId, claim)
 }
 
 // getResourceClaim retrieves a specific ResourceClaim by its ID from the snapshot.

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state.go
@@ -18,6 +18,7 @@ package snapshot
 
 import (
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured"
 )
@@ -66,8 +67,9 @@ type allocatedStateTracker struct {
 	// devices holds the devices claimed exclusively, matching what GatherAllocatedState
 	// reports when the DRAConsumableCapacity feature is enabled.
 	devices refCountedSet[structured.DeviceID]
-	// allDevices holds every allocated device, including the shared ones. This matches
-	// ListAllAllocatedDevices, which asks foreachAllocatedDevice to ignore sharing.
+	// allDevices holds every allocated device, including the shared ones. This is what
+	// ListAllAllocatedDevices reports, and what GatherAllocatedState reports as allocated
+	// when the DRAConsumableCapacity feature is disabled.
 	allDevices refCountedSet[structured.DeviceID]
 	// sharedDeviceIDs holds the (device, share) pairs of the shared devices.
 	sharedDeviceIDs refCountedSet[structured.SharedDeviceID]
@@ -149,7 +151,8 @@ func (t *allocatedStateTracker) apply(claimId ResourceClaimId, claim *resourceap
 			contribution.sharedDevices = append(contribution.sharedDevices, deviceID)
 			contribution.sharedDeviceIDs = append(contribution.sharedDeviceIDs, structured.MakeSharedDeviceID(deviceID, result.ShareID))
 			if result.ConsumedCapacity != nil {
-				contribution.capacity = append(contribution.capacity, structured.NewDeviceConsumedCapacity(deviceID, result.ConsumedCapacity))
+				contribution.capacity = append(contribution.capacity,
+					ownedDeviceConsumedCapacity(deviceID, result.ConsumedCapacity))
 			}
 			return
 		}
@@ -176,6 +179,44 @@ func (t *allocatedStateTracker) apply(claimId ResourceClaimId, claim *resourceap
 		t.capacity.Insert(deviceCapacity)
 	}
 	t.contributions[claimId] = contribution
+}
+
+// ownedDeviceConsumedCapacity is structured.NewDeviceConsumedCapacity with a deep copy.
+//
+// The contribution outlives the call that builds it, and withdraw has to subtract exactly
+// what apply added, so it needs capacity values the claim cannot reach. The upstream
+// constructor does not give that: it stores &quantity of its range variable, which copies
+// the resource.Quantity struct but not the *inf.Dec a quantity carries when ParseQuantity
+// could not land it in the scaled-int64 form. It therefore aliases the source for exactly
+// those values and copies the rest, which is the awkward half of the two. Since the Snapshot
+// rewrites claims in place, an aliased contribution would let a later update move a number
+// already recorded against it, and the aggregate is never recomputed.
+//
+// Which values those are is not obvious, and the cost here follows the same split, so it is
+// worth stating: DeepCopy is a plain struct copy when the quantity is in the int64 form and
+// allocates a fresh inf.Dec when it is not. It is not a question of magnitude - "1e20" is in
+// the int64 form and free, while "9223372036854775807" is not and allocates. The case that
+// matters for DRA is that ANY fractional binary-suffixed value goes to inf.Dec, including
+// "0.5Gi", which is a whole number of bytes. Consumed capacity written as a fraction of a
+// device - the natural way to express a partial GPU - therefore pays the allocation, while
+// "4Gi", "512Mi" and "1Ti" do not. Measured at +1.6%..+4.8% time and +8.7%..+12.5% allocs on
+// the write path for the inf.Dec case, and no measurable difference for int64.
+//
+// Deliberately not NewDeviceConsumedCapacity(...).Clone(). That reaches the same result by
+// allocating a map of pointers and immediately discarding it for a second one, measured at
+// ~13% slower and ~23% more allocations on this path than the single pass below.
+//
+// This does duplicate the shape of the upstream constructor. The better fix is for
+// schedulerapi.NewDeviceConsumedCapacity to stop aliasing, which would remove both the
+// duplication here and the trap for every other caller - schedulerapi is declared a
+// scheduler/autoscaler contract, so that is a change Cluster Autoscaler can propose.
+func ownedDeviceConsumedCapacity(deviceID structured.DeviceID, capacity map[resourceapi.QualifiedName]resource.Quantity) structured.DeviceConsumedCapacity {
+	owned := make(structured.ConsumedCapacity, len(capacity))
+	for name, quantity := range capacity {
+		q := quantity.DeepCopy()
+		owned[name] = &q
+	}
+	return structured.DeviceConsumedCapacity{DeviceID: deviceID, ConsumedCapacity: owned}
 }
 
 // withdraw removes whatever the claim with the given id currently contributes.

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/dynamic-resource-allocation/structured"
+)
+
+// allocatedStateTracker maintains the set of devices consumed by the ResourceClaims in a
+// Snapshot. The scheduler asks for this state in every PreFilter, that is once per pod
+// placement attempt, and recomputing it means walking every claim and re-deriving every
+// DeviceID. Between two consecutive attempts only a handful of claims change, so the state
+// is instead maintained as claims are written and served directly.
+//
+// Time Complexities:
+//   - apply(claimId, claim): O(D).
+//   - withdraw(claimId): O(D), over the devices the claim contributed when applied.
+//   - refresh(claimIds, lookup): O(P * D), driven by Snapshot.Revert.
+//   - ensureBuilt(walkClaims): O(C * D) plus the cost of listing the claims on the
+//     first read, O(1) on every read after that.
+//   - allocatedState(): O(1) - the collections are handed over as they are.
+//
+// Variables used in complexity analysis:
+//   - C: The number of ResourceClaims effective in the Snapshot.
+//   - D: The number of allocated devices in a single ResourceClaim.
+//   - P: The number of modified/deleted entries in a single patch layer.
+//
+// The work moved onto a write is bounded by the claim being written, never by the size of
+// the Snapshot, and it takes the O(C * D) walk off every read but the first. Snapshot.Revert
+// is the one operation where the tracker adds work proportional to something other than a
+// single claim, and PatchSet.Revert is already O(P), so the refresh keeps it in the same
+// complexity class with a larger constant.
+//
+// Withdrawing a claim cannot work by looking at its previous value: Snapshot mutates claims
+// in place (see Snapshot.ensureClaimWritable, which hands back the stored object whenever the
+// claim already lives in the current patch layer), so by the time a write reaches the tracker
+// the old allocation may already be gone. The tracker therefore records what each claim
+// contributed when it was applied, and withdraws exactly that.
+//
+// That in-place mutation is itself the subject of two open bugs - kubernetes-sigs/cluster-autoscaler#33,
+// where a Pod referencing one claim through two aliases leaves the base layer dirty past a
+// Revert, and #37, where the base layer holds the informer's own objects. Recording
+// contributions rather than re-deriving them keeps the tracker consistent with whatever the
+// claims currently say, so it stays correct however those two are eventually resolved.
+//
+// Entries are reference counted. A device should only ever be consumed by one claim, but
+// refcounting means a duplicate does not make the device disappear from the state when just
+// one of the claims goes away.
+type allocatedStateTracker struct {
+	// devices holds the devices claimed exclusively, matching what GatherAllocatedState
+	// reports when the DRAConsumableCapacity feature is enabled.
+	devices refCountedSet[structured.DeviceID]
+	// allDevices holds every allocated device, including the shared ones. This matches
+	// ListAllAllocatedDevices, which asks foreachAllocatedDevice to ignore sharing.
+	allDevices refCountedSet[structured.DeviceID]
+	// sharedDeviceIDs holds the (device, share) pairs of the shared devices.
+	sharedDeviceIDs refCountedSet[structured.SharedDeviceID]
+	// capacity aggregates the consumed capacity of the shared devices.
+	capacity structured.ConsumedCapacityCollection
+
+	// contributions records what each claim currently adds to the collections above.
+	contributions map[ResourceClaimId]*claimContribution
+
+	// built is false until the state has been populated from a full pass over the claims.
+	// Writes are ignored while it is false, because that first pass picks them up anyway.
+	built bool
+}
+
+// claimContribution is what a single ResourceClaim adds to the tracked state.
+//
+// The devices of shared results are kept apart from the dedicated ones rather than in a
+// second combined slice: allDevices is the union of the two, and claims using shared devices
+// are rare, so the common claim only needs the one slice.
+type claimContribution struct {
+	// devices are the devices the claim consumes exclusively.
+	devices []structured.DeviceID
+	// sharedDevices are the devices behind sharedDeviceIDs. They count towards allDevices
+	// but not towards devices.
+	sharedDevices   []structured.DeviceID
+	sharedDeviceIDs []structured.SharedDeviceID
+	capacity        []structured.DeviceConsumedCapacity
+}
+
+func newAllocatedStateTracker() *allocatedStateTracker {
+	return &allocatedStateTracker{
+		devices:         newRefCountedSet[structured.DeviceID](),
+		allDevices:      newRefCountedSet[structured.DeviceID](),
+		sharedDeviceIDs: newRefCountedSet[structured.SharedDeviceID](),
+		capacity:        structured.NewConsumedCapacityCollection(),
+		contributions:   map[ResourceClaimId]*claimContribution{},
+	}
+}
+
+// isBuilt reports whether the state has been populated. While it hasn't, updates are
+// skipped, because the first full pass picks them up anyway.
+func (t *allocatedStateTracker) isBuilt() bool {
+	return t.built
+}
+
+// ensureBuilt populates the state from a full pass over the claims, unless that has already
+// happened. walkClaims has to visit every ResourceClaim effective in the Snapshot.
+func (t *allocatedStateTracker) ensureBuilt(walkClaims func(func(*resourceapi.ResourceClaim) bool)) {
+	if t.built {
+		return
+	}
+
+	// Mark as built first - apply is a no-op until it is.
+	t.built = true
+	walkClaims(func(claim *resourceapi.ResourceClaim) bool {
+		t.apply(GetClaimId(claim), claim)
+		return true
+	})
+}
+
+// apply records the claim as the current contribution for claimId, withdrawing whatever the
+// claim contributed before. A nil claim only withdraws.
+func (t *allocatedStateTracker) apply(claimId ResourceClaimId, claim *resourceapi.ResourceClaim) {
+	if !t.built {
+		return
+	}
+
+	t.withdraw(claimId)
+	if claim == nil {
+		return
+	}
+
+	// Both device set variants are maintained, because which one a caller wants depends on
+	// the DRAConsumableCapacity feature gate, and that can be flipped after the Snapshot was
+	// created. Deriving them in one pass keeps the DeviceID interning to a single call.
+	contribution := &claimContribution{}
+	forEachAllocatedResult(claim, func(deviceID structured.DeviceID, result *resourceapi.DeviceRequestAllocationResult) {
+		if result.ShareID != nil {
+			contribution.sharedDevices = append(contribution.sharedDevices, deviceID)
+			contribution.sharedDeviceIDs = append(contribution.sharedDeviceIDs, structured.MakeSharedDeviceID(deviceID, result.ShareID))
+			if result.ConsumedCapacity != nil {
+				contribution.capacity = append(contribution.capacity, structured.NewDeviceConsumedCapacity(deviceID, result.ConsumedCapacity))
+			}
+			return
+		}
+
+		contribution.devices = append(contribution.devices, deviceID)
+	})
+
+	if contribution.isEmpty() {
+		// Unallocated claims are the common case - don't keep an entry for them.
+		return
+	}
+
+	for _, deviceID := range contribution.devices {
+		t.devices.insert(deviceID)
+		t.allDevices.insert(deviceID)
+	}
+	for _, deviceID := range contribution.sharedDevices {
+		t.allDevices.insert(deviceID)
+	}
+	for _, sharedDeviceID := range contribution.sharedDeviceIDs {
+		t.sharedDeviceIDs.insert(sharedDeviceID)
+	}
+	for _, deviceCapacity := range contribution.capacity {
+		t.capacity.Insert(deviceCapacity)
+	}
+	t.contributions[claimId] = contribution
+}
+
+// withdraw removes whatever the claim with the given id currently contributes.
+func (t *allocatedStateTracker) withdraw(claimId ResourceClaimId) {
+	if !t.built {
+		return
+	}
+
+	contribution, found := t.contributions[claimId]
+	if !found {
+		return
+	}
+
+	for _, deviceID := range contribution.devices {
+		t.devices.remove(deviceID)
+		t.allDevices.remove(deviceID)
+	}
+	for _, deviceID := range contribution.sharedDevices {
+		t.allDevices.remove(deviceID)
+	}
+	for _, sharedDeviceID := range contribution.sharedDeviceIDs {
+		t.sharedDeviceIDs.remove(sharedDeviceID)
+	}
+	for _, deviceCapacity := range contribution.capacity {
+		t.capacity.Remove(deviceCapacity)
+	}
+	delete(t.contributions, claimId)
+}
+
+// refresh re-reads the given claims and updates their contributions. It is used after a
+// Revert, where the effective value of the reverted layer's keys changes without any
+// individual write going through the tracker. lookup returns the claim now effective for an
+// id, or false if there is none.
+func (t *allocatedStateTracker) refresh(claimIds []ResourceClaimId, lookup func(ResourceClaimId) (*resourceapi.ResourceClaim, bool)) {
+	if !t.built {
+		return
+	}
+
+	for _, claimId := range claimIds {
+		claim, found := lookup(claimId)
+		if !found {
+			t.withdraw(claimId)
+			continue
+		}
+		t.apply(claimId, claim)
+	}
+}
+
+// allocatedState returns the tracked state. The returned collections are the tracker's own
+// and must not be modified - see snapshotClaimTracker.GatherAllocatedState.
+func (t *allocatedStateTracker) allocatedState() *structured.AllocatedState {
+	return &structured.AllocatedState{
+		AllocatedDevices:         t.devices.set,
+		AllocatedSharedDeviceIDs: t.sharedDeviceIDs.set,
+		AggregatedCapacity:       t.capacity,
+	}
+}
+
+func (c *claimContribution) isEmpty() bool {
+	return len(c.devices) == 0 && len(c.sharedDevices) == 0 && len(c.sharedDeviceIDs) == 0 && len(c.capacity) == 0
+}
+
+// refCountedSet is a set that only drops an element once every insert of it has been removed.
+// The set itself is kept materialized so that it can be handed to the scheduler without
+// copying.
+type refCountedSet[T comparable] struct {
+	set sets.Set[T]
+	// refCounts only holds entries inserted more than once, which should not normally
+	// happen - a device is expected to be consumed by a single claim.
+	refCounts map[T]int
+}
+
+func newRefCountedSet[T comparable]() refCountedSet[T] {
+	return refCountedSet[T]{set: sets.New[T](), refCounts: map[T]int{}}
+}
+
+func (s refCountedSet[T]) insert(item T) {
+	if s.set.Has(item) {
+		s.refCounts[item]++
+		return
+	}
+	s.set.Insert(item)
+}
+
+func (s refCountedSet[T]) remove(item T) {
+	if count := s.refCounts[item]; count > 0 {
+		if count == 1 {
+			delete(s.refCounts, item)
+		} else {
+			s.refCounts[item] = count - 1
+		}
+		return
+	}
+	s.set.Delete(item)
+}

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state_test.go
@@ -19,6 +19,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"testing"
 
@@ -43,20 +44,34 @@ import (
 // referenceAllocatedState recomputes the allocated state from scratch, the way
 // GatherAllocatedState used to before the state was maintained incrementally. The
 // incremental tracker has to agree with this at all times.
+//
+// It deliberately shares no traversal code with the implementation it checks: it walks the
+// allocation results itself rather than going through forEachAllocatedResult, and lists the
+// claims with listResourceClaims rather than the Snapshot.walkResourceClaims wrapper the
+// tracker builds itself from. Both of those are part of what is under test here, and a
+// reference that called them would agree with a broken tracker about a skipped or
+// double-counted result.
 func referenceAllocatedState(snapshot *Snapshot, enabledConsumableCapacity bool) *structured.AllocatedState {
 	devices := sets.New[structured.DeviceID]()
 	sharedDeviceIDs := sets.New[structured.SharedDeviceID]()
 	capacity := structured.NewConsumedCapacityCollection()
 
-	snapshot.walkResourceClaims(func(claim *resourceapi.ResourceClaim) bool {
-		foreachAllocatedDevice(claim,
-			func(deviceID structured.DeviceID) { devices.Insert(deviceID) },
-			enabledConsumableCapacity,
-			func(sharedDeviceID structured.SharedDeviceID) { sharedDeviceIDs.Insert(sharedDeviceID) },
-			func(deviceCapacity structured.DeviceConsumedCapacity) { capacity.Insert(deviceCapacity) },
-		)
-		return true
-	})
+	for _, claim := range snapshot.listResourceClaims() {
+		if claim.Status.Allocation == nil {
+			continue
+		}
+		for _, result := range claim.Status.Allocation.Devices.Results {
+			deviceID := structured.MakeDeviceID(result.Driver, result.Pool, result.Device)
+			if enabledConsumableCapacity && result.ShareID != nil {
+				sharedDeviceIDs.Insert(structured.MakeSharedDeviceID(deviceID, result.ShareID))
+				if result.ConsumedCapacity != nil {
+					capacity.Insert(structured.NewDeviceConsumedCapacity(deviceID, result.ConsumedCapacity))
+				}
+				continue
+			}
+			devices.Insert(deviceID)
+		}
+	}
 
 	return &structured.AllocatedState{
 		AllocatedDevices:         devices,
@@ -279,6 +294,78 @@ func TestAllocatedStateTrackerRandomizedOperations(t *testing.T) {
 	}
 }
 
+// TestAllocatedStateRevertWithoutForkRefreshesNothing checks that a Revert with no Fork
+// under it does not refresh anything, and that a Revert with one still does.
+//
+// PatchSet.Revert keeps the bottom layer, so at that depth it discards nothing and no
+// claim's effective value changes. The topmost layer is then the base layer holding every
+// claim in the snapshot, so a refresh driven off it would re-read the whole cluster's worth
+// of claims to conclude nothing moved - turning a no-op into the O(claims) walk this
+// mechanism exists to avoid.
+//
+// A refresh replaces a claim's contribution with a freshly allocated one, so contribution
+// identity is an exact witness for whether a claim was re-read. That lets this drive the
+// real Snapshot.Revert rather than a copy of its logic, which a guard in the wrong place
+// would otherwise satisfy.
+func TestAllocatedStateRevertWithoutForkRefreshesNothing(t *testing.T) {
+	newSnapshotWithClaims := func(t *testing.T) *Snapshot {
+		t.Helper()
+		claims := map[ResourceClaimId]*resourceapi.ResourceClaim{}
+		for i := 0; i < 3; i++ {
+			claim := allocatedStateTestClaim("default", fmt.Sprintf("claim-%d", i),
+				allocationForDevices(dedicatedResult("driver", "pool", fmt.Sprintf("dev-%d", i))))
+			claims[GetClaimId(claim)] = claim
+		}
+		snapshot := NewSnapshot(claims, nil, nil, nil)
+		// Build the state, so the contributions below exist.
+		assertStateMatchesReference(t, snapshot, "initial")
+		if got := len(snapshot.allocatedState.contributions); got != 3 {
+			t.Fatalf("expected a contribution per claim, got %d", got)
+		}
+		return snapshot
+	}
+
+	refreshedClaims := func(before map[ResourceClaimId]*claimContribution, snapshot *Snapshot) []ResourceClaimId {
+		var refreshed []ResourceClaimId
+		for claimId, contribution := range before {
+			if snapshot.allocatedState.contributions[claimId] != contribution {
+				refreshed = append(refreshed, claimId)
+			}
+		}
+		return refreshed
+	}
+
+	t.Run("withoutFork", func(t *testing.T) {
+		snapshot := newSnapshotWithClaims(t)
+		before := maps.Clone(snapshot.allocatedState.contributions)
+
+		snapshot.Revert()
+
+		if refreshed := refreshedClaims(before, snapshot); len(refreshed) != 0 {
+			t.Errorf("Revert with no Fork under it re-read %d claims (%v), want none", len(refreshed), refreshed)
+		}
+		assertStateMatchesReference(t, snapshot, "after Revert without Fork")
+	})
+
+	// The control: without this, a guard that suppressed every refresh would also pass.
+	t.Run("withFork", func(t *testing.T) {
+		snapshot := newSnapshotWithClaims(t)
+		snapshot.Fork()
+		changed := allocatedStateTestClaim("default", "claim-0",
+			allocationForDevices(dedicatedResult("driver", "pool", "dev-changed")))
+		snapshot.configureResourceClaim(changed)
+		before := maps.Clone(snapshot.allocatedState.contributions)
+
+		snapshot.Revert()
+
+		refreshed := refreshedClaims(before, snapshot)
+		if len(refreshed) != 1 || refreshed[0] != GetClaimId(changed) {
+			t.Errorf("Revert with a Fork under it re-read %v, want just %v", refreshed, GetClaimId(changed))
+		}
+		assertStateMatchesReference(t, snapshot, "after Revert with Fork")
+	})
+}
+
 // TestAllocatedStateTrackerBuildsLazily checks that mutations applied before the state is
 // ever read are still reflected, since the tracker skips updates until its first full pass.
 func TestAllocatedStateTrackerBuildsLazily(t *testing.T) {
@@ -292,13 +379,79 @@ func TestAllocatedStateTrackerBuildsLazily(t *testing.T) {
 	// First read of the state - has to pick up the claim added before any read.
 	assertStateMatchesReference(t, snapshot, "after first read")
 
+	if want := structured.MakeDeviceID("driver", "pool", "dev-1"); !deviceAllocated(t, snapshot, want) {
+		t.Errorf("GatherAllocatedState(): device %v missing from the allocated state", want)
+	}
+}
+
+// TestAllocatedStateTrackerConsumedCapacityIsCopied checks that a claim's consumed capacity
+// is copied into the contribution rather than referenced.
+//
+// structured.NewDeviceConsumedCapacity only shallow-copies each resource.Quantity out of the
+// claim, so the copy still points at the same inf.Dec whenever the quantity is held in
+// decimal form - which is what a value too large for int64 gets parsed into. The Snapshot
+// rewrites claims in place, so arithmetic reaching that quantity would move the number the
+// contribution recorded, and withdraw would then subtract something other than what apply
+// added. Nothing recomputes the aggregate, so the skew would be permanent.
+func TestAllocatedStateTrackerConsumedCapacityIsCopied(t *testing.T) {
+	featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAConsumableCapacity, true)
+
+	// A fractional binary quantity. Any of these lands in resource.Quantity's inf.Dec
+	// form rather than its int64 form - that is a property of the fractional binary
+	// suffix, not of the magnitude, and it holds for "0.5Gi" too even though that is a
+	// whole number of bytes. The inf.Dec sits behind a pointer, and that pointer is what
+	// the contribution would otherwise share with the claim.
+	const decFormQuantity = "0.1Gi"
+
+	result := dedicatedResult("driver", "pool", "dev-1")
+	result.ShareID = ptr.To(types.UID("share-a"))
+	result.ConsumedCapacity = map[resourceapi.QualifiedName]resource.Quantity{
+		"memory": resource.MustParse(decFormQuantity),
+	}
+	claim := allocatedStateTestClaim("default", "shared", allocationForDevices(result))
+
+	snapshot := NewSnapshot(map[ResourceClaimId]*resourceapi.ResourceClaim{GetClaimId(claim): claim}, nil, nil, nil)
+	// Build the state, so the claim's capacity is recorded as a contribution.
+	assertStateMatchesReference(t, snapshot, "initial")
+
+	// Mutate the claim's quantity in place, the way an update rewriting the claim would.
+	// Quantity.Add on a decimal-form value writes through the shared inf.Dec pointer.
+	stored, found := snapshot.getResourceClaim(GetClaimId(claim))
+	if !found {
+		t.Fatalf("getResourceClaim(): claim not found")
+	}
+	capacity := stored.Status.Allocation.Devices.Results[0].ConsumedCapacity
+	quantity := capacity["memory"]
+	quantity.Add(resource.MustParse(decFormQuantity))
+	capacity["memory"] = quantity
+
+	// Withdrawing has to remove exactly what was added, leaving nothing behind.
+	snapshot.deleteResourceClaim(GetClaimId(claim))
+
 	state, err := snapshot.ResourceClaims().GatherAllocatedState()
 	if err != nil {
 		t.Fatalf("GatherAllocatedState(): %v", err)
 	}
-	if want := structured.MakeDeviceID("driver", "pool", "dev-1"); !state.AllocatedDevices.Has(want) {
-		t.Errorf("GatherAllocatedState(): device %v missing from %v", want, state.AllocatedDevices)
+	if len(state.AggregatedCapacity) != 0 {
+		t.Errorf("AggregatedCapacity should be empty once the only claim is gone, got %v", state.AggregatedCapacity)
 	}
+}
+
+// deviceAllocated reads the currently allocated devices out of the snapshot and reports
+// whether deviceID is among them.
+//
+// The state has to be re-read after every write: GatherAllocatedState borrows the snapshot's
+// own collections, so a value fetched before a write is not a live view of what comes after
+// it, and holding one across a write is exactly what the method documents callers must not
+// do.
+func deviceAllocated(t *testing.T, snapshot *Snapshot, deviceID structured.DeviceID) bool {
+	t.Helper()
+
+	state, err := snapshot.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		t.Fatalf("GatherAllocatedState(): %v", err)
+	}
+	return state.AllocatedDevices.Has(deviceID)
 }
 
 // TestAllocatedStateTrackerDuplicateDevice checks the reference counting: a device claimed by
@@ -312,21 +465,17 @@ func TestAllocatedStateTrackerDuplicateDevice(t *testing.T) {
 	}, nil, nil, nil)
 
 	deviceID := structured.MakeDeviceID("driver", "pool", "dev-1")
-	state, err := snapshot.ResourceClaims().GatherAllocatedState()
-	if err != nil {
-		t.Fatalf("GatherAllocatedState(): %v", err)
-	}
-	if !state.AllocatedDevices.Has(deviceID) {
+	if !deviceAllocated(t, snapshot, deviceID) {
 		t.Fatalf("device %v should be allocated", deviceID)
 	}
 
 	snapshot.deleteResourceClaim(GetClaimId(first))
-	if !state.AllocatedDevices.Has(deviceID) {
+	if !deviceAllocated(t, snapshot, deviceID) {
 		t.Errorf("device %v should still be allocated while the second claim holds it", deviceID)
 	}
 
 	snapshot.deleteResourceClaim(GetClaimId(second))
-	if state.AllocatedDevices.Has(deviceID) {
+	if deviceAllocated(t, snapshot, deviceID) {
 		t.Errorf("device %v should be released once no claim holds it", deviceID)
 	}
 }
@@ -371,11 +520,183 @@ func TestAllocatedStateTrackerAliasedClaim(t *testing.T) {
 	snapshot.deleteResourceClaim(GetClaimId(claim))
 	assertStateMatchesReference(t, snapshot, "after delete")
 
-	state, err := snapshot.ResourceClaims().GatherAllocatedState()
-	if err != nil {
-		t.Fatalf("GatherAllocatedState(): %v", err)
-	}
-	if deviceID := structured.MakeDeviceID("driver", "pool", "dev-1"); state.AllocatedDevices.Has(deviceID) {
+	if deviceID := structured.MakeDeviceID("driver", "pool", "dev-1"); deviceAllocated(t, snapshot, deviceID) {
 		t.Errorf("device %v should be released once the aliased claim is gone", deviceID)
+	}
+}
+
+// TestAllocatedStateTrackerExpectedStates pins the derived state down against expectations
+// written out by hand, for each shape an allocation result can take.
+//
+// The randomized and reference-comparison tests above check the tracker against a
+// recomputation, which establishes that the incremental path agrees with a full pass but not
+// that either is right. These cases say what the answer should be. They also cover shapes a
+// random walk reaches rarely or not at all - two claims holding the same share of a device,
+// two shares of one device in a single claim, and a shared result carrying no capacity.
+func TestAllocatedStateTrackerExpectedStates(t *testing.T) {
+	dev1 := structured.MakeDeviceID("driver", "pool", "dev-1")
+	dev2 := structured.MakeDeviceID("driver", "pool", "dev-2")
+	shareA, shareB := ptr.To(types.UID("share-a")), ptr.To(types.UID("share-b"))
+
+	// capacityOf builds an expected AggregatedCapacity holding one device's total. The
+	// totals in the cases below are worked out by hand, not derived from the claims.
+	capacityOf := func(deviceID structured.DeviceID, total int64) structured.ConsumedCapacityCollection {
+		collection := structured.NewConsumedCapacityCollection()
+		collection.Insert(structured.NewDeviceConsumedCapacity(deviceID, map[resourceapi.QualifiedName]resource.Quantity{
+			"memory": *resource.NewQuantity(total, resource.DecimalSI),
+		}))
+		return collection
+	}
+
+	for _, tc := range []struct {
+		name               string
+		consumableCapacity bool
+		claims             []*resourceapi.ResourceClaim
+		wantDevices        sets.Set[structured.DeviceID]
+		wantShared         sets.Set[structured.SharedDeviceID]
+		wantCapacity       structured.ConsumedCapacityCollection
+		wantAllDevices     sets.Set[structured.DeviceID]
+	}{
+		{
+			name:               "dedicated",
+			consumableCapacity: true,
+			claims: []*resourceapi.ResourceClaim{allocatedStateTestClaim("default", "a", allocationForDevices(
+				dedicatedResult("driver", "pool", "dev-1"),
+				dedicatedResult("driver", "pool", "dev-2"),
+			))},
+			wantDevices:    sets.New(dev1, dev2),
+			wantShared:     sets.New[structured.SharedDeviceID](),
+			wantCapacity:   structured.NewConsumedCapacityCollection(),
+			wantAllDevices: sets.New(dev1, dev2),
+		},
+		{
+			// With the gate off, sharing is not reported and the device counts as
+			// ordinarily allocated.
+			name:               "shared/gateOff",
+			consumableCapacity: false,
+			claims: []*resourceapi.ResourceClaim{allocatedStateTestClaim("default", "a", allocationForDevices(
+				sharedResult("driver", "pool", "dev-1", "share-a", 4),
+			))},
+			wantDevices:    sets.New(dev1),
+			wantShared:     sets.New[structured.SharedDeviceID](),
+			wantCapacity:   structured.NewConsumedCapacityCollection(),
+			wantAllDevices: sets.New(dev1),
+		},
+		{
+			// A shared device is not an exclusively allocated one, so it stays out of
+			// AllocatedDevices while still counting towards ListAllAllocatedDevices.
+			name:               "shared",
+			consumableCapacity: true,
+			claims: []*resourceapi.ResourceClaim{allocatedStateTestClaim("default", "a", allocationForDevices(
+				sharedResult("driver", "pool", "dev-1", "share-a", 4),
+			))},
+			wantDevices:    sets.New[structured.DeviceID](),
+			wantShared:     sets.New(structured.MakeSharedDeviceID(dev1, shareA)),
+			wantCapacity:   capacityOf(dev1, 4),
+			wantAllDevices: sets.New(dev1),
+		},
+		{
+			// Two claims holding the same share of one device: one shared entry, and the
+			// capacities add up. This is what the refcounting exists for - the entry has
+			// to survive one of the claims going away.
+			name:               "duplicateShare",
+			consumableCapacity: true,
+			claims: []*resourceapi.ResourceClaim{
+				allocatedStateTestClaim("default", "a", allocationForDevices(
+					sharedResult("driver", "pool", "dev-1", "share-a", 4))),
+				allocatedStateTestClaim("default", "b", allocationForDevices(
+					sharedResult("driver", "pool", "dev-1", "share-a", 4))),
+			},
+			wantDevices:    sets.New[structured.DeviceID](),
+			wantShared:     sets.New(structured.MakeSharedDeviceID(dev1, shareA)),
+			wantCapacity:   capacityOf(dev1, 8),
+			wantAllDevices: sets.New(dev1),
+		},
+		{
+			// Two distinct shares of one device inside a single claim: two shared entries,
+			// one device, capacities summed.
+			name:               "twoSharesOfOneDevice",
+			consumableCapacity: true,
+			claims: []*resourceapi.ResourceClaim{allocatedStateTestClaim("default", "a", allocationForDevices(
+				sharedResult("driver", "pool", "dev-1", "share-a", 4),
+				sharedResult("driver", "pool", "dev-1", "share-b", 6),
+			))},
+			wantDevices: sets.New[structured.DeviceID](),
+			wantShared: sets.New(
+				structured.MakeSharedDeviceID(dev1, shareA),
+				structured.MakeSharedDeviceID(dev1, shareB),
+			),
+			wantCapacity:   capacityOf(dev1, 10),
+			wantAllDevices: sets.New(dev1),
+		},
+		{
+			// A share can carry no consumed capacity at all, which must not create an
+			// AggregatedCapacity entry.
+			name:               "sharedWithoutCapacity",
+			consumableCapacity: true,
+			claims: []*resourceapi.ResourceClaim{allocatedStateTestClaim("default", "a", allocationForDevices(
+				sharedResult("driver", "pool", "dev-1", "share-a", 0),
+			))},
+			wantDevices:    sets.New[structured.DeviceID](),
+			wantShared:     sets.New(structured.MakeSharedDeviceID(dev1, shareA)),
+			wantCapacity:   structured.NewConsumedCapacityCollection(),
+			wantAllDevices: sets.New(dev1),
+		},
+		{
+			// Dedicated and shared together: AllocatedDevices holds only the dedicated
+			// one, ListAllAllocatedDevices holds both.
+			name:               "dedicatedAndShared",
+			consumableCapacity: true,
+			claims: []*resourceapi.ResourceClaim{
+				allocatedStateTestClaim("default", "a", allocationForDevices(
+					dedicatedResult("driver", "pool", "dev-1"))),
+				allocatedStateTestClaim("default", "b", allocationForDevices(
+					sharedResult("driver", "pool", "dev-2", "share-a", 3))),
+			},
+			wantDevices:    sets.New(dev1),
+			wantShared:     sets.New(structured.MakeSharedDeviceID(dev2, shareA)),
+			wantCapacity:   capacityOf(dev2, 3),
+			wantAllDevices: sets.New(dev1, dev2),
+		},
+		{
+			name:               "unallocated",
+			consumableCapacity: true,
+			claims:             []*resourceapi.ResourceClaim{allocatedStateTestClaim("default", "a", nil)},
+			wantDevices:        sets.New[structured.DeviceID](),
+			wantShared:         sets.New[structured.SharedDeviceID](),
+			wantCapacity:       structured.NewConsumedCapacityCollection(),
+			wantAllDevices:     sets.New[structured.DeviceID](),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAConsumableCapacity, tc.consumableCapacity)
+
+			claimMap := map[ResourceClaimId]*resourceapi.ResourceClaim{}
+			for _, claim := range tc.claims {
+				claimMap[GetClaimId(claim)] = claim
+			}
+			snapshot := NewSnapshot(claimMap, nil, nil, nil)
+
+			want := &structured.AllocatedState{
+				AllocatedDevices:         tc.wantDevices,
+				AllocatedSharedDeviceIDs: tc.wantShared,
+				AggregatedCapacity:       tc.wantCapacity,
+			}
+			got, err := snapshot.ResourceClaims().GatherAllocatedState()
+			if err != nil {
+				t.Fatalf("GatherAllocatedState(): %v", err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("GatherAllocatedState(): unexpected output (-want +got): %s", diff)
+			}
+
+			gotAll, err := snapshot.ResourceClaims().ListAllAllocatedDevices()
+			if err != nil {
+				t.Fatalf("ListAllAllocatedDevices(): %v", err)
+			}
+			if diff := cmp.Diff(tc.wantAllDevices, gotAll); diff != "" {
+				t.Errorf("ListAllAllocatedDevices(): unexpected output (-want +got): %s", diff)
+			}
+		})
 	}
 }

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_allocated_state_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	apiv1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuretesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/ptr"
+	drautils "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/utils"
+
+	. "sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+// referenceAllocatedState recomputes the allocated state from scratch, the way
+// GatherAllocatedState used to before the state was maintained incrementally. The
+// incremental tracker has to agree with this at all times.
+func referenceAllocatedState(snapshot *Snapshot, enabledConsumableCapacity bool) *structured.AllocatedState {
+	devices := sets.New[structured.DeviceID]()
+	sharedDeviceIDs := sets.New[structured.SharedDeviceID]()
+	capacity := structured.NewConsumedCapacityCollection()
+
+	snapshot.walkResourceClaims(func(claim *resourceapi.ResourceClaim) bool {
+		foreachAllocatedDevice(claim,
+			func(deviceID structured.DeviceID) { devices.Insert(deviceID) },
+			enabledConsumableCapacity,
+			func(sharedDeviceID structured.SharedDeviceID) { sharedDeviceIDs.Insert(sharedDeviceID) },
+			func(deviceCapacity structured.DeviceConsumedCapacity) { capacity.Insert(deviceCapacity) },
+		)
+		return true
+	})
+
+	return &structured.AllocatedState{
+		AllocatedDevices:         devices,
+		AllocatedSharedDeviceIDs: sharedDeviceIDs,
+		AggregatedCapacity:       capacity,
+	}
+}
+
+func assertStateMatchesReference(t *testing.T, snapshot *Snapshot, step string) {
+	t.Helper()
+
+	enabledConsumableCapacity := utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity)
+
+	got, err := snapshot.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		t.Fatalf("%s: GatherAllocatedState(): unexpected error: %v", step, err)
+	}
+	want := referenceAllocatedState(snapshot, enabledConsumableCapacity)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("%s: GatherAllocatedState(): unexpected output (-want +got): %s", step, diff)
+	}
+
+	gotDevices, err := snapshot.ResourceClaims().ListAllAllocatedDevices()
+	if err != nil {
+		t.Fatalf("%s: ListAllAllocatedDevices(): unexpected error: %v", step, err)
+	}
+	wantDevices := referenceAllocatedState(snapshot, false).AllocatedDevices
+	if diff := cmp.Diff(wantDevices, gotDevices); diff != "" {
+		t.Fatalf("%s: ListAllAllocatedDevices(): unexpected output (-want +got): %s", step, diff)
+	}
+}
+
+func allocationForDevices(devices ...resourceapi.DeviceRequestAllocationResult) *resourceapi.AllocationResult {
+	// Only Devices.Results matters here - that is all the allocated state is derived from.
+	return &resourceapi.AllocationResult{
+		Devices: resourceapi.DeviceAllocationResult{Results: devices},
+	}
+}
+
+func dedicatedResult(driver, pool, device string) resourceapi.DeviceRequestAllocationResult {
+	return resourceapi.DeviceRequestAllocationResult{Request: "req", Driver: driver, Pool: pool, Device: device}
+}
+
+func sharedResult(driver, pool, device, shareID string, capacity int64) resourceapi.DeviceRequestAllocationResult {
+	result := dedicatedResult(driver, pool, device)
+	result.ShareID = ptr.To(types.UID(shareID))
+	if capacity > 0 {
+		result.ConsumedCapacity = map[resourceapi.QualifiedName]resource.Quantity{
+			"memory": *resource.NewQuantity(capacity, resource.DecimalSI),
+		}
+	}
+	return result
+}
+
+func allocatedStateTestClaim(namespace, name string, allocation *resourceapi.AllocationResult) *resourceapi.ResourceClaim {
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(namespace + "/" + name)},
+	}
+	if allocation != nil {
+		claim = drautils.TestClaimWithAllocation(claim, allocation)
+	}
+	return claim
+}
+
+// TestAllocatedStateTrackerMatchesReference walks the tracker through the individual
+// operations that change ResourceClaims, checking against a from-scratch recomputation after
+// every one of them.
+func TestAllocatedStateTrackerMatchesReference(t *testing.T) {
+	for _, consumableCapacity := range []bool{true, false} {
+		t.Run(fmt.Sprintf("DRAConsumableCapacity=%v", consumableCapacity), func(t *testing.T) {
+			featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAConsumableCapacity, consumableCapacity)
+
+			allocated := allocatedStateTestClaim("default", "allocated", allocationForDevices(dedicatedResult("driver", "pool", "dev-1")))
+			shared := allocatedStateTestClaim("default", "shared", allocationForDevices(
+				sharedResult("driver", "pool", "dev-2", "share-a", 10),
+				sharedResult("driver", "pool", "dev-2", "share-b", 5),
+			))
+			unallocated := allocatedStateTestClaim("default", "unallocated", nil)
+
+			snapshot := NewSnapshot(
+				map[ResourceClaimId]*resourceapi.ResourceClaim{
+					GetClaimId(allocated): allocated,
+					GetClaimId(shared):    shared,
+				}, nil, nil, nil)
+			assertStateMatchesReference(t, snapshot, "initial")
+
+			// Adding an unallocated claim contributes nothing.
+			if err := snapshot.AddClaims([]*resourceapi.ResourceClaim{unallocated}); err != nil {
+				t.Fatalf("AddClaims(): %v", err)
+			}
+			assertStateMatchesReference(t, snapshot, "after adding unallocated claim")
+
+			// Adding an allocated claim contributes its devices.
+			extra := allocatedStateTestClaim("default", "extra", allocationForDevices(dedicatedResult("driver", "pool", "dev-3")))
+			if err := snapshot.AddClaims([]*resourceapi.ResourceClaim{extra}); err != nil {
+				t.Fatalf("AddClaims(): %v", err)
+			}
+			assertStateMatchesReference(t, snapshot, "after adding allocated claim")
+
+			// Allocating a previously unallocated claim.
+			snapshot.Fork()
+			nowAllocated := allocatedStateTestClaim("default", "unallocated", allocationForDevices(dedicatedResult("driver", "pool", "dev-4")))
+			snapshot.configureResourceClaim(nowAllocated)
+			assertStateMatchesReference(t, snapshot, "after allocating in a fork")
+
+			// Reverting has to bring back the unallocated version.
+			snapshot.Revert()
+			assertStateMatchesReference(t, snapshot, "after reverting the allocation")
+
+			// The same allocation, committed this time.
+			snapshot.Fork()
+			snapshot.configureResourceClaim(nowAllocated)
+			snapshot.Commit()
+			assertStateMatchesReference(t, snapshot, "after committing the allocation")
+
+			// Deleting a claim withdraws its devices.
+			snapshot.Fork()
+			snapshot.deleteResourceClaim(GetClaimId(extra))
+			assertStateMatchesReference(t, snapshot, "after deleting a claim")
+
+			snapshot.Revert()
+			assertStateMatchesReference(t, snapshot, "after reverting the deletion")
+		})
+	}
+}
+
+// TestAllocatedStateTrackerRandomizedOperations is the main guard on the incremental
+// bookkeeping: it drives a Snapshot through a long random sequence of the operations that
+// mutate ResourceClaims, and after every step asserts the maintained state still equals a
+// from-scratch recomputation. Pod reservations are included because they rewrite claims in
+// place, which is exactly the case the tracker's contribution bookkeeping exists for.
+func TestAllocatedStateTrackerRandomizedOperations(t *testing.T) {
+	for _, consumableCapacity := range []bool{true, false} {
+		t.Run(fmt.Sprintf("DRAConsumableCapacity=%v", consumableCapacity), func(t *testing.T) {
+			featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAConsumableCapacity, consumableCapacity)
+
+			const claimCount = 12
+			const steps = 400
+			// Fixed seed - the sequence has to be reproducible when it finds a problem.
+			random := rand.New(rand.NewSource(1))
+
+			claimIds := make([]ResourceClaimId, 0, claimCount)
+			initial := map[ResourceClaimId]*resourceapi.ResourceClaim{}
+			pods := make([]*apiv1.Pod, 0, claimCount)
+			for i := 0; i < claimCount; i++ {
+				claim := allocatedStateTestClaim("default", fmt.Sprintf("claim-%d", i), nil)
+				pod := BuildTestPod(fmt.Sprintf("pod-%d", i), 1, 1, WithResourceClaim(claim.Name, claim.Name, ""))
+				claim = drautils.TestClaimWithPodOwnership(pod, claim)
+				initial[GetClaimId(claim)] = claim
+				claimIds = append(claimIds, GetClaimId(claim))
+				pods = append(pods, pod)
+			}
+
+			snapshot := NewSnapshot(initial, nil, nil, nil)
+			assertStateMatchesReference(t, snapshot, "initial")
+
+			depth := 0
+			for step := 0; step < steps; step++ {
+				index := random.Intn(claimCount)
+				claimId := claimIds[index]
+				pod := pods[index]
+
+				switch random.Intn(8) {
+				case 0: // allocate a dedicated device
+					claim, found := snapshot.getResourceClaim(claimId)
+					if !found {
+						break
+					}
+					updated := drautils.TestClaimWithAllocation(claim.DeepCopy(), allocationForDevices(
+						dedicatedResult("driver", fmt.Sprintf("pool-%d", random.Intn(3)), fmt.Sprintf("dev-%d", random.Intn(5))),
+					))
+					snapshot.configureResourceClaim(updated)
+				case 1: // allocate shared devices with consumed capacity
+					claim, found := snapshot.getResourceClaim(claimId)
+					if !found {
+						break
+					}
+					updated := drautils.TestClaimWithAllocation(claim.DeepCopy(), allocationForDevices(
+						sharedResult("driver", "pool-shared", fmt.Sprintf("dev-%d", random.Intn(3)), fmt.Sprintf("share-%d", random.Intn(3)), int64(random.Intn(10)+1)),
+					))
+					snapshot.configureResourceClaim(updated)
+				case 2: // reserve for the owning pod - rewrites the claim in place
+					if err := snapshot.ReservePodClaims(pod); err != nil {
+						// Expected when the claim isn't allocated or is gone.
+						break
+					}
+				case 3: // unreserve - can deallocate the claim in place
+					if err := snapshot.UnreservePodClaims(pod); err != nil {
+						break
+					}
+				case 4: // remove the pod-owned claim
+					snapshot.RemovePodOwnedClaims(context.Background(), pod)
+				case 5: // re-add a removed claim
+					if _, found := snapshot.getResourceClaim(claimId); found {
+						break
+					}
+					readded := allocatedStateTestClaim(claimId.Namespace, claimId.Name, nil)
+					readded = drautils.TestClaimWithPodOwnership(pod, readded)
+					if err := snapshot.AddClaims([]*resourceapi.ResourceClaim{readded}); err != nil {
+						t.Fatalf("step %d: AddClaims(): %v", step, err)
+					}
+				case 6: // fork
+					snapshot.Fork()
+					depth++
+				case 7: // commit or revert
+					if depth == 0 {
+						break
+					}
+					depth--
+					if random.Intn(2) == 0 {
+						snapshot.Commit()
+					} else {
+						snapshot.Revert()
+					}
+				}
+
+				assertStateMatchesReference(t, snapshot, fmt.Sprintf("step %d", step))
+			}
+		})
+	}
+}
+
+// TestAllocatedStateTrackerBuildsLazily checks that mutations applied before the state is
+// ever read are still reflected, since the tracker skips updates until its first full pass.
+func TestAllocatedStateTrackerBuildsLazily(t *testing.T) {
+	snapshot := NewSnapshot(nil, nil, nil, nil)
+
+	claim := allocatedStateTestClaim("default", "claim", allocationForDevices(dedicatedResult("driver", "pool", "dev-1")))
+	if err := snapshot.AddClaims([]*resourceapi.ResourceClaim{claim}); err != nil {
+		t.Fatalf("AddClaims(): %v", err)
+	}
+
+	// First read of the state - has to pick up the claim added before any read.
+	assertStateMatchesReference(t, snapshot, "after first read")
+
+	state, err := snapshot.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		t.Fatalf("GatherAllocatedState(): %v", err)
+	}
+	if want := structured.MakeDeviceID("driver", "pool", "dev-1"); !state.AllocatedDevices.Has(want) {
+		t.Errorf("GatherAllocatedState(): device %v missing from %v", want, state.AllocatedDevices)
+	}
+}
+
+// TestAllocatedStateTrackerDuplicateDevice checks the reference counting: a device claimed by
+// two claims only leaves the state once both are gone.
+func TestAllocatedStateTrackerDuplicateDevice(t *testing.T) {
+	first := allocatedStateTestClaim("default", "first", allocationForDevices(dedicatedResult("driver", "pool", "dev-1")))
+	second := allocatedStateTestClaim("default", "second", allocationForDevices(dedicatedResult("driver", "pool", "dev-1")))
+	snapshot := NewSnapshot(map[ResourceClaimId]*resourceapi.ResourceClaim{
+		GetClaimId(first):  first,
+		GetClaimId(second): second,
+	}, nil, nil, nil)
+
+	deviceID := structured.MakeDeviceID("driver", "pool", "dev-1")
+	state, err := snapshot.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		t.Fatalf("GatherAllocatedState(): %v", err)
+	}
+	if !state.AllocatedDevices.Has(deviceID) {
+		t.Fatalf("device %v should be allocated", deviceID)
+	}
+
+	snapshot.deleteResourceClaim(GetClaimId(first))
+	if !state.AllocatedDevices.Has(deviceID) {
+		t.Errorf("device %v should still be allocated while the second claim holds it", deviceID)
+	}
+
+	snapshot.deleteResourceClaim(GetClaimId(second))
+	if state.AllocatedDevices.Has(deviceID) {
+		t.Errorf("device %v should be released once no claim holds it", deviceID)
+	}
+}
+
+// TestAllocatedStateTrackerAliasedClaim covers a Pod that reaches the same ResourceClaim
+// through two names. Every claim write then hits the tracker twice for one claimId, and on
+// the second hit Snapshot.ensureClaimWritable hands back the already-stored object, so the
+// tracker cannot recover the previous allocation from the claim itself. Recording each
+// claim's contribution is what keeps the refcounts balanced here, and a stray increment
+// would strand the device in the state after the claim goes away.
+//
+// This is the shape reported in kubernetes-sigs/cluster-autoscaler#33. The base-layer leak
+// described there is a Snapshot bug and is deliberately not asserted on; what this pins down
+// is that the derived state stays in agreement with the claims either way.
+func TestAllocatedStateTrackerAliasedClaim(t *testing.T) {
+	pod := BuildTestPod("alias-pod", 1, 1,
+		WithResourceClaim("first", "shared-claim", ""),
+		WithResourceClaim("second", "shared-claim", ""),
+	)
+	claim := allocatedStateTestClaim("default", "shared-claim", allocationForDevices(dedicatedResult("driver", "pool", "dev-1")))
+	snapshot := NewSnapshot(map[ResourceClaimId]*resourceapi.ResourceClaim{GetClaimId(claim): claim}, nil, nil, nil)
+
+	// Build the state before forking, so the writes below actually reach the tracker.
+	assertStateMatchesReference(t, snapshot, "initial")
+
+	snapshot.Fork()
+	if err := snapshot.ReservePodClaims(pod); err != nil {
+		t.Fatalf("ReservePodClaims(): %v", err)
+	}
+	assertStateMatchesReference(t, snapshot, "after ReservePodClaims")
+
+	if err := snapshot.UnreservePodClaims(pod); err != nil {
+		t.Fatalf("UnreservePodClaims(): %v", err)
+	}
+	assertStateMatchesReference(t, snapshot, "after UnreservePodClaims")
+
+	snapshot.Revert()
+	assertStateMatchesReference(t, snapshot, "after Revert")
+
+	// The device was reached through two aliases, so a leaked refcount would keep it in the
+	// state past the removal of the only claim holding it.
+	snapshot.deleteResourceClaim(GetClaimId(claim))
+	assertStateMatchesReference(t, snapshot, "after delete")
+
+	state, err := snapshot.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		t.Fatalf("GatherAllocatedState(): %v", err)
+	}
+	if deviceID := structured.MakeDeviceID("driver", "pool", "dev-1"); state.AllocatedDevices.Has(deviceID) {
+		t.Errorf("device %v should be released once the aliased claim is gone", deviceID)
+	}
+}

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
@@ -44,14 +44,51 @@ func (ct snapshotClaimTracker) Get(namespace, claimName string) (*resourceapi.Re
 	return claim, nil
 }
 
-// ListAllAllocatedDevices returns every device consumed by the ResourceClaims in the
-// snapshot.
+// Borrowed collections
 //
-// The returned set is the snapshot's own rather than a copy: it must not be modified, and
-// it is only valid until the next change to the snapshot's ResourceClaims. Handing it over
-// directly is what keeps the per-attempt walk over every claim off this path. The scheduler
-// honours that - the DRA plugin folds the set into a structured.AllocatedState and passes it
-// to structured.NewAllocator, which only ever reads it (Set.Has, range, map lookup).
+// ListAllAllocatedDevices and GatherAllocatedState hand back the snapshot's own live
+// collections instead of copies. Copying them would put an O(allocated devices) walk back on
+// a path the scheduler takes once per pod placement attempt, which is the cost this whole
+// mechanism exists to remove, so the borrow is deliberate. It comes with two conditions on
+// the caller:
+//
+//   - Read only. Writing through a returned collection corrupts the snapshot's derived
+//     state, and nothing recomputes it.
+//   - Valid until the next write. Any change to the snapshot's ResourceClaims - including
+//     Fork, Commit and Revert - may mutate the collection in place. Callers that need a
+//     value across a write have to call again afterwards, or copy it themselves.
+//
+// fwk.ResourceClaimTracker states neither condition, so this is a contract Cluster
+// Autoscaler adds on top of the interface rather than one the interface grants. That is only
+// sound because every caller is known and checked:
+//
+//   - k8s.io/dynamic-resource-allocation/structured, which is where the DRA scheduler plugin
+//     sends the result. All three allocator variants (stable, incubating, experimental) and
+//     structured.IsDeviceAllocated only ever read - Set.Has, len, range, map index.
+//   - Cluster Autoscaler's own code, which does not call either method outside tests.
+//
+// TestSnapshotClaimTrackerBorrowedCollectionsAreReadOnly pins the first bullet down against
+// the real allocator, so a Kubernetes bump that starts writing through the alias fails there
+// instead of silently skewing the snapshot.
+//
+// Be aware of what that leaves standing. Nothing detects a violation at runtime: a consumer
+// that writes through one of these collections corrupts the snapshot's derived state
+// silently and permanently, because nothing recomputes it. The test above covers the
+// consumer that exists today, so a violation should surface as a test failure on a
+// Kubernetes bump rather than in a cluster - but that is the whole of the protection, and it
+// only covers callers the test drives. A cheap runtime check is not available either: the
+// collections are maps, so the affordable signal is their size, and that misses both a
+// balanced insert-and-delete and a resource.Quantity edited in place inside an
+// AggregatedCapacity entry that already exists. Anything that caught those would need a deep
+// comparison on every write, which costs exactly what handing the collections out saves.
+//
+// If a future caller needs these to be safe rather than merely known-safe, the fix is to
+// state the contract in k8s.io/dynamic-resource-allocation/structured/schedulerapi, whose
+// types are declared a scheduler/autoscaler contract that Cluster Autoscaler has approval
+// rights over, rather than to add a partial guard here.
+
+// ListAllAllocatedDevices returns every device consumed by the ResourceClaims in the
+// snapshot. The returned set is borrowed - see "Borrowed collections" above.
 func (ct snapshotClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
 	tracker := ct.snapshot.allocationTracker()
 	tracker.ensureBuilt(ct.snapshot.walkResourceClaims)
@@ -59,25 +96,22 @@ func (ct snapshotClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.De
 }
 
 // GatherAllocatedState returns the state of all devices consumed by the ResourceClaims in
-// the snapshot.
+// the snapshot. The collections behind the returned AllocatedState are borrowed - see
+// "Borrowed collections" above.
 //
 // The scheduler calls this once per PreFilter, that is once per pod scheduling attempt, so
 // the state is maintained as ResourceClaims change rather than recomputed here.
-//
-// The returned collections are the snapshot's own rather than copies: they must not be
-// modified, and they are only valid until the next change to the snapshot's ResourceClaims.
-// The DRA scheduler plugin dereferences the AllocatedState into structured.NewAllocator, and
-// the allocator only ever reads the collections (Set.Has, range, map lookup), so nothing
-// downstream writes through the alias. The AllocatedState wrapper itself is built fresh on
-// every call, so reassigning its fields below is safe.
 func (ct snapshotClaimTracker) GatherAllocatedState() (*structured.AllocatedState, error) {
 	tracker := ct.snapshot.allocationTracker()
 	tracker.ensureBuilt(ct.snapshot.walkResourceClaims)
 
+	// The AllocatedState wrapper is built fresh on every call, so the fields below can be
+	// reassigned without disturbing the tracker or an earlier caller's copy of the struct.
 	state := tracker.allocatedState()
 	if !utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity) {
-		// Without the feature the shared devices are reported as ordinary allocated ones,
-		// matching what foreachAllocatedDevice does when told sharing is disabled.
+		// With the feature off, shared devices are reported as ordinary allocated ones and
+		// sharing is not reported at all. The two empty collections are freshly allocated
+		// rather than borrowed, but callers should not rely on that distinction.
 		state.AllocatedDevices = tracker.allDevices.set
 		state.AllocatedSharedDeviceIDs = sets.New[structured.SharedDeviceID]()
 		state.AggregatedCapacity = structured.NewConsumedCapacityCollection()
@@ -134,44 +168,12 @@ func (ct snapshotClaimTracker) AssumedClaimRestore(namespace, claimName string) 
 	panic("snapshotClaimTracker.AssumedClaimRestore() was called - this should never happen")
 }
 
-// foreachAllocatedDevice invokes the provided callback for each
-// device in the claim's allocation result which was allocated
-// exclusively for the claim.
-//
-// This method is a fork of a corresponding scheduler logic
-func foreachAllocatedDevice(claim *resourceapi.ResourceClaim,
-	dedicatedDeviceCallback func(deviceID structured.DeviceID),
-	enabledConsumableCapacity bool,
-	sharedDeviceCallback func(structured.SharedDeviceID),
-	consumedCapacityCallback func(structured.DeviceConsumedCapacity)) {
-	forEachAllocatedResult(claim, func(deviceID structured.DeviceID, result *resourceapi.DeviceRequestAllocationResult) {
-
-		// Execute sharedDeviceCallback and consumedCapacityCallback correspondingly
-		// if DRAConsumableCapacity feature is enabled
-		if enabledConsumableCapacity {
-			shared := result.ShareID != nil
-			if shared {
-				sharedDeviceID := structured.MakeSharedDeviceID(deviceID, result.ShareID)
-				sharedDeviceCallback(sharedDeviceID)
-				if result.ConsumedCapacity != nil {
-					deviceConsumedCapacity := structured.NewDeviceConsumedCapacity(deviceID, result.ConsumedCapacity)
-					consumedCapacityCallback(deviceConsumedCapacity)
-				}
-				return
-			}
-		}
-
-		// Otherwise, execute dedicatedDeviceCallback
-		dedicatedDeviceCallback(deviceID)
-	})
-}
-
 // forEachAllocatedResult invokes the provided callback for each allocation result in the
 // claim that counts as consuming its device, along with the DeviceID derived from it.
 //
-// This is the single place where an allocation result is turned into a DeviceID, so that
-// foreachAllocatedDevice and allocatedStateTracker cannot drift apart on which devices count
-// as allocated.
+// This replaces foreachAllocatedDevice, which was a fork of the corresponding scheduler
+// logic. Splitting the devices between dedicated and shared now happens in
+// allocatedStateTracker.apply, which is the only place that needs it.
 func forEachAllocatedResult(claim *resourceapi.ResourceClaim, callback func(structured.DeviceID, *resourceapi.DeviceRequestAllocationResult)) {
 	if claim.Status.Allocation == nil {
 		return

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_claim_tracker.go
@@ -44,44 +44,45 @@ func (ct snapshotClaimTracker) Get(namespace, claimName string) (*resourceapi.Re
 	return claim, nil
 }
 
+// ListAllAllocatedDevices returns every device consumed by the ResourceClaims in the
+// snapshot.
+//
+// The returned set is the snapshot's own rather than a copy: it must not be modified, and
+// it is only valid until the next change to the snapshot's ResourceClaims. Handing it over
+// directly is what keeps the per-attempt walk over every claim off this path. The scheduler
+// honours that - the DRA plugin folds the set into a structured.AllocatedState and passes it
+// to structured.NewAllocator, which only ever reads it (Set.Has, range, map lookup).
 func (ct snapshotClaimTracker) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
-	result := sets.New[structured.DeviceID]()
-	for _, claim := range ct.snapshot.listResourceClaims() {
-		foreachAllocatedDevice(claim,
-			func(deviceID structured.DeviceID) {
-				result.Insert(deviceID)
-			}, false, func(structured.SharedDeviceID) {}, func(capacity structured.DeviceConsumedCapacity) {})
-	}
-	return result, nil
+	tracker := ct.snapshot.allocationTracker()
+	tracker.ensureBuilt(ct.snapshot.walkResourceClaims)
+	return tracker.allDevices.set, nil
 }
 
+// GatherAllocatedState returns the state of all devices consumed by the ResourceClaims in
+// the snapshot.
+//
+// The scheduler calls this once per PreFilter, that is once per pod scheduling attempt, so
+// the state is maintained as ResourceClaims change rather than recomputed here.
+//
+// The returned collections are the snapshot's own rather than copies: they must not be
+// modified, and they are only valid until the next change to the snapshot's ResourceClaims.
+// The DRA scheduler plugin dereferences the AllocatedState into structured.NewAllocator, and
+// the allocator only ever reads the collections (Set.Has, range, map lookup), so nothing
+// downstream writes through the alias. The AllocatedState wrapper itself is built fresh on
+// every call, so reassigning its fields below is safe.
 func (ct snapshotClaimTracker) GatherAllocatedState() (*structured.AllocatedState, error) {
-	allocatedDevices := sets.New[structured.DeviceID]()
-	allocatedSharedDeviceIDs := sets.New[structured.SharedDeviceID]()
-	aggregatedCapacity := structured.NewConsumedCapacityCollection()
+	tracker := ct.snapshot.allocationTracker()
+	tracker.ensureBuilt(ct.snapshot.walkResourceClaims)
 
-	enabledConsumableCapacity := utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity)
-
-	for _, claim := range ct.snapshot.listResourceClaims() {
-		foreachAllocatedDevice(claim,
-			func(deviceID structured.DeviceID) {
-				allocatedDevices.Insert(deviceID)
-			},
-			enabledConsumableCapacity,
-			func(sharedDeviceID structured.SharedDeviceID) {
-				allocatedSharedDeviceIDs.Insert(sharedDeviceID)
-			},
-			func(capacity structured.DeviceConsumedCapacity) {
-				aggregatedCapacity.Insert(capacity)
-			},
-		)
+	state := tracker.allocatedState()
+	if !utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity) {
+		// Without the feature the shared devices are reported as ordinary allocated ones,
+		// matching what foreachAllocatedDevice does when told sharing is disabled.
+		state.AllocatedDevices = tracker.allDevices.set
+		state.AllocatedSharedDeviceIDs = sets.New[structured.SharedDeviceID]()
+		state.AggregatedCapacity = structured.NewConsumedCapacityCollection()
 	}
-
-	return &structured.AllocatedState{
-		AllocatedDevices:         allocatedDevices,
-		AllocatedSharedDeviceIDs: allocatedSharedDeviceIDs,
-		AggregatedCapacity:       aggregatedCapacity,
-	}, nil
+	return state, nil
 }
 
 func (ct snapshotClaimTracker) SignalClaimPendingAllocation(claimUid types.UID, allocatedClaim *resourceapi.ResourceClaim) error {
@@ -143,11 +144,7 @@ func foreachAllocatedDevice(claim *resourceapi.ResourceClaim,
 	enabledConsumableCapacity bool,
 	sharedDeviceCallback func(structured.SharedDeviceID),
 	consumedCapacityCallback func(structured.DeviceConsumedCapacity)) {
-	if claim.Status.Allocation == nil {
-		return
-	}
-	for _, result := range claim.Status.Allocation.Devices.Results {
-		deviceID := structured.MakeDeviceID(result.Driver, result.Pool, result.Device)
+	forEachAllocatedResult(claim, func(deviceID structured.DeviceID, result *resourceapi.DeviceRequestAllocationResult) {
 
 		// Execute sharedDeviceCallback and consumedCapacityCallback correspondingly
 		// if DRAConsumableCapacity feature is enabled
@@ -160,11 +157,27 @@ func foreachAllocatedDevice(claim *resourceapi.ResourceClaim,
 					deviceConsumedCapacity := structured.NewDeviceConsumedCapacity(deviceID, result.ConsumedCapacity)
 					consumedCapacityCallback(deviceConsumedCapacity)
 				}
-				continue
+				return
 			}
 		}
 
 		// Otherwise, execute dedicatedDeviceCallback
 		dedicatedDeviceCallback(deviceID)
+	})
+}
+
+// forEachAllocatedResult invokes the provided callback for each allocation result in the
+// claim that counts as consuming its device, along with the DeviceID derived from it.
+//
+// This is the single place where an allocation result is turned into a DeviceID, so that
+// foreachAllocatedDevice and allocatedStateTracker cannot drift apart on which devices count
+// as allocated.
+func forEachAllocatedResult(claim *resourceapi.ResourceClaim, callback func(structured.DeviceID, *resourceapi.DeviceRequestAllocationResult)) {
+	if claim.Status.Allocation == nil {
+		return
+	}
+	for resultIndex := range claim.Status.Allocation.Devices.Results {
+		result := &claim.Status.Allocation.Devices.Results[resultIndex]
+		callback(structured.MakeDeviceID(result.Driver, result.Pool, result.Device), result)
 	}
 }

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_claim_tracker_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_claim_tracker_test.go
@@ -17,17 +17,25 @@ limitations under the License.
 package snapshot
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuretesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/dynamic-resource-allocation/cel"
 	"k8s.io/dynamic-resource-allocation/structured"
 	schedulerinterface "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
 )
 
@@ -241,6 +249,194 @@ func TestSnapshotClaimTrackerSignalClaimPendingAllocation(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.allocatedClaim, claimAfterSignal); diff != "" {
 				t.Errorf("Claim in unexpected state after snapshotClaimTracker.SignalClaimPendingAllocation() (-want +got): %s", diff)
+			}
+		})
+	}
+}
+
+// TestSnapshotClaimTrackerBorrowedCollectionsAreReadOnly guards the "Borrowed collections"
+// contract documented on ListAllAllocatedDevices and GatherAllocatedState.
+//
+// Both hand back the snapshot's own live collections, which is only safe because the code
+// they are handed to - the structured allocator behind the DRA scheduler plugin - only reads
+// them. fwk.ResourceClaimTracker does not promise that, so nothing but this test stops a
+// Kubernetes bump from quietly starting to write through the alias and skewing a snapshot
+// that is never recomputed.
+//
+// So: hand the real allocator the real borrowed collections, let it allocate, and check that
+// it did not touch them.
+func TestSnapshotClaimTrackerBorrowedCollectionsAreReadOnly(t *testing.T) {
+	const (
+		driver    = "driver.example.com"
+		className = "example-class"
+		nodeName  = "node-1"
+		poolName  = "pool-1"
+	)
+
+	// Both allocator variants that can be reached through structured.NewAllocator: the
+	// stable one takes only AllocatedDevices, the incubating one takes the whole
+	// AllocatedState including the shared devices and the aggregated capacity.
+	//
+	// GatherAllocatedState only fills the latter two in when Kubernetes'
+	// DRAConsumableCapacity gate is on, so the gate has to move with the allocator variant -
+	// otherwise the incubating case would be handed two empty collections and the
+	// assertions on them would hold no matter what the allocator did.
+	for _, tc := range []struct {
+		name               string
+		allocatorFeatures  structured.Features
+		consumableCapacity bool
+	}{
+		{name: "stable", allocatorFeatures: structured.Features{}},
+		{name: "incubating/ConsumableCapacity", allocatorFeatures: structured.Features{ConsumableCapacity: true}, consumableCapacity: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAConsumableCapacity, tc.consumableCapacity)
+			ctx := context.Background()
+
+			devices := make([]resourceapi.Device, 4)
+			for i := range devices {
+				devices[i] = resourceapi.Device{Name: fmt.Sprintf("device-%d", i)}
+			}
+			slice := &resourceapi.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "slice-1", UID: "slice-1"},
+				Spec: resourceapi.ResourceSliceSpec{
+					NodeName: ptr.To(nodeName),
+					Driver:   driver,
+					Pool:     resourceapi.ResourcePool{Name: poolName, ResourceSliceCount: 1},
+					Devices:  devices,
+				},
+			}
+			deviceClass := &resourceapi.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+				Spec: resourceapi.DeviceClassSpec{
+					Selectors: []resourceapi.DeviceSelector{
+						{CEL: &resourceapi.CELDeviceSelector{Expression: fmt.Sprintf("device.driver == %q", driver)}},
+					},
+				},
+			}
+
+			// An already-allocated claim, so the borrowed collections are not empty and the
+			// allocator has something to read out of them.
+			allocated := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "allocated", UID: "allocated", Namespace: "default"},
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{Request: "req", Driver: driver, Pool: poolName, Device: "device-0"},
+							},
+						},
+					},
+				},
+			}
+
+			// A claim holding a share of a device, so AllocatedSharedDeviceIDs and
+			// AggregatedCapacity are populated too and the assertions on them are not
+			// comparing one empty collection to another.
+			shared := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared", UID: "shared", Namespace: "default"},
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{
+									Request: "req", Driver: driver, Pool: poolName, Device: "device-1",
+									ShareID: ptr.To(types.UID("share-a")),
+									ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+										"memory": *resource.NewQuantity(4, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			snapshot := NewSnapshot(
+				map[ResourceClaimId]*resourceapi.ResourceClaim{
+					GetClaimId(allocated): allocated,
+					GetClaimId(shared):    shared,
+				},
+				map[string][]*resourceapi.ResourceSlice{nodeName: {slice}},
+				nil,
+				map[string]*resourceapi.DeviceClass{className: deviceClass},
+			)
+
+			state, err := snapshot.ResourceClaims().GatherAllocatedState()
+			if err != nil {
+				t.Fatalf("GatherAllocatedState(): %v", err)
+			}
+			borrowedDevices, err := snapshot.ResourceClaims().ListAllAllocatedDevices()
+			if err != nil {
+				t.Fatalf("ListAllAllocatedDevices(): %v", err)
+			}
+
+			wantDevices := state.AllocatedDevices.Clone()
+			wantSharedDeviceIDs := state.AllocatedSharedDeviceIDs.Clone()
+			wantCapacity := state.AggregatedCapacity.Clone()
+			wantAllDevices := borrowedDevices.Clone()
+
+			// An assertion that a collection did not change is worthless if the collection
+			// was empty to begin with, so check the fixture actually filled them.
+			if len(wantDevices) == 0 || len(wantAllDevices) == 0 {
+				t.Fatalf("fixture produced no allocated devices: %d dedicated, %d total", len(wantDevices), len(wantAllDevices))
+			}
+			if tc.consumableCapacity && (len(wantSharedDeviceIDs) == 0 || len(wantCapacity) == 0) {
+				t.Fatalf("fixture produced no sharing to guard: %d shared device IDs, %d capacity entries",
+					len(wantSharedDeviceIDs), len(wantCapacity))
+			}
+
+			pending := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending", UID: "pending", Namespace: "default"},
+				Spec: resourceapi.ResourceClaimSpec{
+					Devices: resourceapi.DeviceClaim{
+						Requests: []resourceapi.DeviceRequest{
+							{
+								Name: "req",
+								Exactly: &resourceapi.ExactDeviceRequest{
+									DeviceClassName: className,
+									AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+									Count:           1,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			allocator, err := structured.NewAllocator(
+				ctx,
+				tc.allocatorFeatures,
+				*state,
+				snapshot.DeviceClasses(),
+				[]*resourceapi.ResourceSlice{slice},
+				cel.NewCache(10, cel.Features{EnableConsumableCapacity: tc.allocatorFeatures.ConsumableCapacity}),
+			)
+			if err != nil {
+				t.Fatalf("structured.NewAllocator(): %v", err)
+			}
+
+			results, err := allocator.Allocate(ctx, test.BuildTestNode(nodeName, 1000, 1000), []*resourceapi.ResourceClaim{pending})
+			if err != nil {
+				t.Fatalf("Allocate(): %v", err)
+			}
+			// A no-op allocation would read nothing and pass the assertions below for the
+			// wrong reason.
+			if len(results) != 1 {
+				t.Fatalf("Allocate(): got %d results, want 1 - the allocation has to actually run", len(results))
+			}
+
+			if diff := cmp.Diff(wantDevices, state.AllocatedDevices); diff != "" {
+				t.Errorf("the allocator modified the borrowed AllocatedDevices (-before +after): %s", diff)
+			}
+			if diff := cmp.Diff(wantSharedDeviceIDs, state.AllocatedSharedDeviceIDs); diff != "" {
+				t.Errorf("the allocator modified the borrowed AllocatedSharedDeviceIDs (-before +after): %s", diff)
+			}
+			if diff := cmp.Diff(wantCapacity, state.AggregatedCapacity); diff != "" {
+				t.Errorf("the allocator modified the borrowed AggregatedCapacity (-before +after): %s", diff)
+			}
+			if diff := cmp.Diff(wantAllDevices, borrowedDevices); diff != "" {
+				t.Errorf("the allocator modified the borrowed ListAllAllocatedDevices set (-before +after): %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The scheduler asks for the allocated device state of the cluster in every PreFilter — once per pod
placement attempt. Both `ListAllAllocatedDevices` and `GatherAllocatedState` answered that by
walking every `ResourceClaim` in the snapshot and re-deriving every `DeviceID`. Between two
consecutive attempts only a handful of claims change, so almost all of that work is repeated.

This derives the state once and then maintains it as claims are written, so the per-attempt cost
stops scaling with the size of the cluster. Every write to the claim `PatchSet` goes through
`setResourceClaim`/`deleteResourceClaim` to keep it in sync, and `Revert` re-reads only the claims
whose effective value the dropped layer changed.

This directly addresses a question @towca raised reviewing the patchset implementation in
kubernetes/autoscaler#8090:

> Have you thought about caching the LIST responses? The DRA scheduler plugin only GETs claims,
> the rest is listed (deviceclasses - which CA doesn't affect so caching would be very effective,
> resourceclaims filtered to allocated devices, resourceslices).

**Two commits, deliberately together.** The first adds `PatchSet.WalkCurrentPatchKeys`, which
exposes the keys modified or deleted in the topmost patch layer — exactly the keys whose effective
value a `Revert` changes. The second uses it. Splitting them would mean merging an exported method
with no caller, so they are in one PR.

#### Results

`benchstat`, n=6 unless noted, on a dedicated 32-vCPU cloud node (`GOMAXPROCS=8`),
using the benchmarks from #53 so both sides run byte-identical measurement code.

| benchmark | baseline | with this PR | delta |
|---|---|---|---|
| `RunOnceScaleUpDRA` | 15.003 s | 5.596 s | **-62.70%** |
| `RunOnceScaleDownDRA` (n=10) | 6.530 s | 1.938 s | **-70.32%** |
| `BinpackingEstimateDRA` 1000 nodes / 4000 claims | 526.8 ms | 100.3 ms | -80.96% |
| `BinpackingEstimateDRA` 5000 nodes / 20000 claims | 8.304 s | 1.032 s | -87.57% |
| DRA estimator geomean | 276.3 ms | 65.63 ms | -76.24% |

Memory:

| benchmark | baseline | with this PR | delta |
|---|---|---|---|
| `RunOnceScaleUpDRA` | 10.038 GiB | 3.657 GiB | -63.56% |
| `RunOnceScaleDownDRA` | 3.041 GiB | 1.308 GiB | -56.98% |

Non-DRA paths are unaffected:

| control | baseline | with this PR | delta |
|---|---|---|---|
| `RunOnceScaleUp` | 10.26 s | 10.28 s | `~` |
| `RunOnceScaleDown` | 11.84 s | 12.08 s | `~` |
| `BinpackingEstimate` (non-DRA) | 4.392 s | 4.377 s | `~` |
| snapshot store geomean | 153.8 us | 146.1 us | -4.99% |

#### How the win scales

The scenarios above move nodes, claims and pending pods together, so they cannot say which of them
the improvement tracks. Two sweeps in #53 hold one axis fixed and vary the other.

All figures below are `benchstat`, n=6, p=0.002, measured on #53 versus #53 plus this PR's two
commits — the same baseline as the tables above.

Pending pods varied, fleet fixed at 5000 nodes / 20000 allocated claims:

| pending pods | baseline | with this PR | delta |
|---|---|---|---|
| 100 | 1.711 s | 273.2 ms | -84.03% |
| 500 | 8.332 s | 1.057 s | -87.31% |
| 2500 | 43.61 s | 5.200 s | -88.08% |

Allocated claims varied, fleet fixed at 5000 nodes / 500 pending pods:

| allocated claims | baseline | with this PR | delta |
|---|---|---|---|
| 10,000 | 4.272 s | 1.035 s | -75.77% |
| 20,000 | 8.332 s | 1.057 s | -87.31% |
| 40,000 | 19.58 s | 1.137 s | -94.20% |

The second table states the mechanism directly. With this PR the cost is **flat in the number of
allocated claims** — 1.035 -> 1.057 -> 1.137 s while claims quadruple — where the baseline grows
linearly, 4.3 -> 8.3 -> 19.6 s. The saving is therefore proportional to the allocated state the old
code re-derived on every attempt, and the ratio improves as a cluster accumulates DRA workload.

#### Across device-sharing modes

`BenchmarkBinpackingEstimateDRAProfiles` (also #53) varies how devices are shaped and shared rather
than how many there are. The `noGain/*` profiles are the deliberate controls — cases constructed so
the change should *not* help.

| profile | baseline | with this PR | time | memory |
|---|---|---|---|---|
| `gpu8/exclusive` | 410.4 ms | 87.83 ms | -78.60% | -71.59% |
| `gpu8/wholeNode` | 297.6 ms | 121.7 ms | -59.12% | -48.94% |
| `gpu8/sharedClaims` | 70.67 ms | 26.14 ms | -63.00% | -52.52% |
| `mig56/fractional` | 836.6 ms | 71.78 ms | -91.42% | -88.40% |
| `devices256/multiSlice` | 840.8 ms | 64.36 ms | -92.34% | -91.99% |
| `multiDriver/gpu+net+computeDomain` | 304.1 ms | 87.34 ms | -71.27% | -67.28% |
| `noGain/existingUnallocated` | 342.7 ms | 46.49 ms | -86.43% | -86.88% |
| `noGain/manyClaimsFewPods` | 30.74 ms | 20.68 ms | -32.74% | **+6.00%** |
| `noGain/draFleetNonDraPods` | 15.96 ms | 16.37 ms | `~` | `~` |

Three things worth pulling out.

`noGain/draFleetNonDraPods` is flat on both time and memory. That is the control that matters: a
cluster with DRA capacity but pods that do not use it pays nothing for the maintained state.

`noGain/manyClaimsFewPods` is the one case that costs memory, **+6.00%** — many claims with few
placement attempts to amortise them, so the state is maintained and barely read. Time still
improves 32.74%, and the absolute figure is small, but it is the shape to watch.

`wholeNode` is the weakest real gain at -59.12%, which makes sense: one claim per node means fewer
allocated entries to re-derive per attempt, so there is less redundant work to remove.

#### What it costs

Maintaining the state is not free, and the adverse benchmarks in #53 exist to show where:

| benchmark | baseline | with this PR | delta |
|---|---|---|---|
| `AllocatedStateSingleRead/claims=100` | 69.02 us | 110.48 us | +60.05% |
| `AllocatedStateSingleRead/claims=5000` | 18.13 ms | 21.62 ms | +19.26% |
| `AllocatedStateSingleRead/claims=20000` | 96.92 ms | 111.44 ms | +14.99% |
| `AllocatedStateWriteHeavy/writes=100` | 163.7 us | 326.8 us | +99.70% |
| `AllocatedStateWriteHeavy/writes=1000` | 3.995 ms | 7.087 ms | +77.37% |
| `AllocatedStateUnallocatedClaims/claims=5000` | 2.041 ms | 1.877 ms | -8.02% |
| `AllocatedStateUnallocatedClaims/claims=20000` | 8.844 ms | 7.797 ms | -11.83% |
| `SnapshotForkRevertNoDRA` | 41.56 us | 40.27 us | `~` |

Fork/revert churn, from a dedicated high-sample run (`-benchtime=20000x -count=20`, +/-2%) because
the default sampling is too coarse at this timescale:

| benchmark | baseline | with this PR | delta | allocs/op |
|---|---|---|---|---|
| `AllocatedStateForkRevertChurn/claims=0` | 408.6 ns | 424.6 ns | +3.92% | 9 -> 9 |
| `AllocatedStateForkRevertChurn/claims=10` | 1.517 us | 2.817 us | +85.70% | 18 -> 23 |
| `AllocatedStateForkRevertChurn/claims=1000` | 1.658 us | 3.691 us | +122.62% | 18 -> 23 |

So **+2.03 us and 5 extra allocations per Fork+Revert cycle**. The overhead is *identical* at 10
claims and at 1000, because it scales with the size of the reverted patch layer, not with the
snapshot. For an empty layer it is zero — `claims=0` stays at 9 allocations, unchanged.

`PatchSet.Revert` was already O(P) in the size of the dropped layer, so the refresh keeps `Revert`
in the same complexity class with a larger constant. `BenchmarkSnapshotForkRevertNoDRA` being flat
is the check that clusters not using DRA pay nothing at all.

Net: microseconds added to fork/revert, seconds removed from the scale-up loop.

#### Cluster-scale confirmation

The benchmarks above isolate `Estimate`. To check the result survives contact with a real cluster,
the same two refs were run against a kwok-backed cluster: 1,000 nodes advertising 8 devices each,
every one of the 8,000 devices already allocated, then a 500-pod burst that forces a 63-node
scale-up.

| | baseline | with this PR | delta |
|---|---|---|---|
| `scaleUp:estimate` | 436.5 ms | 26.0 ms | **-94.0%** |
| `main` (whole CA loop) | 837.8 ms | 544.6 ms | **-35.0%** |
| time to converge | 69 s | 42 s | **-39.1%** |
| final nodes | 1,063 | 1,063 | identical |
| unschedulable pods at end | 0 | 0 | identical |

Both sides reach the same end state with nothing left pending, which is what makes the comparison
meaningful. The claims-scaling shows up here too: the same run against a 400-claim fleet gives -75%
rather than -94%.

What the scenario models, why each parameter is set the way it is, the YAML for every object it
creates, and how to rerun it:
**[hack/kwok-benchmarks/DRA-SCENARIO.md](https://github.com/tlipski/cluster-autoscaler/blob/kwok-benchmarks/hack/kwok-benchmarks/DRA-SCENARIO.md)**

This is a single run with no significance testing, so treat it as corroboration rather than primary
evidence. It does show two things the microbenchmarks structurally cannot: the whole loop moving,
and time-to-converge dropping on a real scale-up.

One caveat on reproducing it — the kwok provider cannot do DRA as it stands. `TemplateNodeInfo`
passes `nil` ResourceSlices, so a node the provider creates advertises no devices and no pod
carrying a `ResourceClaim` can ever be placed on one. The run uses a small provider fix, identical
on both sides of the comparison and not part of this PR.

#### Reproducing the comparison

The loop benchmarks already exist on `main`, so this PR can be compared against it directly:

```bash
git fetch origin main
git fetch origin pull/55/head:pr-allocated-state
go install golang.org/x/perf/cmd/benchstat@latest

git checkout origin/main
go test -run '^$' -bench BenchmarkRunOnce -benchmem -benchtime=1x -count=6 \
  ./pkg/core/bench/ > base-loop.txt

git checkout pr-allocated-state
go test -run '^$' -bench BenchmarkRunOnce -benchmem -benchtime=1x -count=6 \
  ./pkg/core/bench/ > new-loop.txt

benchstat base-loop.txt new-loop.txt
```

The DRA estimator and adverse benchmarks live in #53, so the candidate side needs both. #53 alone
is the baseline:

```bash
git fetch origin pull/53/head:pr53

git checkout -B ab-baseline pr53
git checkout -B ab-candidate pr53 && git cherry-pick main..pr-allocated-state

for side in baseline candidate; do
  git checkout ab-$side
  go test -run '^$' -bench BenchmarkBinpackingEstimateDRA -benchmem -benchtime=3x -count=6 \
    ./pkg/estimator/ > $side-dra.txt
  go test -run '^$' -bench 'BenchmarkAllocatedState|BenchmarkSnapshotForkRevertNoDRA' \
    -benchmem -benchtime=200x -count=6 \
    ./pkg/simulator/dynamicresources/snapshot/ > $side-adverse.txt
done

benchstat baseline-dra.txt candidate-dra.txt
benchstat baseline-adverse.txt candidate-adverse.txt
```

For the churn numbers specifically, raise the sampling — at 200x the readings swing by a factor of
three run to run:

```bash
go test -run '^$' -bench BenchmarkAllocatedStateForkRevertChurn -benchmem \
  -benchtime=20000x -count=20 ./pkg/simulator/dynamicresources/snapshot/
```

`RunOnceScaleDownDRA` is bimodal and does not reach significance at n=6; the -70.32% above is from
`-count=10` on that benchmark alone. All of this needs a machine with nothing else running on it —
on a laptop, thermal drift alone produced a "significant" +5% and -24% on benchmarks in code the
change does not touch.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

**On withdrawal.** The tracker records what each claim contributed when it was applied, rather than
re-deriving it when the claim is withdrawn. That is not premature generality: `ensureClaimWritable`
hands back the stored object whenever the claim already lives in the current patch layer, so the
snapshot mutates claims in place and the previous allocation may already be gone by the time a
write reaches the tracker. Recording contributions keeps the derived state consistent with whatever
the claims currently say.

That in-place mutation is also the root of #33 (a Pod referencing one claim through two aliases
leaves the base layer dirty past a `Revert`) and #37 (the base layer holds the informer's own
objects). This PR neither introduces nor fixes those; the tracker is correct either way, and
`TestAllocatedStateTrackerAliasedClaim` pins down the aliasing shape from #33 specifically.

**On returned collections.** `ListAllAllocatedDevices` and `GatherAllocatedState` now return the
snapshot's own sets rather than fresh copies — that is what removes the per-attempt walk. I checked
the consumer: the DRA plugin folds them into a `structured.AllocatedState` and passes it to
`structured.NewAllocator`, which only ever reads them (`Set.Has`, range, map lookup). The contract
is documented on both methods.

**Testing.** `TestAllocatedStateTrackerMatchesReference` and
`TestAllocatedStateTrackerRandomizedOperations` check the incremental state against a from-scratch
recomputation after every operation, so the tracker cannot silently drift from what the old code
would have returned. Full package suite passes under `-race`, and the DRA benchmarks run clean
under `-race` as well.

Relates to #53, which adds the benchmarks the numbers above come from. No code dependency — this
PR can merge in either order.

#### Does this PR introduce a user-facing change?

```release-note
Improved Cluster Autoscaler performance for clusters using Dynamic Resource Allocation. The
allocated device state the scheduler requests on every pod placement attempt is now maintained
incrementally instead of being recomputed from every ResourceClaim, cutting DRA scale-up loop time
by roughly 60% and DRA scale-down by roughly 70% in benchmarks.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

