### PR TITLE
Set default scheduler verbosity equal to -v

### DIFF
--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -242,7 +242,7 @@ func (p *AutoscalingFlags) AddFlags(fs *pflag.FlagSet) {
 			"--max-graceful-termination-sec flag should not be set when this flag is set. Not setting this flag will use unordered evictor by default."+
 			"Priority evictor reuses the concepts of drain logic in kubelet(https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown#migration-from-the-node-graceful-shutdown-feature)."+
 			"Eg. flag usage:  '10000:20,1000:100,0:60'")
-	fs.IntVar(&p.schedulerVerbosity, "scheduler-verbosity", 0, "Specifies the verbosity threshold for logs produced by the scheduler.")
+	fs.IntVar(&p.schedulerVerbosity, "scheduler-verbosity", -1, "Specifies the verbosity threshold for logs produced by the scheduler. Should not be greater than -v flag value. If it's set to -1 the scheduler log verbosity will be equal to -v flag value.")
 }
 
 // Options builds AutoscalingOptions from the flags and returns them by value
@@ -309,15 +309,17 @@ func (p *AutoscalingFlags) Options() (config.AutoscalingOptions, error) {
 		p.o.MaxStartupTime = maxHealthCheckTimeout
 	}
 
-	var verbosity int = p.schedulerVerbosity
+	var verbosity int
 	if vFlag := flag.CommandLine.Lookup("v"); vFlag != nil {
 		if v, err := strconv.Atoi(vFlag.Value.String()); err == nil {
 			verbosity = v
 		}
 	}
-
 	if verbosity < p.schedulerVerbosity {
-		klog.Warningf("--scheduler-verbosity should be at most as high as -v flag, overriding it to: %d", verbosity)
+		klog.Warningf("--scheduler-verbosity should be at most as high as --v flag, overriding it to: %d", verbosity)
+		p.schedulerVerbosity = verbosity
+	}
+	if p.schedulerVerbosity < 0 {
 		p.schedulerVerbosity = verbosity
 	}
 

--- a/pkg/config/flags/flags_test.go
+++ b/pkg/config/flags/flags_test.go
@@ -537,31 +537,81 @@ func TestAutoscalingFlagsAllPossible(t *testing.T) {
 }
 
 func TestSchedulerVerbosityFlag(t *testing.T) {
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	// klog flags registration is required because we use -v flag
-	// value in order to resolve and validate scheduler verbosity value.
-	// Sadly this requires adding the global flag set to our test flag set
-	// due to the way how current --verbosity handles the flag lookup.
-	klog.InitFlags(flag.CommandLine)
-	fs.AddGoFlagSet(flag.CommandLine)
-
-	f := &AutoscalingFlags{}
-	f.AddFlags(fs)
-	err := fs.Parse([]string{"-v=5", "--scheduler-verbosity=1"})
-	if err != nil {
-		t.Fatalf("unexpected Parse error: %v", err)
+	testCases := []struct {
+		name                         string
+		flags                        []string
+		wantSchedulerVerbosityOffset int
+	}{
+		{
+			name:                         "empty input",
+			flags:                        []string{},
+			wantSchedulerVerbosityOffset: 0,
+		},
+		{
+			name:                         "scheduler verbosity is capped at CA verbosity",
+			flags:                        []string{"-v=3", "--scheduler-verbosity=10"},
+			wantSchedulerVerbosityOffset: 0,
+		},
+		{
+			name:                         "scheduler offset",
+			flags:                        []string{"-v=3", "--scheduler-verbosity=1"},
+			wantSchedulerVerbosityOffset: 2,
+		},
+		{
+			name:                         "scheduler verbosity is unset",
+			flags:                        []string{"-v=5"},
+			wantSchedulerVerbosityOffset: 0,
+		},
+		{
+			name:                         "verbosity is unset",
+			flags:                        []string{"--scheduler-verbosity=3"},
+			wantSchedulerVerbosityOffset: 0,
+		},
+		{
+			name:                         "scheduler verbosity is -1",
+			flags:                        []string{"-v=4", "--scheduler-verbosity=-1"},
+			wantSchedulerVerbosityOffset: 0,
+		},
 	}
 
-	opts, err := f.Options()
-	if err != nil {
-		t.Fatalf("unexpected Options error: %v", err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// klog flags registration is required because we use -v flag
+			// value in order to resolve and validate scheduler verbosity value.
+			// This requires adding the global flag set to our test flag set
+			// due to the way how current --verbosity handles the flag lookup.
+			klog.InitFlags(flag.CommandLine)
+
+			// Default verbosity value is 0 and it is set in the init() of k8s.io/klog/v2 module.
+			// It is a global variable in klog package. This means it leaks state, because imported packages are not re-initialized between tests.
+			// To avoid the state leak, we manually reset it to its default value before the test execution.
+			_ = flag.CommandLine.Lookup("v").Value.Set("0")
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			fs.AddGoFlagSet(flag.CommandLine)
+
+			f := &AutoscalingFlags{}
+
+			f.AddFlags(fs)
+			err := fs.Parse(tc.flags)
+			if err != nil {
+				t.Fatalf("unexpected Parse error: %v", err)
+			}
+
+			opts, err := f.Options()
+			if err != nil {
+				t.Fatalf("unexpected Options error: %v", err)
+			}
+
+			// Recreate global flag set so that race condition is shorter in time
+			flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError)
+
+			assert.Equal(t, tc.wantSchedulerVerbosityOffset, opts.SchedulerVerbosityOffset)
+		})
 	}
 
