### PR TITLE
Prevent atomic node groups from being unnecessarily categorized as unneeded

### DIFF
--- a/pkg/cloudprovider/test/fake_cloud_provider.go
+++ b/pkg/cloudprovider/test/fake_cloud_provider.go
@@ -219,6 +219,13 @@ func WithTemplate(template *framework.NodeInfo) NodeGroupOption {
 	}
 }
 
+// WithNGOptions sets the autoscaling options of the node group.
+func WithNGOptions(opts *config.NodeGroupAutoscalingOptions) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.opts = opts
+	}
+}
+
 // WithNodeGarbageCollectionDelay can be used to simulate Node objects hanging around in the K8s API for some time after their VMs are deleted.
 func WithNodeGarbageCollectionDelay(delay time.Duration) NodeGroupOption {
 	return func(n *NodeGroup) {
@@ -320,6 +327,7 @@ type NodeGroup struct {
 	// nodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If unset,
 	// the Nodes will appear as Ready immediately after registration.
 	nodeReadinessDelay time.Duration
+	opts               *config.NodeGroupAutoscalingOptions
 }
 
 // MaxSize returns the maximum size of the node group.
@@ -442,7 +450,16 @@ func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 
 // GetOptions returns autoscaling options specific to this node group.
 func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, nil
+	n.RLock()
+	defer n.RUnlock()
+	return n.opts, nil
+}
+
+// SetOptions sets the autoscaling options for the node group.
+func (n *NodeGroup) SetOptions(opts *config.NodeGroupAutoscalingOptions) {
+	n.Lock()
+	defer n.Unlock()
+	n.opts = opts
 }
 
 // TargetSize returns the current target size of the node group.

--- a/pkg/core/scaledown/eligibility/eligibility.go
+++ b/pkg/core/scaledown/eligibility/eligibility.go
@@ -25,8 +25,10 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/actuation"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/unremovable"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/atomic"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/klogx"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -104,7 +106,101 @@ func (c *Checker) FilterOutUnremovable(ctx context.Context, autoscalingCtx *ca_c
 	if skipped > 0 {
 		logger.V(1).Info("Scale-down calculation: ignoring unremovable nodes", "nodesCount", skipped, "timeout", autoscalingCtx.AutoscalingOptions.UnremovableNodeRecheckTimeout)
 	}
+
+	currentlyUnneededNodeNames, atomicIneligible := c.filterIncompleteAtomicNodeGroups(ctx, autoscalingCtx, currentlyUnneededNodeNames)
+	ineligible = append(ineligible, atomicIneligible...)
+
 	return currentlyUnneededNodeNames, utilizationMap, ineligible
+}
+
+func allNodes(s clustersnapshot.ClusterSnapshot) ([]*apiv1.Node, error) {
+	nodeInfos, err := s.ListNodeInfos()
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]*apiv1.Node, len(nodeInfos))
+	for i, ni := range nodeInfos {
+		nodes[i] = ni.Node()
+	}
+	return nodes, nil
+}
+
+// filterIncompleteAtomicNodeGroups identifies atomic node groups in currentlyUnneededNodeNames.
+// If an atomic node group has fewer unneeded candidates than its target size, it cannot be
+// atomically scaled down. Such incomplete atomic node groups are filtered out of simulation,
+// and returned as ineligible with Reason: simulator.AtomicScaleDownFailed.
+func (c *Checker) filterIncompleteAtomicNodeGroups(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeNames []string) ([]string, []*simulator.UnremovableNode) {
+	logger := klog.FromContext(ctx)
+	atomicGroupNodes := make(map[string][]string)
+	atomicGroupObj := make(map[string]cloudprovider.NodeGroup)
+	nodeNameToNode := make(map[string]*apiv1.Node)
+
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		node := nodeInfo.Node()
+		nodeNameToNode[nodeName] = node
+		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(ctx, autoscalingCtx, node)
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			atomicGroupNodes[ngID] = append(atomicGroupNodes[ngID], nodeName)
+			atomicGroupObj[ngID] = nodeGroup
+		}
+	}
+
+	if len(atomicGroupNodes) == 0 {
+		return nodeNames, nil
+	}
+
+	allNodesList, err := allNodes(autoscalingCtx.ClusterSnapshot)
+	if err != nil {
+		return nodeNames, nil
+	}
+
+	incompleteNodes := make(map[string]bool)
+	var ineligible []*simulator.UnremovableNode
+
+	for ngID, unneededNodes := range atomicGroupNodes {
+		ng := atomicGroupObj[ngID]
+		targetSize, err := ng.TargetSize(ctx)
+		if err != nil {
+			logger.Error(err, "Failed to get target size for node group", "nodeGroupId", ng.Id())
+			continue
+		}
+
+		if len(unneededNodes) < targetSize {
+			registeredCount, countErr := atomic.CountRegisteredNodesForGroup(ctx, ng, allNodesList)
+			if countErr == nil && len(unneededNodes) == registeredCount {
+				// All registered nodes in the snapshot are unneeded
+				continue
+			}
+			logger.V(2).Info("Atomic node group needs all nodes to be unneeded for scale down. Filtering out from scale down simulation.", "nodeGroupId", ng.Id(), "ngUnneededNodesCount", len(unneededNodes), "ngTargetSize", targetSize)
+			for _, nodeName := range unneededNodes {
+				incompleteNodes[nodeName] = true
+				if node, ok := nodeNameToNode[nodeName]; ok {
+					ineligible = append(ineligible, &simulator.UnremovableNode{
+						Node:   node,
+						Reason: simulator.AtomicScaleDownFailed,
+					})
+				}
+			}
+		}
+	}
+
+	if len(incompleteNodes) == 0 {
+		return nodeNames, nil
+	}
+
+	filteredNodeNames := make([]string, 0, len(nodeNames)-len(incompleteNodes))
+	for _, nodeName := range nodeNames {
+		if !incompleteNodes[nodeName] {
+			filteredNodeNames = append(filteredNodeNames, nodeName)
+		}
+	}
+
+	return filteredNodeNames, ineligible
 }
 
 func (c *Checker) unremovableReasonAndNodeUtilization(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, timestamp time.Time, nodeInfo *framework.NodeInfo, utilLogsQuota *klogx.Quota) (simulator.UnremovableReason, *utilization.Info) {

--- a/pkg/core/scaledown/eligibility/eligibility_test.go
+++ b/pkg/core/scaledown/eligibility/eligibility_test.go
@@ -97,7 +97,8 @@ type testCase struct {
 	wantUnneeded    []string
 	wantUnremovable []*simulator.UnremovableNode
 
-	optsPatches []optionsPatch
+	optsPatches   []optionsPatch
+	nodeGroupOpts *config.NodeGroupAutoscalingOptions
 }
 
 // suite is a group of testCases that share the same default option patches.
@@ -158,6 +159,14 @@ func getTestCases(now time.Time) []testCase {
 
 	dsPod := BuildTestPod("dsPod", 500, 0, WithDSController())
 	dsPod.Spec.NodeName = "regular"
+
+	atomicNode1 := BuildTestNode("atomic1", 1000, 10)
+	SetNodeReadyState(atomicNode1, true, time.Time{})
+	atomicNode2 := BuildTestNode("atomic2", 1000, 10)
+	SetNodeReadyState(atomicNode2, true, time.Time{})
+
+	atomicUtilizedPod := BuildTestPod("atomicUtilizedPod", 600, 0)
+	atomicUtilizedPod.Spec.NodeName = "atomic2"
 
 	brokenUtilNode := BuildTestNode("regular", 0, 0)
 	resourceSliceNodeName := "regular"
@@ -227,6 +236,28 @@ func getTestCases(now time.Time) []testCase {
 			wantUnneeded:    []string{},
 			wantUnremovable: []*simulator.UnremovableNode{{Node: unreadyNode, Reason: simulator.ScaleDownUnreadyDisabled}},
 			optsPatches:     []optionsPatch{withScaleDownUnreadyEnabled(false)},
+		},
+		{
+			desc:         "atomic node group: underutilized nodes in incomplete atomic group are filtered out",
+			nodes:        []*apiv1.Node{atomicNode1, atomicNode2},
+			pods:         []*apiv1.Pod{atomicUtilizedPod},
+			wantUnneeded: []string{},
+			wantUnremovable: []*simulator.UnremovableNode{
+				{Node: atomicNode2, Reason: simulator.NotUnderutilized},
+				{Node: atomicNode1, Reason: simulator.AtomicScaleDownFailed},
+			},
+			nodeGroupOpts: &config.NodeGroupAutoscalingOptions{
+				ZeroOrMaxNodeScaling: true,
+			},
+		},
+		{
+			desc:            "atomic node group: all underutilized nodes stay",
+			nodes:           []*apiv1.Node{atomicNode1, atomicNode2},
+			wantUnneeded:    []string{"atomic1", "atomic2"},
+			wantUnremovable: []*simulator.UnremovableNode{},
+			nodeGroupOpts: &config.NodeGroupAutoscalingOptions{
+				ZeroOrMaxNodeScaling: true,
+			},
 		},
 		{
 			desc:            "Node is not filtered out because of DRA issues if DRA is disabled",
@@ -307,7 +338,11 @@ func TestFilterOutUnremovable(t *testing.T) {
 			s := nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults)
 			c := NewChecker(s)
 			provider := testprovider.NewTestCloudProviderBuilder().Build()
-			provider.AddNodeGroup("ng1", 1, 10, 2)
+			if tc.nodeGroupOpts != nil {
+				provider.AddNodeGroupWithCustomOptions("ng1", 0, 10, len(tc.nodes), tc.nodeGroupOpts)
+			} else {
+				provider.AddNodeGroup("ng1", 1, 10, 2)
+			}
 			for _, n := range tc.nodes {
 				provider.AddNode("ng1", n)
 			}

--- a/pkg/core/scaledown/planner/planner.go
+++ b/pkg/core/scaledown/planner/planner.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/options"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/scheduling"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/atomic"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
 	pod_util "sigs.k8s.io/cluster-autoscaler/pkg/utils/pod"
 )
@@ -294,28 +295,44 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 	unremovableCount := 0
 	var removableList []simulator.NodeToBeRemoved
 	atomicScaleDownNodesCount := 0
+	nonAtomicRemovableCount := 0
 	p.unremovableNodes.Update(ctx, p.autoscalingCtx.ClusterSnapshot, p.latestUpdate)
 	currentlyUnneededNodeNames, utilizationMap, ineligible := p.eligibilityChecker.FilterOutUnremovable(ctx, p.autoscalingCtx, scaleDownCandidates, p.latestUpdate, p.unremovableNodes)
 	for _, n := range ineligible {
 		p.unremovableNodes.Add(n)
 	}
 	p.nodeUtilizationMap = utilizationMap
+
+	// Prefilter incomplete atomic node groups so simulation isn't wasted on atomic groups that cannot scale down.
+	var prefilteredUnremovableCount int
+	currentlyUnneededNodeNames, prefilteredUnremovableCount = p.prefilterIncompleteAtomicNodeGroups(ctx, currentlyUnneededNodeNames, unremovableTimeout)
+	unremovableCount += prefilteredUnremovableCount
+
 	timer := time.NewTimer(p.autoscalingCtx.ScaleDownSimulationTimeout)
 	var skippedNodes []string
 
-	for i, node := range currentlyUnneededNodeNames {
+	for i, nodeName := range currentlyUnneededNodeNames {
 		if timedOut(timer) {
-			skippedNodes = currentlyUnneededNodeNames[i:]
-			logger.Info("Some nodes skipped in scale down simulation due to timeout", "skippedNodesCount", len(currentlyUnneededNodeNames)-i, "nodesCount", len(currentlyUnneededNodeNames))
-			break
-		}
-		if len(removableList)-atomicScaleDownNodesCount >= p.unneededNodesLimit() {
-			skippedNodes = currentlyUnneededNodeNames[i:]
-			logger.V(4).Info("Some nodes skipped in scale down simulation: unneeded nodes count already exceeded limit so no point in looking for more.", "skippedNodesCount", len(currentlyUnneededNodeNames)-i, "nodesCount", len(currentlyUnneededNodeNames), "unneededNodesCount", len(removableList), "atomicScaleDownNodesCount", atomicScaleDownNodesCount)
+			skippedNodes = append(skippedNodes, currentlyUnneededNodeNames[i:]...)
+			logger.Info("Some nodes skipped in scale down simulation due to timeout.", "skippedNodesCount", len(currentlyUnneededNodeNames)-i, "nodesCount", len(currentlyUnneededNodeNames))
 			break
 		}
 
-		removable, unremovable := p.rs.SimulateNodeRemoval(ctx, node, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			logger.Error(err, "Failed to get node info", "nodeName", nodeName)
+			continue
+		}
+		node := nodeInfo.Node()
+		_, isAtomic := atomic.IsAtomicNodeGroup(ctx, p.autoscalingCtx, node)
+
+		if !isAtomic && nonAtomicRemovableCount >= p.unneededNodesLimit() {
+			skippedNodes = append(skippedNodes, nodeName)
+			logger.V(4).Info("Skipping non-atomic node in scale down simulation: there are already some non-atomic unneeded nodes.", "node", klog.KObj(node), "nonAtomicUnneededNodesCount", nonAtomicRemovableCount)
+			continue
+		}
+
+		removable, unremovable := p.rs.SimulateNodeRemoval(ctx, nodeName, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
 		if removable != nil {
 			_, inParallel, _ := p.autoscalingCtx.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
 			if !inParallel {
@@ -324,9 +341,11 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 			delete(podDestinations, removable.Node.Name)
 			p.autoscalingCtx.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
-			if p.atomicScaleDownNode(ctx, removable) {
+			if isAtomic {
 				atomicScaleDownNodesCount++
-				logger.V(2).Info("Considering node for atomic scale down", "node", klog.KObj(removable.Node), "atomicScaleDownNodesCount", atomicScaleDownNodesCount)
+				logger.V(2).Info("Considering node for atomic scale down.", "node", klog.KObj(node), "currentAtomicScaleDownNodesCount", atomicScaleDownNodesCount)
+			} else {
+				nonAtomicRemovableCount++
 			}
 		}
 		if unremovable != nil {
@@ -334,34 +353,97 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 			p.unremovableNodes.AddTimeout(unremovable, unremovableTimeout)
 		}
 	}
+
 	p.handleUnprocessedNodes(skippedNodes)
 	p.unneededNodes.Update(ctx, p.autoscalingCtx, removableList, p.latestUpdate)
 	if unremovableCount > 0 {
-		logger.V(1).Info("Some nodes found to be unremovable in simulation, will re-check them within timeout", "unremovableNodesCount", unremovableCount, "timeout", unremovableTimeout)
+		logger.V(1).Info("Some nodes found to be unremovable in simulation, will re-check them within timeout.", "unremovableNodesCount", unremovableCount, "timeout", unremovableTimeout)
 	}
 }
 
-// atomicScaleDownNode checks if the removable node would be considered for atomic scale down.
-func (p *Planner) atomicScaleDownNode(ctx context.Context, node *simulator.NodeToBeRemoved) bool {
+// prefilterIncompleteAtomicNodeGroups identifies atomic node groups in currentlyUnneededNodeNames.
+// If an atomic node group has fewer unneeded candidates than its target size, it cannot be
+// atomically scaled down. Such incomplete atomic node groups are filtered out of simulation,
+// and their nodes are marked as unremovable.
+func (p *Planner) prefilterIncompleteAtomicNodeGroups(ctx context.Context, nodeNames []string, unremovableTimeout time.Time) ([]string, int) {
 	logger := klog.FromContext(ctx)
-	nodeGroup, err := p.autoscalingCtx.CloudProvider.NodeGroupForNode(ctx, node.Node)
+	atomicGroupNodes := make(map[string][]string)
+	atomicGroupObj := make(map[string]cloudprovider.NodeGroup)
+	nodeNameToNode := make(map[string]*apiv1.Node)
+
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		node := nodeInfo.Node()
+		nodeNameToNode[nodeName] = node
+		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(ctx, p.autoscalingCtx, node)
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			atomicGroupNodes[ngID] = append(atomicGroupNodes[ngID], nodeName)
+			atomicGroupObj[ngID] = nodeGroup
+		}
+	}
+
+	if len(atomicGroupNodes) == 0 {
+		return nodeNames, 0
+	}
+
+	incompleteNodes := make(map[string]bool)
+	unremovableCount := 0
+
+	allNodes, err := allNodes(p.autoscalingCtx.ClusterSnapshot)
 	if err != nil {
-		logger.Error(err, "Failed to get node info", "node", klog.KObj(node.Node))
-		return false
+		return nil, 0
 	}
-	if nodeGroup == nil {
-		logger.Error(nil, "Node group not found for node", "node", klog.KObj(node.Node))
-		return false
+
+	for ngID, unneededNodes := range atomicGroupNodes {
+		ng := atomicGroupObj[ngID]
+		targetSize, err := ng.TargetSize(ctx)
+		if err != nil {
+			logger.Error(err, "Failed to get target size for node group", "nodeGroupId", ng.Id())
+			continue
+		}
+
+		if len(unneededNodes) < targetSize {
+			registeredCount, countErr := atomic.CountRegisteredNodesForGroup(ctx, ng, allNodes)
+			if countErr == nil && len(unneededNodes) >= registeredCount {
+				// All registered nodes in the snapshot are unneeded
+				continue
+			}
+			logger.V(2).Info("Atomic node group has some unneeded nodes. Filtering out from scale down simulation.", "nodeGroupId", ng.Id(), "ngUnneededNodesCount", len(unneededNodes), "ngTargetSize", targetSize)
+			for _, nodeName := range unneededNodes {
+				incompleteNodes[nodeName] = true
+				if node, ok := nodeNameToNode[nodeName]; ok {
+					p.unremovableNodes.AddTimeout(&simulator.UnremovableNode{
+						Node:   node,
+						Reason: simulator.AtomicScaleDownFailed,
+					}, unremovableTimeout)
+					unremovableCount++
+				}
+			}
+		}
 	}
-	autoscalingOptions, err := nodeGroup.GetOptions(ctx, p.autoscalingCtx.NodeGroupDefaults)
-	if err != nil && err != cloudprovider.ErrNotImplemented {
-		logger.Error(err, "Failed to get autoscaling options for node group", "nodeGroupId", nodeGroup.Id())
-		return false
+
+	if len(incompleteNodes) == 0 {
+		return nodeNames, 0
 	}
-	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
-		return true
+
+	filteredNodeNames := make([]string, 0, len(nodeNames)-len(incompleteNodes))
+	for _, nodeName := range nodeNames {
+		if !incompleteNodes[nodeName] {
+			filteredNodeNames = append(filteredNodeNames, nodeName)
+		}
 	}
-	return false
+
+	return filteredNodeNames, unremovableCount
+}
+
+// isNodeAtomicScaleDown checks if the node would be considered for atomic scale down.
+func (p *Planner) isNodeAtomicScaleDown(ctx context.Context, node *apiv1.Node) bool {
+	_, isAtomic := atomic.IsAtomicNodeGroup(ctx, p.autoscalingCtx, node)
+	return isAtomic
 }
 
 // unneededNodesLimit returns the number of nodes after which calculating more

--- a/pkg/core/scaledown/planner/planner.go
+++ b/pkg/core/scaledown/planner/planner.go
@@ -24,7 +24,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/eligibility"
@@ -53,6 +52,7 @@ type eligibilityChecker interface {
 type removalSimulator interface {
 	DropOldHints()
 	SimulateNodeRemoval(ctx context.Context, node string, podDestinations map[string]bool, timestamp time.Time, remainingPdbTracker pdb.RemainingPdbTracker) (*simulator.NodeToBeRemoved, *simulator.UnremovableNode)
+	SimulateNodesGroupRemoval(ctx context.Context, nodeNames []string, destinationMap map[string]bool, timestamp time.Time, remainingPdbTracker pdb.RemainingPdbTracker) ([]simulator.NodeToBeRemoved, *simulator.UnremovableNode, int)
 }
 
 // controllerReplicasCalculator calculates a number of target and expected replicas for a given controller.
@@ -303,18 +303,20 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 	}
 	p.nodeUtilizationMap = utilizationMap
 
-	// Prefilter incomplete atomic node groups so simulation isn't wasted on atomic groups that cannot scale down.
-	var prefilteredUnremovableCount int
-	currentlyUnneededNodeNames, prefilteredUnremovableCount = p.prefilterIncompleteAtomicNodeGroups(ctx, currentlyUnneededNodeNames, unremovableTimeout)
-	unremovableCount += prefilteredUnremovableCount
-
-	timer := time.NewTimer(p.autoscalingCtx.ScaleDownSimulationTimeout)
+	simCtx, cancel := context.WithTimeout(ctx, p.autoscalingCtx.ScaleDownSimulationTimeout)
+	defer cancel()
 	var skippedNodes []string
+	atomicGroups := atomic.GroupAtomicNodes(simCtx, p.autoscalingCtx, currentlyUnneededNodeNames)
+	processedAtomicGroups := make(map[string]bool)
+
+	onTimeout := func(remainingNodes []string) {
+		skippedNodes = p.appendUnprocessed(ctx, skippedNodes, remainingNodes, processedAtomicGroups)
+		logger.Info("Some nodes skipped in scale down simulation due to timeout or cancellation.", "skippedNodesCount", len(skippedNodes), "nodesCount", len(currentlyUnneededNodeNames))
+	}
 
 	for i, nodeName := range currentlyUnneededNodeNames {
-		if timedOut(timer) {
-			skippedNodes = append(skippedNodes, currentlyUnneededNodeNames[i:]...)
-			logger.Info("Some nodes skipped in scale down simulation due to timeout.", "skippedNodesCount", len(currentlyUnneededNodeNames)-i, "nodesCount", len(currentlyUnneededNodeNames))
+		if simCtx.Err() != nil {
+			onTimeout(currentlyUnneededNodeNames[i:])
 			break
 		}
 
@@ -324,15 +326,35 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 			continue
 		}
 		node := nodeInfo.Node()
-		_, isAtomic := atomic.IsAtomicNodeGroup(ctx, p.autoscalingCtx, node)
+		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(simCtx, p.autoscalingCtx, node)
 
-		if !isAtomic && nonAtomicRemovableCount >= p.unneededNodesLimit() {
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			if processedAtomicGroups[ngID] {
+				continue
+			}
+			groupRemovable, groupUnremovableCount, groupSkipped, err := p.simulateAtomicNodeGroup(simCtx, ngID, atomicGroups[ngID], podDestinations, unremovableTimeout)
+			if err != nil {
+				onTimeout(currentlyUnneededNodeNames[i:])
+				break
+			}
+			processedAtomicGroups[ngID] = true
+			if len(groupRemovable) > 0 {
+				removableList = append(removableList, groupRemovable...)
+				atomicScaleDownNodesCount += len(groupRemovable)
+			}
+			unremovableCount += groupUnremovableCount
+			skippedNodes = append(skippedNodes, groupSkipped...)
+			continue
+		}
+
+		if nonAtomicRemovableCount >= p.unneededNodesLimit() {
 			skippedNodes = append(skippedNodes, nodeName)
 			logger.V(4).Info("Skipping non-atomic node in scale down simulation: there are already some non-atomic unneeded nodes.", "node", klog.KObj(node), "nonAtomicUnneededNodesCount", nonAtomicRemovableCount)
 			continue
 		}
 
-		removable, unremovable := p.rs.SimulateNodeRemoval(ctx, nodeName, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
+		removable, unremovable := p.rs.SimulateNodeRemoval(simCtx, nodeName, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
 		if removable != nil {
 			_, inParallel, _ := p.autoscalingCtx.RemainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
 			if !inParallel {
@@ -341,12 +363,7 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 			delete(podDestinations, removable.Node.Name)
 			p.autoscalingCtx.RemainingPdbTracker.RemovePods(removable.PodsToReschedule)
 			removableList = append(removableList, *removable)
-			if isAtomic {
-				atomicScaleDownNodesCount++
-				logger.V(2).Info("Considering node for atomic scale down.", "node", klog.KObj(node), "currentAtomicScaleDownNodesCount", atomicScaleDownNodesCount)
-			} else {
-				nonAtomicRemovableCount++
-			}
+			nonAtomicRemovableCount++
 		}
 		if unremovable != nil {
 			unremovableCount += 1
@@ -361,83 +378,60 @@ func (p *Planner) categorizeNodes(ctx context.Context, podDestinations map[strin
 	}
 }
 
-// prefilterIncompleteAtomicNodeGroups identifies atomic node groups in currentlyUnneededNodeNames.
-// If an atomic node group has fewer unneeded candidates than its target size, it cannot be
-// atomically scaled down. Such incomplete atomic node groups are filtered out of simulation,
-// and their nodes are marked as unremovable.
-func (p *Planner) prefilterIncompleteAtomicNodeGroups(ctx context.Context, nodeNames []string, unremovableTimeout time.Time) ([]string, int) {
-	logger := klog.FromContext(ctx)
-	atomicGroupNodes := make(map[string][]string)
-	atomicGroupObj := make(map[string]cloudprovider.NodeGroup)
-	nodeNameToNode := make(map[string]*apiv1.Node)
-
+// appendUnprocessed appends remaining node names to skippedNodes, excluding nodes belonging to
+// atomic node groups that were already simulated.
+func (p *Planner) appendUnprocessed(ctx context.Context, skippedNodes []string, nodeNames []string, processedAtomicGroups map[string]bool) []string {
 	for _, nodeName := range nodeNames {
 		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
-		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
-			continue
-		}
-		node := nodeInfo.Node()
-		nodeNameToNode[nodeName] = node
-		nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(ctx, p.autoscalingCtx, node)
-		if isAtomic && nodeGroup != nil {
-			ngID := nodeGroup.Id()
-			atomicGroupNodes[ngID] = append(atomicGroupNodes[ngID], nodeName)
-			atomicGroupObj[ngID] = nodeGroup
-		}
-	}
-
-	if len(atomicGroupNodes) == 0 {
-		return nodeNames, 0
-	}
-
-	incompleteNodes := make(map[string]bool)
-	unremovableCount := 0
-
-	allNodes, err := allNodes(p.autoscalingCtx.ClusterSnapshot)
-	if err != nil {
-		return nil, 0
-	}
-
-	for ngID, unneededNodes := range atomicGroupNodes {
-		ng := atomicGroupObj[ngID]
-		targetSize, err := ng.TargetSize(ctx)
-		if err != nil {
-			logger.Error(err, "Failed to get target size for node group", "nodeGroupId", ng.Id())
-			continue
-		}
-
-		if len(unneededNodes) < targetSize {
-			registeredCount, countErr := atomic.CountRegisteredNodesForGroup(ctx, ng, allNodes)
-			if countErr == nil && len(unneededNodes) >= registeredCount {
-				// All registered nodes in the snapshot are unneeded
+		if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
+			nodeGroup, isAtomic := atomic.IsAtomicNodeGroup(ctx, p.autoscalingCtx, nodeInfo.Node())
+			if isAtomic && nodeGroup != nil && processedAtomicGroups[nodeGroup.Id()] {
 				continue
 			}
-			logger.V(2).Info("Atomic node group has some unneeded nodes. Filtering out from scale down simulation.", "nodeGroupId", ng.Id(), "ngUnneededNodesCount", len(unneededNodes), "ngTargetSize", targetSize)
-			for _, nodeName := range unneededNodes {
-				incompleteNodes[nodeName] = true
-				if node, ok := nodeNameToNode[nodeName]; ok {
+		}
+		skippedNodes = append(skippedNodes, nodeName)
+	}
+	return skippedNodes
+}
+
+// simulateAtomicNodeGroup simulates removal of all nodes in an atomic node group as an all-or-nothing unit.
+// If any node in the group is unremovable, simulation of remaining nodes is aborted early, and any temporary
+// podDestinations and RemainingPdbTracker mutations are rolled back.
+// Returns removableList for the group, unremovableCount, skippedNodes, and an error if the context was canceled or timed out.
+func (p *Planner) simulateAtomicNodeGroup(
+	ctx context.Context,
+	ngID string,
+	ngNodes []string,
+	podDestinations map[string]bool,
+	unremovableTimeout time.Time,
+) ([]simulator.NodeToBeRemoved, int, []string, error) {
+	logger := klog.FromContext(ctx)
+
+	if ctx.Err() != nil {
+		return nil, 0, ngNodes, ctx.Err()
+	}
+
+	groupRemovable, unremovable, failedIdx := p.rs.SimulateNodesGroupRemoval(ctx, ngNodes, podDestinations, p.latestUpdate, p.autoscalingCtx.RemainingPdbTracker)
+	if unremovable != nil {
+		logger.V(2).Info("Atomic node group cannot scale down because node is unremovable. Early aborting simulation for nodes.", "nodeGroupId", ngID, "nodeName", ngNodes[failedIdx], "ngNodesCount", len(ngNodes))
+		for idx, name := range ngNodes {
+			if idx == failedIdx {
+				p.unremovableNodes.AddTimeout(unremovable, unremovableTimeout)
+			} else {
+				nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(name)
+				if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
 					p.unremovableNodes.AddTimeout(&simulator.UnremovableNode{
-						Node:   node,
+						Node:   nodeInfo.Node(),
 						Reason: simulator.AtomicScaleDownFailed,
 					}, unremovableTimeout)
-					unremovableCount++
 				}
 			}
 		}
+		return nil, len(ngNodes), nil, nil
 	}
 
-	if len(incompleteNodes) == 0 {
-		return nodeNames, 0
-	}
-
-	filteredNodeNames := make([]string, 0, len(nodeNames)-len(incompleteNodes))
-	for _, nodeName := range nodeNames {
-		if !incompleteNodes[nodeName] {
-			filteredNodeNames = append(filteredNodeNames, nodeName)
-		}
-	}
-
-	return filteredNodeNames, unremovableCount
+	logger.V(2).Info("Atomic node group with some nodes successfully simulated for removal.", "nodeGroupId", ngID, "removableNodesCountForAtomicNodeGroup", len(groupRemovable))
+	return groupRemovable, 0, nil, nil
 }
 
 // isNodeAtomicScaleDown checks if the node would be considered for atomic scale down.
@@ -550,13 +544,4 @@ func sortByRisk(nodes []simulator.NodeToBeRemoved) []simulator.NodeToBeRemoved {
 		}
 	}
 	return append(okNodes, riskyNodes...)
-}
-
-func timedOut(timer *time.Timer) bool {
-	select {
-	case <-timer.C:
-		return true
-	default:
-		return false
-	}
 }

--- a/pkg/core/scaledown/planner/planner_test.go
+++ b/pkg/core/scaledown/planner/planner_test.go
@@ -1298,6 +1298,6 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 		Node: n1,
 	}
 
-	result := p.atomicScaleDownNode(context.Background(), node)
+	result := p.isNodeAtomicScaleDown(context.Background(), node.Node)
 	assert.False(t, result)
 }

--- a/pkg/core/scaledown/planner/planner_test.go
+++ b/pkg/core/scaledown/planner/planner_test.go
@@ -1280,6 +1280,18 @@ func (r *fakeRemovalSimulator) SimulateNodeRemoval(ctx context.Context, name str
 	return &simulator.NodeToBeRemoved{Node: node}, nil
 }
 
+func (r *fakeRemovalSimulator) SimulateNodesGroupRemoval(ctx context.Context, names []string, destinations map[string]bool, timestamp time.Time, tracker pdb.RemainingPdbTracker) ([]simulator.NodeToBeRemoved, *simulator.UnremovableNode, int) {
+	var removable []simulator.NodeToBeRemoved
+	for i, name := range names {
+		rem, unrem := r.SimulateNodeRemoval(ctx, name, destinations, timestamp, tracker)
+		if unrem != nil {
+			return nil, unrem, i
+		}
+		removable = append(removable, *rem)
+	}
+	return removable, nil, -1
+}
+
 func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 	n1 := BuildTestNode("n1", 1000, 1000)
 	provider := testprovider.NewTestCloudProviderBuilder().Build()
@@ -1300,4 +1312,37 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 
 	result := p.isNodeAtomicScaleDown(context.Background(), node.Node)
 	assert.False(t, result)
+}
+
+func TestUpdateClusterStateContextCancelled(t *testing.T) {
+	n1 := BuildTestNode("n1", 1000, 10)
+	n2 := BuildTestNode("n2", 1000, 10)
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 0, 0, 0)
+	provider.AddNode("ng1", n1)
+	provider.AddNode("ng1", n2)
+
+	opts := config.AutoscalingOptions{
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			ScaleDownUnneededTime: 10 * time.Minute,
+		},
+		ScaleDownSimulationTimeout: 1 * time.Minute,
+		MaxScaleDownParallelism:    10,
+	}
+	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(opts)
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(opts, &fake.Clientset{}, kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, nil, nil), provider, nil, nil, templateNodeInfoRegistry)
+	assert.NoError(t, err)
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, []*apiv1.Node{n1, n2}, nil)
+	deleteOptions := options.NodeDeleteOptions{}
+	factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
+	p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+	p.eligibilityChecker = &fakeEligibilityChecker{eligible: map[string]bool{"n1": true, "n2": true}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately to simulate shutdown
+
+	assert.NoError(t, p.UpdateClusterState(ctx, []*apiv1.Node{n1, n2}, []*apiv1.Node{n1, n2}, &fakeActuationStatus{}, time.Now()))
+	// Since context was cancelled before simulation started, nodes should not be marked unneeded
+	assert.False(t, p.unneededNodes.Contains("n1"))
+	assert.False(t, p.unneededNodes.Contains("n2"))
 }

--- a/pkg/processors/nodes/scale_down_set_processor.go
+++ b/pkg/processors/nodes/scale_down_set_processor.go
@@ -19,7 +19,6 @@ package nodes
 import (
 	"context"
 	"slices"
-	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
@@ -27,7 +26,7 @@ import (
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
-	"sigs.k8s.io/cluster-autoscaler/pkg/utils/annotations"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/atomic"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/klogx"
 )
 
@@ -134,15 +133,15 @@ func (p *AtomicResizeFilteringProcessor) FilterUnremovableNodes(ctx context.Cont
 			logger.V(2).Info("Scheduling atomic scale down for all nodes from node group", "nodesCount", len(consideredNodes), "nodeGroupId", nodeGroup.Id())
 			nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 		} else {
-			registeredNodes, err := p.getAllRegisteredNodesForNodeGroup(ctx, nodeGroup, allNodes)
+			registeredCount, err := atomic.CountRegisteredNodesForGroup(ctx, nodeGroup, allNodes)
 			if err != nil {
 				logger.Error(err, "Failed to get registered nodes for node group", "nodeGroupId", nodeGroup.Id())
 				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, ngSize, unremovableNodes, nodeGroup)
-			} else if len(registeredNodes) == len(consideredNodes) {
+			} else if registeredCount == len(consideredNodes) {
 				logger.V(2).Info("Scheduling atomic scale down for all registered nodes from node group", "nodesCount", len(consideredNodes), "nodeGroupId", nodeGroup.Id())
 				nodesToBeRemoved = append(nodesToBeRemoved, consideredNodes...)
 			} else {
-				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, len(registeredNodes), unremovableNodes, nodeGroup)
+				unremovableNodes = p.atomicScaleDownFailed(ctx, consideredNodes, registeredCount, unremovableNodes, nodeGroup)
 			}
 		}
 	}
@@ -170,29 +169,6 @@ func allNodes(s clustersnapshot.ClusterSnapshot) ([]*v1.Node, error) {
 		nodes[i] = ni.Node()
 	}
 	return nodes, nil
-}
-
-func (p *AtomicResizeFilteringProcessor) getAllRegisteredNodesForNodeGroup(ctx context.Context, nodeGroup cloudprovider.NodeGroup, allNodes []*v1.Node) ([]*v1.Node, error) {
-	allNodesInNodeGroup, err := nodeGroup.Nodes(ctx)
-	if err != nil {
-		return nil, err
-	}
-	nodeByNodeName := map[string]cloudprovider.Instance{}
-	for _, node := range allNodesInNodeGroup {
-		nodeByNodeName[node.Id] = node
-	}
-	var registeredNodesForNodeGroup []*v1.Node
-	for _, node := range allNodes {
-		if val, ok := node.Annotations[annotations.NodeUpcomingAnnotation]; ok {
-			if res, ok := strconv.ParseBool(val); ok == nil && res {
-				continue
-			}
-		}
-		if _, ok := nodeByNodeName[node.Spec.ProviderID]; ok {
-			registeredNodesForNodeGroup = append(registeredNodesForNodeGroup, node)
-		}
-	}
-	return registeredNodesForNodeGroup, nil
 }
 
 // CleanUp is called at CA termination

--- a/pkg/simulator/cluster.go
+++ b/pkg/simulator/cluster.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/pdb"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
@@ -218,6 +219,69 @@ func (r *RemovalSimulator) SimulateNodeRemoval(
 		DaemonSetPods:    podMoveInfo.DaemonSetPods,
 		OnCompletionPods: podMoveInfo.OnCompletionPods,
 	}, nil
+}
+
+// SimulateNodesGroupRemoval simulates removing a group of nodes atomically (all-or-nothing).
+// If any node in the group is unremovable, simulation is aborted early and any temporary
+// destinationMap and remainingPdbTracker mutations are rolled back.
+// Returns:
+//   - removable: the list of removable nodes if all nodes in the group can be removed.
+//   - unremovable: the unremovable node failure info if any node failed removal.
+//   - failedNodeIndex: the index in nodeNames of the node that failed removal (-1 if all succeeded).
+func (r *RemovalSimulator) SimulateNodesGroupRemoval(
+	ctx context.Context,
+	nodeNames []string,
+	destinationMap map[string]bool,
+	timestamp time.Time,
+	remainingPdbTracker pdb.RemainingPdbTracker,
+) ([]NodeToBeRemoved, *UnremovableNode, int) {
+	logger := klog.FromContext(ctx)
+
+	destinationMapCopy := make(map[string]bool, len(destinationMap))
+	for k, v := range destinationMap {
+		destinationMapCopy[k] = v
+	}
+
+	var pdbsSnapshot []*policyv1.PodDisruptionBudget
+	if remainingPdbTracker != nil {
+		pdbsSnapshot = remainingPdbTracker.GetPdbs()
+	}
+
+	rollback := func() {
+		for k := range destinationMap {
+			delete(destinationMap, k)
+		}
+		for k, v := range destinationMapCopy {
+			destinationMap[k] = v
+		}
+		if remainingPdbTracker != nil {
+			if err := remainingPdbTracker.SetPdbs(pdbsSnapshot); err != nil {
+				logger.Error(err, "Failed to restore PDB snapshot after rollback in group removal simulation")
+			}
+		}
+	}
+
+	var removableList []NodeToBeRemoved
+	for j, nodeName := range nodeNames {
+		removable, unremovable := r.SimulateNodeRemoval(ctx, nodeName, destinationMap, timestamp, remainingPdbTracker)
+		if unremovable != nil {
+			logger.V(2).Info("Node in group cannot be removed. Early aborting group removal simulation.", "nodeName", nodeName, "nodesCount", len(nodeNames))
+			rollback()
+			return nil, unremovable, j
+		}
+
+		if remainingPdbTracker != nil {
+			_, inParallel, _ := remainingPdbTracker.CanRemovePods(removable.PodsToReschedule)
+			if !inParallel {
+				removable.IsRisky = true
+			}
+			remainingPdbTracker.RemovePods(removable.PodsToReschedule)
+		}
+		delete(destinationMap, removable.Node.Name)
+		removableList = append(removableList, *removable)
+	}
+
+	return removableList, nil, -1
 }
 
 func (r *RemovalSimulator) withForkedSnapshot(ctx context.Context, f func() error) (err error) {

--- a/pkg/simulator/cluster_test.go
+++ b/pkg/simulator/cluster_test.go
@@ -237,6 +237,114 @@ func TestSimulateNodeRemoval(t *testing.T) {
 	}
 }
 
+func TestSimulateNodesGroupRemoval(t *testing.T) {
+	node1 := BuildTestNode("n1", 1000, 2000000)
+	node2 := BuildTestNode("n2", 1000, 2000000)
+	destNode := BuildTestNode("dest", 2000, 4000000)
+
+	SetNodeReadyState(node1, true, time.Time{})
+	SetNodeReadyState(node2, true, time.Time{})
+	SetNodeReadyState(destNode, true, time.Time{})
+
+	replicas := int32(5)
+	replicaSets := []*appsv1.ReplicaSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rs",
+				Namespace: "default",
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: &replicas,
+			},
+		},
+	}
+	rsLister, err := kube_util.NewTestReplicaSetLister(replicaSets)
+	assert.NoError(t, err)
+	registry := kube_util.NewListerRegistry(nil, nil, nil, nil, nil, nil, nil, rsLister, nil)
+	ownerRefs := GenerateOwnerReferences("rs", "ReplicaSet", "extensions/v1beta1", "")
+
+	pod1 := BuildTestPod("pod1", 100, 100000)
+	pod1.OwnerReferences = ownerRefs
+	pod1.Spec.NodeName = node1.Name
+
+	pod2 := BuildTestPod("pod2", 100, 100000)
+	pod2.OwnerReferences = ownerRefs
+	pod2.Spec.NodeName = node2.Name
+
+	podUnmovable := BuildTestPod("pod-unmovable", 100, 100000)
+	podUnmovable.Spec.NodeName = node2.Name
+
+	testCases := []struct {
+		name                 string
+		groupNodes           []string
+		pods                 []*apiv1.Pod
+		initialDestinations  map[string]bool
+		expectUnremovable    bool
+		expectedFailedIndex  int
+		expectedRemovableLen int
+		expectedDestinations map[string]bool
+	}{
+		{
+			name:                 "all nodes in group removable",
+			groupNodes:           []string{"n1", "n2"},
+			pods:                 []*apiv1.Pod{pod1, pod2},
+			initialDestinations:  map[string]bool{"dest": true, "n1": true, "n2": true},
+			expectUnremovable:    false,
+			expectedFailedIndex:  -1,
+			expectedRemovableLen: 2,
+			expectedDestinations: map[string]bool{"dest": true, "n1": false, "n2": false},
+		},
+		{
+			name:                 "node in group unremovable aborts early and rolls back destinations",
+			groupNodes:           []string{"n1", "n2"},
+			pods:                 []*apiv1.Pod{pod1, podUnmovable},
+			initialDestinations:  map[string]bool{"dest": true, "n1": true, "n2": true},
+			expectUnremovable:    true,
+			expectedFailedIndex:  1,
+			expectedRemovableLen: 0,
+			// destinations should be rolled back to their original state
+			expectedDestinations: map[string]bool{"dest": true, "n1": true, "n2": true},
+		},
+		{
+			name:                 "empty group succeeds with empty result",
+			groupNodes:           []string{},
+			pods:                 []*apiv1.Pod{pod1, pod2},
+			initialDestinations:  map[string]bool{"dest": true, "n1": true, "n2": true},
+			expectUnremovable:    false,
+			expectedFailedIndex:  -1,
+			expectedRemovableLen: 0,
+			expectedDestinations: map[string]bool{"dest": true, "n1": true, "n2": true},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+			clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, []*apiv1.Node{node1, node2, destNode}, tc.pods)
+
+			destinations := make(map[string]bool, len(tc.initialDestinations))
+			for k, v := range tc.initialDestinations {
+				destinations[k] = v
+			}
+
+			r := NewRemovalSimulator(registry, snapshot, testDeleteOptions(), nil, false)
+			removable, unremovable, failedIdx := r.SimulateNodesGroupRemoval(context.Background(), tc.groupNodes, destinations, time.Now(), nil)
+
+			if tc.expectUnremovable {
+				assert.NotNil(t, unremovable)
+				assert.Nil(t, removable)
+			} else {
+				assert.Nil(t, unremovable)
+				assert.Len(t, removable, tc.expectedRemovableLen)
+			}
+			assert.Equal(t, tc.expectedFailedIndex, failedIdx)
+			for k, expectedVal := range tc.expectedDestinations {
+				assert.Equalf(t, expectedVal, destinations[k], "destinationMap mismatch for node %s", k)
+			}
+		})
+	}
+}
+
 func testDeleteOptions() options.NodeDeleteOptions {
 	return options.NodeDeleteOptions{
 		SkipNodesWithSystemPods:           true,

--- a/pkg/test/integration/inmemory/planner_test.go
+++ b/pkg/test/integration/inmemory/planner_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	fakecloudprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	"sigs.k8s.io/cluster-autoscaler/pkg/test/integration"
+	synctestutils "sigs.k8s.io/cluster-autoscaler/pkg/test/integration/synctest"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
+)
+
+const (
+	plannerTestUnneededTime = 1 * time.Minute
+	plannerStepDuration     = 10 * time.Second
+)
+
+// TestPlanner_AtomicAndNonAtomicScaleDown verifies that the scaledown planner
+// correctly evaluates and processes both atomic and non-atomic node groups.
+func TestPlanner_AtomicAndNonAtomicScaleDown(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Create non-atomic node group with 2 nodes.
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic", fakecloudprovider.WithNodes(naTemplate, 2))
+
+		// Create atomic node group with ZeroOrMaxNodeScaling option and 2 nodes.
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Initial size check
+		sizeNonAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize(ctx)
+		assert.Equal(t, 2, sizeNonAtomic)
+		sizeAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 2, sizeAtomic)
+
+		// Run CA loop once to mark empty nodes as unneeded.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance time past unneededTime to allow scale down actuation.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run loop again to complete removal of all unneeded nodes.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Verify both non-atomic and atomic empty nodes are scaled down.
+		finalSizeNonAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize(ctx)
+		assert.Equal(t, 0, finalSizeNonAtomic, "Non-atomic empty nodes should be scaled down")
+
+		finalSizeAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 0, finalSizeAtomic, "Atomic empty nodes should be scaled down")
+	})
+}
+
+// TestPlanner_AtomicNodesProcessedAfterNonAtomicLimit verifies that when non-atomic simulation
+// hits the unneededNodesLimit, non-atomic loop breaks, but atomic nodes are still evaluated.
+func TestPlanner_AtomicNodesProcessedAfterNonAtomicLimit(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+			func(o *config.AutoscalingOptions) {
+				// Set MaxScaleDownParallelism to 1 so unneededNodesLimit() is capped at 2.
+				o.MaxScaleDownParallelism = 1
+			},
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Create 4 non-atomic nodes (exceeding limit of 2) in ng-nonatomic.
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic", fakecloudprovider.WithNodes(naTemplate, 4))
+
+		// Create atomic node group with ZeroOrMaxNodeScaling option and 2 nodes.
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Initial verification of target sizes
+		sizeNA, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize(ctx)
+		assert.Equal(t, 4, sizeNA)
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 2, sizeA)
+
+		// Run loop to mark unneeded
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance past unneeded time and run scale down loop
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run subsequent iterations to allow scale down actuation of all evaluated nodes.
+		for i := 0; i < 5; i++ {
+			synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+		}
+
+		// Check that atomic nodes were evaluated and scaled down.
+		finalSizeAtomic, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 0, finalSizeAtomic, "Atomic nodes should be evaluated and scaled down even when non-atomic limit is reached")
+	})
+}
+
+// TestPlanner_SimulationTimeoutSkipsAtomicAndNonAtomic verifies that a simulation timeout
+// during non-atomic loop properly skips remaining non-atomic nodes and all atomic nodes.
+func TestPlanner_SimulationTimeoutSkipsAtomicAndNonAtomic(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+			func(o *config.AutoscalingOptions) {
+				// Set simulation timeout to negative duration to force immediate simulation timeout.
+				o.ScaleDownSimulationTimeout = -1 * time.Second
+			},
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Add destination helper node where pods can schedule if simulation runs.
+		destNode := test.BuildTestNode("dest-node", 10000, 10000, test.IsReady(true))
+		fakes.K8s.AddNode(destNode)
+
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic", fakecloudprovider.WithNodes(naTemplate, 2))
+
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Add scheduled pods to nodes so scale down simulation is required.
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-na-0", 100, 100, "ng-nonatomic-node-0"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-na-1", 100, 100, "ng-nonatomic-node-1"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-a-0", 100, 100, "ng-atomic-node-0"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-a-1", 100, 100, "ng-atomic-node-1"))
+
+		// Run CA loop. With simulation timeout <= 0, nodes should be skipped.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Node groups should remain at original size because scale down simulation was skipped due to timeout.
+		sizeNA, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize(ctx)
+		assert.Equal(t, 2, sizeNA)
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 2, sizeA)
+	})
+}
+
+// TestPlanner_AtomicNodePdbHandling verifies scale down behavior when atomic nodes host pods subject to PDBs.
+func TestPlanner_AtomicNodePdbHandling(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		destNode := test.BuildTestNode("dest-node", 10000, 10000, test.IsReady(true))
+		fakes.K8s.AddNode(destNode)
+
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Create PDB allowing at most 1 pod disruption at a time
+		maxUnavailable := intstr.FromInt32(1)
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app-pdb",
+				Namespace: "default",
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &maxUnavailable,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test"},
+				},
+			},
+		}
+		_, err = fakes.KubeClient.PolicyV1().PodDisruptionBudgets("default").Create(ctx, pdb, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		pod0 := test.BuildScheduledTestPod("pod-a-0", 100, 100, "ng-atomic-node-0")
+		pod0.Labels = map[string]string{"app": "test"}
+		pod1 := test.BuildScheduledTestPod("pod-a-1", 100, 100, "ng-atomic-node-1")
+		pod1.Labels = map[string]string{"app": "test"}
+		fakes.K8s.AddPod(pod0)
+		fakes.K8s.AddPod(pod1)
+
+		// Run CA loop once to mark unneeded and run simulation.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run loop to actuate.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.LessOrEqual(t, sizeA, 2, "Atomic node group evaluation with PDB succeeded")
+	})
+}
+
+// TestPlanner_IncompleteAtomicNodeGroupPrefiltered verifies that an atomic node group
+// with fewer unneeded nodes than its target size is prefiltered out before simulation,
+// and its target size remains unchanged.
+func TestPlanner_IncompleteAtomicNodeGroupPrefiltered(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		// Create atomic node group with ZeroOrMaxNodeScaling option and 2 nodes.
+		aTemplate := test.BuildTestNode("node", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 2),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Add a non-removable pod to node 0 of ng-atomic so node 0 is NOT unneeded.
+		blockingPod := test.BuildScheduledTestPod("blocking-pod", 100, 100, "ng-atomic-node-0")
+		blockingPod.Annotations = map[string]string{
+			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+		}
+		fakes.K8s.AddPod(blockingPod)
+
+		// Run CA loop once to process candidates.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance past unneeded time and run scale down loop.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// The atomic node group should NOT scale down because only 1 of 2 nodes was unneeded.
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 2, sizeA, "Incomplete atomic node group should be prefiltered and remain at target size 2")
+	})
+}

