### PR TITLE
Add CODE_CONVENTIONS.md to establish API stability policy

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -1,0 +1,71 @@
+# Code Conventions and API Policy
+
+This document outlines the coding standards and API policies for the `cluster-autoscaler` project. As Cluster Autoscaler evolves into a reusable library, maintaining API stability and backward compatibility is crucial for downstream consumers and integrators.
+
+## API Stability Policy
+
+Directly modifying function signatures of exported functions breaks backward compatibility and disrupts downstream library consumers. To prevent this, contributors should follow these guidelines when changing or extending public APIs.
+
+### 1. Prefer Extensible Signatures
+
+When introducing new exported functions, design them to be extensible from the beginning. Avoid long lists of positional arguments.
+
+#### Pattern A: Configuration Structs
+
+Group parameters into a configuration struct. Adding fields to a struct is generally non-breaking, provided zero/nil values are handled gracefully.
+
+```go
+// NodeInfo Example
+
+type NodeInfoConfig struct {
+    Node    *apiv1.Node
+    Pods    []*PodInfo
+    CSINode *storagev1.CSINode
+}
+
+func NewNodeInfo(cfg NodeInfoConfig) *NodeInfo
+```
+
+Alternatively preserve a set of **required** parameters.
+
+```go
+func NewNodeInfo(node *apiv1.Node, cfg NodeInfoConfig) *NodeInfo
+```
+
+#### Pattern B: Functional Options (Variadic Options)
+
+Use functional options to allow adding parameters in the future without breaking existing calls. This is the recommended pattern for complex constructors.
+
+```go
+// NodeInfo Example
+
+// Extensible Signature
+func NewNodeInfo(node *apiv1.Node, opts ...NodeInfoOption) *NodeInfo
+
+type NodeInfoOption func(*NodeInfo)
+
+func WithCSINode(csiNode *storagev1.CSINode) NodeInfoOption {
+    return func(n *NodeInfo) {
+        n.CSINode = csiNode
+    }
+}
+```
+
+This is recommended when the number of options is relatively small and not expected to grow intensively. 
+
+### 2. Deprecation Policy
+
+When an exported API *must* be changed in a breaking way or replaced:
+
+1.  **Do not remove or change the old function signature immediately.**
+2.  **Introduce the new API alongside the old one.**
+3.  **Mark the old API as Deprecated:** Use a standard Go deprecation comment.
+    ```go
+    // Deprecated: Use NewNodeInfoV2 instead.
+    func NewNodeInfo(node *apiv1.Node, ...) *NodeInfo
+    ```
+4.  **Retention:** Retain the deprecated API for at least **two minor release cycles** (or as agreed by maintainers) before removal to give downstream consumers time to migrate.
+
+---
+
+*Note: These guidelines apply primarily to exported APIs (public interfaces, functions, and structs). Internal utilities may be modified more freely, but caution is advised.*


### PR DESCRIPTION
**To the project maintainers and all the contributors**: Please join this thread to discuss the future guidelines for development of Cluster Autoscaler Core Library.

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As Cluster Autoscaler core is transitioning into a standalone library, maintaining API stability and backward compatibility for exported functions is becoming crucial for downstream consumers and integrators.

Historically, function signatures (like `NewNodeInfo`) were modified directly, which is acceptable for a standalone binary but breaks library consumers. This need for formalized conventions was highlighted during the work on #65, where signature changes caused friction.

This document establishes recommended Go patterns (Functional Options, Config Structs) and a clear deprecation cycle (minimum of two minor releases) to guide future contributions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
 N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