-	// Recreate global flag set so that race condition is shorter in time
-	flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError)
-
-	assert.Equal(t, 4, opts.SchedulerVerbosityOffset)
 }
 
 func TestAutoscalingFlagsValidationEdgeCases(t *testing.T) {

--- a/pkg/simulator/clustersnapshot/predicate/plugin_runner.go
+++ b/pkg/simulator/clustersnapshot/predicate/plugin_runner.go
@@ -57,7 +57,7 @@ func NewSchedulerPluginRunner(fwHandle *framework.Handle, snapshot clustersnapsh
 func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts clustersnapshot.SchedulingOptions) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
 	// Currently, the scheduler checks that verbosity threshold for logs is at least 4 before adding contextual data to the logger.
 	// We don't want scheduler to add contextual data to the logger, as it causes performance issues in CA.
-	// This line sets the verbosity threshold of scheduler's logs to match that specified by --scheduler-verbosity flag (0 by default).
+	// This line sets the verbosity threshold of scheduler's logs to match that specified by --scheduler-verbosity flag.
 	loggingCtx := klog.NewContext(context.TODO(), klog.Background().V(p.verbosityOffset))
 
 	nodeInfosList, err := p.snapshot.ListNodeInfos()
@@ -154,7 +154,9 @@ func (p *SchedulerPluginRunner) RunFiltersUntilPassingNode(pod *apiv1.Pod, opts 
 func (p *SchedulerPluginRunner) RunFiltersOnNode(pod *apiv1.Pod, nodeName string) (*apiv1.Node, *schedulerimpl.CycleState, clustersnapshot.SchedulingError) {
 	// Currently, the scheduler checks that verbosity threshold for logs is at least 4 before adding contextual data to the logger.
 	// We don't want scheduler to add contextual data to the logger, as it causes performance issues in CA.
-	// This line sets the verbosity threshold of scheduler's logs to match that specified by --scheduler-verbosity flag (0 by default).
+	// The .V() method creates a new logger with a verbosity of the original logger + the provided offset value.
+	// klog.Background() has the verbosity of the globally initialized logger which comes from the --v flag.
+	// Verbosity offset is computed as the difference between --v and  --scheduler-verbosity flag values.
 	loggingCtx := klog.NewContext(context.TODO(), klog.Background().V(p.verbosityOffset))
 
 	nodeInfo, err := p.snapshot.GetNodeInfo(nodeName)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Sets default scheduler verbosity to -1, which means that scheduler verbosity will be equal to CA verbosity by default (was 0 before)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Default verbosity for scheduler logs is set to the same value as -v. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