--- a/pkg/test/integration/inmemory/planner_test.go
+++ b/pkg/test/integration/inmemory/planner_test.go
@@ -24,8 +24,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgotesting "k8s.io/client-go/testing"
 	fakecloudprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
 	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/test/integration"
@@ -324,5 +328,162 @@ func TestPlanner_IncompleteAtomicNodeGroupPrefiltered(t *testing.T) {
 		// The atomic node group should NOT scale down because only 1 of 2 nodes was unneeded.
 		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
 		assert.Equal(t, 2, sizeA, "Incomplete atomic node group should be prefiltered and remain at target size 2")
+	})
+}
+
+// TestPlanner_AtomicNodeGroupEarlyAbort_DestinationCapacityRollback verifies that when an atomic node group
+// fails removal simulation midway (e.g. because destination capacity is exhausted), simulation of the group
+// is early-aborted, podDestinations mutations are rolled back, and subsequent candidates can use the destination capacity.
+func TestPlanner_AtomicNodeGroupEarlyAbort_DestinationCapacityRollback(t *testing.T) {
+	runAtomicEarlyAbortRollbackTest(t, func(ctx context.Context, fakes *integration.FakeSet) {
+		// Create destination helper node with capacity for exactly 1 pod of 100 CPU.
+		destNode := test.BuildTestNode("dest-node", 100, 1000, test.IsReady(true))
+		fakes.K8s.AddNode(destNode)
+
+		// ng-atomic-node-0 is left EMPTY so EmptySorting orders it first in scaleDownCandidates.
+		// ng-atomic-node-1 has a pod that consumes the destination capacity.
+		fakes.K8s.AddPod(test.SetRSPodSpec(test.BuildScheduledTestPod("pod-a-1", 100, 100, "ng-atomic-node-1"), "rs-a-1"))
+		// ng-atomic-node-2 has a pod that cannot fit on dest-node, triggering early abort.
+		fakes.K8s.AddPod(test.SetRSPodSpec(test.BuildScheduledTestPod("pod-a-2", 100, 100, "ng-atomic-node-2"), "rs-a-2"))
+		// ng-nonatomic-node-0 has a pod that will fit on dest-node once ng-atomic rolls back.
+		fakes.K8s.AddPod(test.SetRSPodSpec(test.BuildScheduledTestPod("pod-na-0", 100, 100, "ng-nonatomic-node-0"), "rs-na-0"))
+	})
+}
+
+// TestPlanner_AtomicNodeGroupEarlyAbort_PdbRollback verifies that when an atomic node group
+// fails removal simulation midway due to PDB constraints, simulation of the group is early-aborted,
+// RemainingPdbTracker mutations are rolled back, and subsequent candidates sharing the PDB can scale down.
+func TestPlanner_AtomicNodeGroupEarlyAbort_PdbRollback(t *testing.T) {
+	runAtomicEarlyAbortRollbackTest(t, func(ctx context.Context, fakes *integration.FakeSet) {
+		// Destination helper node with plenty of capacity for pods.
+		destNode := test.BuildTestNode("dest-node", 10000, 10000, test.IsReady(true))
+		fakes.K8s.AddNode(destNode)
+
+		// Create PDB allowing at most 1 pod disruption.
+		maxUnavailable := intstr.FromInt32(1)
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-pdb",
+				Namespace: "default",
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &maxUnavailable,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "shared"},
+				},
+			},
+			Status: policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 1,
+			},
+		}
+		_, err := fakes.KubeClient.PolicyV1().PodDisruptionBudgets("default").Create(ctx, pdb, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		// ng-atomic-node-0 is EMPTY, so EmptySorting orders it first.
+		// ng-atomic-node-1 has a pod matching shared-pdb, consuming the 1 allowed disruption.
+		podA1 := test.SetRSPodSpec(test.BuildScheduledTestPod("pod-a-1", 100, 100, "ng-atomic-node-1"), "rs-a-1")
+		podA1.Labels = map[string]string{"app": "shared"}
+		fakes.K8s.AddPod(podA1)
+
+		// ng-atomic-node-2 has a pod matching shared-pdb. Since budget is exhausted, this triggers early abort.
+		podA2 := test.SetRSPodSpec(test.BuildScheduledTestPod("pod-a-2", 100, 100, "ng-atomic-node-2"), "rs-a-2")
+		podA2.Labels = map[string]string{"app": "shared"}
+		fakes.K8s.AddPod(podA2)
+
+		// ng-nonatomic-node-0 has a pod matching shared-pdb. It can scale down once PDB is rolled back.
+		podNA := test.SetRSPodSpec(test.BuildScheduledTestPod("pod-na-0", 100, 100, "ng-nonatomic-node-0"), "rs-na-0")
+		podNA.Labels = map[string]string{"app": "shared"}
+		fakes.K8s.AddPod(podNA)
+	})
+}
+
+// runAtomicEarlyAbortRollbackTest sets up an atomic node group (3 nodes) and a non-atomic
+// node group (1 node), invokes setupCluster to configure pods/resources, and verifies that
+// simulation early-abort prevents scale down of the atomic group while allowing the non-atomic group to scale down.
+func runAtomicEarlyAbortRollbackTest(t *testing.T, setupCluster func(ctx context.Context, fakes *integration.FakeSet)) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithScaleDownUnneededTime(plannerTestUnneededTime),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		registerEvictionReactor(fakes)
+
+		// Create atomic node group with 3 nodes.
+		aTemplate := test.BuildTestNode("node-a", 1000, 1000, test.IsReady(true))
+		atomicOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+		}
+		fakes.CloudProvider.AddNodeGroup("ng-atomic",
+			fakecloudprovider.WithNodes(aTemplate, 3),
+			fakecloudprovider.WithNGOptions(atomicOpts),
+		)
+
+		// Create non-atomic node group with 1 node.
+		naTemplate := test.BuildTestNode("node-na", 1000, 1000, test.IsReady(true))
+		fakes.CloudProvider.AddNodeGroup("ng-nonatomic",
+			fakecloudprovider.WithNodes(naTemplate, 1),
+		)
+
+		setupCluster(ctx, fakes)
+
+		// Initial sizes
+		sizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 3, sizeA)
+		sizeNA, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize(ctx)
+		assert.Equal(t, 1, sizeNA)
+
+		// Run CA loop once to mark unneeded and run simulation.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// Advance past unneeded time and run scale down loop.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerTestUnneededTime+time.Second)
+
+		// Run loop to actuate removal.
+		synctestutils.MustRunOnceAfter(t, autoscaler, plannerStepDuration)
+
+		// ng-atomic should not be scaled down because removal simulation early-aborted.
+		finalSizeA, _ := fakes.CloudProvider.GetNodeGroup("ng-atomic").TargetSize(ctx)
+		assert.Equal(t, 3, finalSizeA, "Atomic node group should not scale down when simulation early aborts")
+
+		// ng-nonatomic should be scaled down because rolled back resources were freed.
+		finalSizeNA, _ := fakes.CloudProvider.GetNodeGroup("ng-nonatomic").TargetSize(ctx)
+		assert.Equal(t, 0, finalSizeNA, "Non-atomic node should scale down using rolled back resources")
+	})
+}
+
+// registerEvictionReactor registers a reactor on the fake kube client that automatically
+// deletes evicted pods from the object tracker so that node draining succeeds.
+func registerEvictionReactor(fakes *integration.FakeSet) {
+	fakes.KubeClient.Fake.PrependReactor("create", "pods", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "eviction" {
+			if createAction, ok := action.(clientgotesting.CreateAction); ok {
+				var podName string
+				if eviction, ok := createAction.GetObject().(*policyv1beta1.Eviction); ok {
+					podName = eviction.Name
+				} else if evictionV1, ok := createAction.GetObject().(*policyv1.Eviction); ok {
+					podName = evictionV1.Name
+				}
+				if podName != "" {
+					_ = fakes.KubeClient.Tracker().Delete(
+						schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+						action.GetNamespace(),
+						podName,
+					)
+					return true, createAction.GetObject(), nil
+				}
+			}
+		}
+		return false, nil, nil
 	})
 }

--- a/pkg/utils/atomic/atomic.go
+++ b/pkg/utils/atomic/atomic.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"context"
+	"strconv"
+
+	apiv1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
+	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/annotations"
+)
+
+// IsAtomicNodeGroup returns the node group and true if the given node belongs to an atomic node group (ZeroOrMaxNodeScaling).
+func IsAtomicNodeGroup(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, node *apiv1.Node) (cloudprovider.NodeGroup, bool) {
+	nodeGroup, err := autoscalingCtx.CloudProvider.NodeGroupForNode(ctx, node)
+	if err != nil || nodeGroup == nil {
+		return nil, false
+	}
+	autoscalingOptions, err := nodeGroup.GetOptions(ctx, autoscalingCtx.NodeGroupDefaults)
+	if err != nil && err != cloudprovider.ErrNotImplemented {
+		klog.Errorf("Failed to get autoscaling options for node group %s: %v", nodeGroup.Id(), err)
+		return nil, false
+	}
+	if autoscalingOptions != nil && autoscalingOptions.ZeroOrMaxNodeScaling {
+		return nodeGroup, true
+	}
+	return nil, false
+}
+
+// CountRegisteredNodesForGroup returns the number of registered (non-upcoming) nodes in allNodes belonging to nodeGroup.
+func CountRegisteredNodesForGroup(ctx context.Context, g cloudprovider.NodeGroup, allNodes []*apiv1.Node) (int, error) {
+	nodesInGroup, err := g.Nodes(ctx)
+	if err != nil {
+		return 0, err
+	}
+	nodeByProviderID := make(map[string]bool, len(nodesInGroup))
+	for _, node := range nodesInGroup {
+		nodeByProviderID[node.Id] = true
+	}
+	count := 0
+	for _, node := range allNodes {
+		if val, ok := node.Annotations[annotations.NodeUpcomingAnnotation]; ok {
+			if res, ok := strconv.ParseBool(val); ok == nil && res {
+				continue
+			}
+		}
+		if nodeByProviderID[node.Spec.ProviderID] {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/pkg/utils/atomic/atomic.go
+++ b/pkg/utils/atomic/atomic.go
@@ -67,3 +67,21 @@ func CountRegisteredNodesForGroup(ctx context.Context, g cloudprovider.NodeGroup
 	}
 	return count, nil
 }
+
+// GroupAtomicNodes groups unneeded atomic node names by their NodeGroup ID.
+func GroupAtomicNodes(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext, nodeNames []string) map[string][]string {
+	atomicGroups := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		nodeInfo, err := autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil || nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		node := nodeInfo.Node()
+		nodeGroup, isAtomic := IsAtomicNodeGroup(ctx, autoscalingCtx, node)
+		if isAtomic && nodeGroup != nil {
+			ngID := nodeGroup.Id()
+			atomicGroups[ngID] = append(atomicGroups[ngID], nodeName)
+		}
+	}
+	return atomicGroups
+}

--- a/pkg/utils/atomic/atomic_test.go
+++ b/pkg/utils/atomic/atomic_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
+	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
+
+	testprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/annotations"
+)
+
+func TestIsAtomicNodeGroup(t *testing.T) {
+	ctx := context.Background()
+	n1 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n1"},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	atomicOpts := &config.NodeGroupAutoscalingOptions{
+		ZeroOrMaxNodeScaling: true,
+	}
+	provider.AddNodeGroupWithCustomOptions("ng-atomic", 0, 10, 2, atomicOpts)
+	provider.AddNode("ng-atomic", n1)
+
+	n2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n2"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n2"},
+	}
+	provider.AddNodeGroup("ng-standard", 0, 10, 2)
+	provider.AddNode("ng-standard", n2)
+
+	autoscalingCtx := ca_context.AutoscalingContext{
+		CloudProvider: provider,
+	}
+
+	ng, isAtomic := IsAtomicNodeGroup(ctx, &autoscalingCtx, n1)
+	assert.True(t, isAtomic)
+	assert.Equal(t, "ng-atomic", ng.Id())
+
+	ng2, isAtomic2 := IsAtomicNodeGroup(ctx, &autoscalingCtx, n2)
+	assert.False(t, isAtomic2)
+	assert.Nil(t, ng2)
+}
+
+func TestCountRegisteredNodesForGroup(t *testing.T) {
+	n1 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n1"},
+	}
+	n2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "n2",
+			Annotations: map[string]string{annotations.NodeUpcomingAnnotation: "true"},
+		},
+		Spec: apiv1.NodeSpec{ProviderID: "n2"},
+	}
+	n3 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n3"},
+		Spec:       apiv1.NodeSpec{ProviderID: "n3"},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 0, 10, 3)
+	provider.AddNode("ng1", n1)
+	provider.AddNode("ng1", n2)
+	provider.AddNode("ng1", n3)
+
+	ng := provider.GetNodeGroup("ng1")
+	allNodes := []*apiv1.Node{n1, n2, n3}
+	count, err := CountRegisteredNodesForGroup(context.Background(), ng, allNodes)
+	assert.NoError(t, err)
+	// n2 has NodeUpcomingAnnotation=true, so registered count should be 2
+	assert.Equal(t, 2, count)
+}

--- a/pkg/utils/atomic/atomic_test.go
+++ b/pkg/utils/atomic/atomic_test.go
@@ -27,6 +27,8 @@ import (
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
 
 	testprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/clustersnapshot/testsnapshot"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/annotations"
 )
 
@@ -93,4 +95,80 @@ func TestCountRegisteredNodesForGroup(t *testing.T) {
 	assert.NoError(t, err)
 	// n2 has NodeUpcomingAnnotation=true, so registered count should be 2
 	assert.Equal(t, 2, count)
+}
+
+func TestGroupAtomicNodes(t *testing.T) {
+	ctx := context.Background()
+
+	nodeAtomic1 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-atomic-1"},
+		Spec:       apiv1.NodeSpec{ProviderID: "node-atomic-1"},
+	}
+	nodeAtomic2 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-atomic-2"},
+		Spec:       apiv1.NodeSpec{ProviderID: "node-atomic-2"},
+	}
+	nodeAtomic3 := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-atomic-3"},
+		Spec:       apiv1.NodeSpec{ProviderID: "node-atomic-3"},
+	}
+	nodeStandard := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-standard"},
+		Spec:       apiv1.NodeSpec{ProviderID: "node-standard"},
+	}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	atomicOpts := &config.NodeGroupAutoscalingOptions{
+		ZeroOrMaxNodeScaling: true,
+	}
+	provider.AddNodeGroupWithCustomOptions("ng-atomic-1", 0, 10, 2, atomicOpts)
+	provider.AddNode("ng-atomic-1", nodeAtomic1)
+	provider.AddNode("ng-atomic-1", nodeAtomic2)
+
+	provider.AddNodeGroupWithCustomOptions("ng-atomic-2", 0, 10, 1, atomicOpts)
+	provider.AddNode("ng-atomic-2", nodeAtomic3)
+
+	provider.AddNodeGroup("ng-standard", 0, 10, 1)
+	provider.AddNode("ng-standard", nodeStandard)
+
+	snapshot := testsnapshot.NewTestSnapshotOrDie(t)
+	clustersnapshot.InitializeClusterSnapshotOrDie(t, snapshot, []*apiv1.Node{nodeAtomic1, nodeAtomic2, nodeAtomic3, nodeStandard}, nil)
+
+	autoscalingCtx := &ca_context.AutoscalingContext{
+		CloudProvider:   provider,
+		ClusterSnapshot: snapshot,
+	}
+
+	testCases := []struct {
+		name      []string
+		testName  string
+		nodeNames []string
+		expected  map[string][]string
+	}{
+		{
+			testName:  "groups atomic nodes by nodegroup and ignores standard and unknown nodes",
+			nodeNames: []string{"node-atomic-1", "node-standard", "node-atomic-2", "node-atomic-3", "non-existent-node"},
+			expected: map[string][]string{
+				"ng-atomic-1": {"node-atomic-1", "node-atomic-2"},
+				"ng-atomic-2": {"node-atomic-3"},
+			},
+		},
+		{
+			testName:  "empty node names returns empty map",
+			nodeNames: []string{},
+			expected:  map[string][]string{},
+		},
+		{
+			testName:  "only standard nodes returns empty map",
+			nodeNames: []string{"node-standard"},
+			expected:  map[string][]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result := GroupAtomicNodes(ctx, autoscalingCtx, tc.nodeNames)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This PR refactors scale-down simulation for Atomic Node Pools (ZeroOrMaxNodeScaling=true) to evaluate candidate groups as all-or-nothing units with early-abort while preserving fair interleaving between atomic and non-atomic node groups.

Previously, the scale-down planner simulated atomic node pools node-by-node in arbitrary order:
1. If a node late in an atomic node group failed removal simulation (e.g., due to an unevictable pod or PDB limit), all earlier simulations for that group were wasted.
2. Nodes from partially removable atomic groups were added to removableList (unneededNodes) and registered in NodeLatencyTracker. When later in the scaled down process node group was rejected from scaling down because of being incomplete, those partially simulated nodes remained trapped in tracking across cycles, ticking past the 600s threshold and triggering false SLO latency alerts.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes b/524606761

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
