### PR TITLE
Scaledown strategies

### DIFF
--- a/pkg/builder/autoscaler.go
+++ b/pkg/builder/autoscaler.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/core"
 	coreoptions "sigs.k8s.io/cluster-autoscaler/pkg/core/options"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/podlistprocessor"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaleup/orchestrator"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/utils"
 	"sigs.k8s.io/cluster-autoscaler/pkg/debuggingsnapshot"
@@ -160,6 +161,11 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 	deleteOptions := options.NewNodeDeleteOptions(autoscalingOptions)
 	drainabilityRules := rules.Default(deleteOptions)
 
+	parsedStrategy, err := strategy.NewStrategy(autoscalingOptions.ScaleDownStrategy)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var snapshotStore clustersnapshot.ClusterSnapshotStore = store.NewDeltaSnapshotStore()
 	opts := coreoptions.AutoscalerOptions{
 		AutoscalingOptions:     autoscalingOptions,
@@ -174,6 +180,7 @@ func (b *AutoscalerBuilder) Build(ctx context.Context) (core.Autoscaler, *loop.L
 		ScaleUpOrchestrator:    orchestrator.New(),
 		KubeClientNew:          b.manager.GetClient(),
 		KubeCache:              b.manager.GetCache(),
+		ScaleDownStrategy:      parsedStrategy,
 	}
 
 	opts.Processors = ca_processors.DefaultProcessors(autoscalingOptions)

--- a/pkg/builder/autoscaler_factory.go
+++ b/pkg/builder/autoscaler_factory.go
@@ -70,6 +70,7 @@ func NewAutoscaler(ctx context.Context, opts coreoptions.AutoscalerOptions, info
 		opts.MinQuotasTrackerOptions,
 		opts.CSIProvider,
 		opts.CapacityBufferPodsRegistry,
+		opts.ScaleDownStrategy,
 	), nil
 }
 

--- a/pkg/config/autoscaling_options.go
+++ b/pkg/config/autoscaling_options.go
@@ -387,6 +387,8 @@ type AutoscalingOptions struct {
 	PendingPodsBatchingTimeout time.Duration
 	// GracefulDegradationEnabled tells if graceful degradation for unschedulable pods is enabled.
 	GracefulDegradationEnabled bool
+	// ScaleDownStrategy is the dimension and weight string for scaledown strategy.
+	ScaleDownStrategy string
 }
 
 // KubeClientOptions specify options for kube client

--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -211,6 +211,7 @@ func (p *AutoscalingFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&p.o.PendingPodsBatchingTimeout, "pending-pods-batching-timeout", 4*time.Minute, "The maximum time spends when running scheduling simulations when preparing the batch of pods passed to scale up logic. This timeout is used in core filter-out pod list processor.")
 	fs.BoolVar(&p.o.GracefulDegradationEnabled, "enable-graceful-degradation", false, "Enables graceful degradation for unschedulable pods. When enabled, scheduling simulations during filter out pod list processor will be stopped after a timeout(specified by scheduling-simulation-timeout) and CA will proceed with a sub set of pods.")
 	fs.BoolVar(&p.o.InterPodAffinityHostnameFastPath, "enable-inter-pod-affinity-hostname-fast-path", false, "Enable the InterPodAffinityHostnameFastPath scheduler feature gate.")
+	fs.StringVar(&p.o.ScaleDownStrategy, "scaledown-strategy", "", "Scale down priority strategy in the format dimension1=score1,dimension2=score2. If empty, scoring is disabled.")
 
 	// Deprecated flags
 	fs.StringArrayVar(&p.ignoreTaints, "ignore-taint", []string{}, "Specifies a taint to ignore in node templates when considering to scale a node group (Deprecated, use startup-taints instead)")

--- a/pkg/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
+++ b/pkg/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/bench/scaledown/efficiency/metrics"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/budgets"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/planner"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 	. "sigs.k8s.io/cluster-autoscaler/pkg/core/test"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors"
 	processorstest "sigs.k8s.io/cluster-autoscaler/pkg/processors/test"
@@ -71,7 +72,7 @@ func defaultAutoscalingOptions() config.AutoscalingOptions {
 	}
 }
 
-func buildScaleDownDependencies(b *testing.B, cs *initialClusterState, autoscalingOpts config.AutoscalingOptions) scaleDownDependencies {
+func buildScaleDownDependencies(b *testing.B, cs *initialClusterState, autoscalingOpts config.AutoscalingOptions) (scaleDownDependencies, error) {
 	b.Helper()
 	var allNodes []*apiv1.Node
 	var allPods []*apiv1.Pod
@@ -98,14 +99,20 @@ func buildScaleDownDependencies(b *testing.B, cs *initialClusterState, autoscali
 
 	a := NewFakeActuator(autoscalingCtx, &fakeActuationStatus{})
 	factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: procs.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
-	p := planner.New(&autoscalingCtx, procs, options.NodeDeleteOptions{}, nil, factory)
+
+	parsedStrategy, err := strategy.NewStrategy("Utilization=0.3")
+	if err != nil {
+		return scaleDownDependencies{}, err
+	}
+
+	p := planner.New(&autoscalingCtx, procs, options.NodeDeleteOptions{}, nil, factory, parsedStrategy)
 
 	return scaleDownDependencies{
 		AutoscalingCtx: &autoscalingCtx,
 		Processors:     procs,
 		Planner:        p,
 		Actuator:       a,
-	}
+	}, nil
 }
 
 // Crucial to pass -benchtime=1x to let the Loop know to run scaledown strategy exactly once.
@@ -115,7 +122,11 @@ func (scenario scaleDownScenario) run(b *testing.B) {
 		scenario.AutoscalingOptsSetup(&opts)
 	}
 	mt := scenario.MetricsTracker
-	sdDeps := buildScaleDownDependencies(b, scenario.InitialClusterState, opts)
+	sdDeps, err := buildScaleDownDependencies(b, scenario.InitialClusterState, opts)
+
+	if err != nil {
+		b.Fatalf("failed to create scaleDownDependencies, err: %s", err.Error())
+	}
 
 	nodeInfos, err := sdDeps.AutoscalingCtx.ClusterSnapshot.ListNodeInfos()
 	if err != nil {

--- a/pkg/core/options/autoscaler.go
+++ b/pkg/core/options/autoscaler.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/context"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/pdb"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaleup"
 	"sigs.k8s.io/cluster-autoscaler/pkg/debuggingsnapshot"
 	"sigs.k8s.io/cluster-autoscaler/pkg/estimator"
@@ -70,4 +71,5 @@ type AutoscalerOptions struct {
 	KubeClientNew              client.Client
 	KubeCache                  cache.Cache
 	CapacityBufferPodsRegistry *fakepods.Registry
+	ScaleDownStrategy          *strategy.Strategy
 }

--- a/pkg/core/scaledown/planner/planner.go
+++ b/pkg/core/scaledown/planner/planner.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/eligibility"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/nodeevaltracker"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/pdb"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/unneeded"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/unremovable"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors"
@@ -79,10 +80,11 @@ type Planner struct {
 	scaleDownSetProcessor nodes.ScaleDownSetProcessor
 	scaleDownContext      *nodes.ScaleDownContext
 	maxNodeSkipEvalTime   *nodeevaltracker.MaxNodeSkipEvalTime
+	scaleDownStrategy     *strategy.Strategy
 }
 
 // New creates a new Planner object.
-func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.AutoscalingProcessors, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, quotasTrackerFactory *resourcequotas.TrackerFactory) *Planner {
+func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.AutoscalingProcessors, deleteOptions options.NodeDeleteOptions, drainabilityRules rules.Rules, quotasTrackerFactory *resourcequotas.TrackerFactory, sdStrategy *strategy.Strategy) *Planner {
 	minUpdateInterval := autoscalingCtx.AutoscalingOptions.NodeGroupDefaults.ScaleDownUnneededTime
 	if minUpdateInterval == 0*time.Nanosecond {
 		minUpdateInterval = 1 * time.Nanosecond
@@ -112,6 +114,7 @@ func New(autoscalingCtx *ca_context.AutoscalingContext, processors *processors.A
 		scaleDownContext:      nodes.NewDefaultScaleDownContext(),
 		minUpdateInterval:     minUpdateInterval,
 		maxNodeSkipEvalTime:   maxNodeSkipEvalTime,
+		scaleDownStrategy:     sdStrategy,
 	}
 }
 
@@ -283,6 +286,36 @@ func (p *Planner) injectPods(pods []*apiv1.Pod) error {
 	return nil
 }
 
+// rankNodes scores, normalizes, weights, totals and sorts candidates based on provided Strategy
+// If any error occurs, original unsorted unneededNodes slice is returned.
+func (p *Planner) rankNodes(unneededNodes []string) []string {
+	rs := strategy.NewRankingSession(p.scaleDownStrategy)
+	for _, nodeName := range unneededNodes {
+		nodeInfo, err := p.autoscalingCtx.ClusterSnapshot.GetNodeInfo(nodeName)
+		if err != nil {
+			klog.Errorf("error getting node info for scoring, returning original unneededNodes slice; err: %s", err.Error())
+			return unneededNodes
+		}
+		err = rs.ScoreNode(nodeInfo)
+		if err != nil {
+			klog.Errorf("error scoring nodes, returning original unneededNodes slice; err: %s", err.Error())
+			return unneededNodes
+		}
+	}
+	err := rs.Normalize()
+	if err != nil {
+		klog.Errorf("error normalizing scores, returning original unneededNodes slice; err: %s", err.Error())
+		return unneededNodes
+	}
+	err = rs.WeightTotal()
+	if err != nil {
+		klog.Errorf("error weighting and totaling scores, returning original unneededNodes slice; err: %s", err.Error())
+		return unneededNodes
+	}
+	unneededNodes = rs.Sort(unneededNodes)
+	return unneededNodes
+}
+
 // categorizeNodes determines, for each node, whether it can be eventually
 // removed or if there are reasons preventing that.
 func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCandidates []*apiv1.Node) {
@@ -299,6 +332,9 @@ func (p *Planner) categorizeNodes(podDestinations map[string]bool, scaleDownCand
 	timer := time.NewTimer(p.autoscalingCtx.ScaleDownSimulationTimeout)
 	var skippedNodes []string
 
+	if len(p.scaleDownStrategy.Dimensions) > 0 {
+		currentlyUnneededNodeNames = p.rankNodes(currentlyUnneededNodeNames)
+	}
 	for i, node := range currentlyUnneededNodeNames {
 		if timedOut(timer) {
 			skippedNodes = currentlyUnneededNodeNames[i:]

--- a/pkg/core/scaledown/planner/planner_test.go
+++ b/pkg/core/scaledown/planner/planner_test.go
@@ -18,11 +18,11 @@ package planner
 
 import (
 	"fmt"
-
-	"sigs.k8s.io/cluster-autoscaler/pkg/resourcequotas"
-
 	"testing"
 	"time"
+
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
+	"sigs.k8s.io/cluster-autoscaler/pkg/resourcequotas"
 
 	"github.com/stretchr/testify/assert"
 
@@ -509,7 +509,8 @@ func TestUpdateClusterState(t *testing.T) {
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, tc.nodes, tc.pods)
 			deleteOptions := options.NodeDeleteOptions{}
 			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
-			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+			sdStrategy, _ := strategy.NewStrategy("")
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory, sdStrategy)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(tc.eligible)}
 			if tc.isSimulationTimeout {
 				autoscalingCtx.AutoscalingOptions.ScaleDownSimulationTimeout = 1 * time.Second
@@ -708,7 +709,8 @@ func TestUpdateClusterStatUnneededNodesLimit(t *testing.T) {
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, nodes, nil)
 			deleteOptions := options.NodeDeleteOptions{}
 			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
-			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+			sdStrategy, _ := strategy.NewStrategy("")
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory, sdStrategy)
 			p.eligibilityChecker = &fakeEligibilityChecker{eligible: asMap(nodeNames(nodes))}
 			p.minUpdateInterval = tc.updateInterval
 			p.unneededNodes.Update(&autoscalingCtx, previouslyUnneeded, time.Now())
@@ -845,7 +847,8 @@ func TestNewPlannerWithExistingDeletionCandidateNodes(t *testing.T) {
 
 			deleteOptions := options.NodeDeleteOptions{}
 			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
-			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+			sdStrategy, _ := strategy.NewStrategy("")
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory, sdStrategy)
 
 			p.unneededNodes.AsList()
 		})
@@ -1111,7 +1114,8 @@ func TestNodesToDelete(t *testing.T) {
 			clustersnapshot.InitializeClusterSnapshotOrDie(t, autoscalingCtx.ClusterSnapshot, allNodes, nil)
 			deleteOptions := options.NodeDeleteOptions{}
 			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
-			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+			sdStrategy, _ := strategy.NewStrategy("")
+			p := New(&autoscalingCtx, processors, deleteOptions, nil, factory, sdStrategy)
 			p.latestUpdate = time.Now()
 
 			if tc.minLimits != nil {
@@ -1291,7 +1295,8 @@ func TestAtomicScaleDownNodeNilGroup(t *testing.T) {
 
 	deleteOptions := options.NodeDeleteOptions{}
 	factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(provider)})
-	p := New(&autoscalingCtx, processors, deleteOptions, nil, factory)
+	sdStrategy, _ := strategy.NewStrategy("")
+	p := New(&autoscalingCtx, processors, deleteOptions, nil, factory, sdStrategy)
 
 	node := &simulator.NodeToBeRemoved{
 		Node: n1,

--- a/pkg/core/scaledown/strategy/interface.go
+++ b/pkg/core/scaledown/strategy/interface.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+)
+
+// NodeDimensionScore represents a score given to the specific node NodeName by a single Dimension.
+// Used for normalization.
+type NodeDimensionScore struct {
+	NodeName string
+	Score    float64
+}
+
+// NodeDimensionScoreList holds scores of all nodes for specific Dimension.
+// Used for normalization.
+type NodeDimensionScoreList []NodeDimensionScore
+
+// DimensionScore represents a score node received for a Dimension DimensionName.
+type DimensionScore struct {
+	DimensionName string
+	Score         float64
+}
+
+// NodeRank holds for node Name scores across all Dimensions.
+type NodeRank struct {
+	Name string
+	// RawScores hold Score() output before normalization for each Dimension.
+	RawScores []DimensionScore
+	// Scores are normalized weighted scores for each Dimension.
+	Scores     []DimensionScore
+	TotalScore float64
+}
+
+// ScoringDimension is the interface representing single scoring Dimension.
+type ScoringDimension interface {
+	// Name returns the name of the dimension.
+	Name() string
+	// Score returns the raw score for a specific node in this Dimension.
+	Score(nodeInfo *framework.NodeInfo) (float64, error)
+}
+
+// DimensionNormalizer is an optional extension interface to normalize raw scores into allowed range.
+type DimensionNormalizer interface {
+	// Normalize modifies the given NodeDimensionScoreList in place to scale the scores at once.
+	Normalize(scores NodeDimensionScoreList) error
+}

--- a/pkg/core/scaledown/strategy/ranking_session.go
+++ b/pkg/core/scaledown/strategy/ranking_session.go
@@ -1,0 +1,143 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"fmt"
+	"sort"
+
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+)
+
+const (
+	// MinDimensionScore is the minimum score a Dimension is allowed to return after normalization.
+	MinDimensionScore float64 = 0
+	// MaxDimensionScore is the maximum score a Dimension is allowed to return after normalization.
+	MaxDimensionScore float64 = 100
+)
+
+// RankingSession acts as the engine to score, normalize, weight, total, and sort nodes for one CA loop.
+// State is tied to a single scaledown evaluation lifecycle.
+type RankingSession struct {
+	strategy *Strategy
+	// Keyed by Node name.
+	Rankings map[string]*NodeRank
+	// Keyed by Dimension name.
+	DimensionScores map[string]NodeDimensionScoreList
+}
+
+// NewRankingSession initializes a new empty RankingSession referencing Strategy.
+func NewRankingSession(strategy *Strategy) *RankingSession {
+	rs := &RankingSession{
+		strategy:        strategy,
+		Rankings:        make(map[string]*NodeRank),
+		DimensionScores: make(map[string]NodeDimensionScoreList),
+	}
+	return rs
+}
+
+// ScoreNode evaluates a single node against all configured Dimensions.
+// Both NodeRank and NodeDimensionScoreList are filled with data.
+func (rs *RankingSession) ScoreNode(nodeInfo *framework.NodeInfo) error {
+	nodeName := nodeInfo.Node().Name
+
+	rank := &NodeRank{
+		Name:      nodeName,
+		RawScores: []DimensionScore{},
+		Scores:    []DimensionScore{},
+	}
+
+	// If Dimensions are empty, no scoring happens and no structs are populated.
+	for _, dim := range rs.strategy.Dimensions {
+		dimName := dim.Name()
+		score, err := dim.Score(nodeInfo)
+		if err != nil {
+			return err
+		}
+
+		// Store node raw score inside its NodeRank struct.
+		rank.RawScores = append(rank.RawScores, DimensionScore{
+			DimensionName: dimName,
+			Score:         score,
+		})
+
+		// Store node raw score inside Dimension struct for later normalization.
+		rs.DimensionScores[dimName] = append(rs.DimensionScores[dimName], NodeDimensionScore{
+			NodeName: nodeName,
+			Score:    score,
+		})
+	}
+	rs.Rankings[nodeName] = rank
+	return nil
+}
+
+// Normalize executes score normalization over all configured Dimensions in-place.
+// Each Dimension must have its normalized score in range <0,100>
+func (rs *RankingSession) Normalize() error {
+	for _, dim := range rs.strategy.Dimensions {
+		if normalizer, ok := dim.(DimensionNormalizer); ok {
+			err := normalizer.Normalize(rs.DimensionScores[dim.Name()])
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// WeightTotal applies configured weights and sums the total score for each node.
+func (rs *RankingSession) WeightTotal() error {
+	for dimName, scoresList := range rs.DimensionScores {
+		weight := rs.strategy.Weights[dimName]
+		for _, dimensionScore := range scoresList {
+			rank := rs.Rankings[dimensionScore.NodeName]
+			if rank != nil {
+				if dimensionScore.Score > MaxDimensionScore || dimensionScore.Score < MinDimensionScore {
+					return fmt.Errorf("normalized dimension %s score not in range, should be in <%1.f,%1f>", dimName, MinDimensionScore, MaxDimensionScore)
+				}
+				weightedScore := dimensionScore.Score * weight
+				rank.Scores = append(rank.Scores, DimensionScore{
+					DimensionName: dimName,
+					Score:         weightedScore,
+				})
+				rank.TotalScore += weightedScore
+			}
+		}
+	}
+	return nil
+}
+
+// Sort returns a sorted copy of unneeded node names according to their TotalScore in descending order.
+func (rs *RankingSession) Sort(nodeNames []string) []string {
+	sorted := append([]string(nil), nodeNames...)
+	sort.Slice(sorted, func(i, j int) bool {
+		rankI := rs.Rankings[sorted[i]]
+		rankJ := rs.Rankings[sorted[j]]
+		var totalI, totalJ float64
+		if rankI != nil {
+			totalI = rankI.TotalScore
+		}
+		if rankJ != nil {
+			totalJ = rankJ.TotalScore
+		}
+		if totalI == totalJ {
+			return sorted[i] < sorted[j]
+		}
+		return totalI > totalJ
+	})
+	return sorted
+}

--- a/pkg/core/scaledown/strategy/strategy.go
+++ b/pkg/core/scaledown/strategy/strategy.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// registeredDimensions is a background Dimension registry.
+var registeredDimensions = make(map[string]ScoringDimension)
+
+// RegisterDimension is called by individual Dimensions to register themselves as available.
+func RegisterDimension(sd ScoringDimension) {
+	registeredDimensions[sd.Name()] = sd
+}
+
+// Strategy holds parsed Dimensions and weights that are applied in every CA loop.
+type Strategy struct {
+	Dimensions []ScoringDimension
+	Weights    map[string]float64
+}
+
+// parse fails fast if any configuration is incorrect.
+func (s *Strategy) parse(strategyStr string) error {
+	strategyStr = strings.TrimSpace(strategyStr)
+	if strategyStr == "" {
+		return nil
+	}
+
+	parts := strings.SplitSeq(strategyStr, ",")
+	for part := range parts {
+		keyValue := strings.Split(part, "=")
+		if len(keyValue) != 2 {
+			return fmt.Errorf("invalid dimension and weight format '%s', expected 'dimension=score'", part)
+		}
+		dimName := strings.TrimSpace(keyValue[0])
+		weightStr := strings.TrimSpace(keyValue[1])
+		weight, err := strconv.ParseFloat(weightStr, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse weight '%s' for dimension '%s', err: %s", weightStr, dimName, err.Error())
+		}
+		if weight < 0 {
+			return fmt.Errorf("weight cannot be negative for dimension '%s'", dimName)
+		}
+		if weight == 0 {
+			return fmt.Errorf("setting weight to zero not allowed, to disable %s do not include it in the list", dimName)
+		}
+		d, ok := registeredDimensions[dimName]
+		if !ok {
+			return fmt.Errorf("unknown scoring dimension '%s' configured", dimName)
+		}
+		s.Dimensions = append(s.Dimensions, d)
+		s.Weights[dimName] = weight
+	}
+	return nil
+}
+
+// NewStrategy returns new instance of Strategy and error in case of failed parsing.
+func NewStrategy(strategyStr string) (*Strategy, error) {
+	s := &Strategy{
+		Dimensions: []ScoringDimension{},
+		Weights:    make(map[string]float64),
+	}
+	err := s.parse(strategyStr)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/pkg/core/scaledown/strategy/utilization.go
+++ b/pkg/core/scaledown/strategy/utilization.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/utilization"
+)
+
+func init() {
+	RegisterDimension(NewUtilizationDimension())
+}
+
+// UtilizationDimension is a Strategy Dimension that scores nodes based on their CPU resource utilization.
+type UtilizationDimension struct{}
+
+// NewUtilizationDimension returns a new UtilizationDimension.
+func NewUtilizationDimension() *UtilizationDimension {
+	return &UtilizationDimension{}
+}
+
+// Name returns the name of the utilization dimension.
+func (d *UtilizationDimension) Name() string {
+	return "Utilization"
+}
+
+// Score returns the raw score for a specific Node as its CPU utilization percentage (float in range <0,1>).
+func (d *UtilizationDimension) Score(nodeInfo *framework.NodeInfo) (float64, error) {
+	util, err := utilization.CalculateUtilizationOfResource(nodeInfo, apiv1.ResourceCPU, true, true, time.Now())
+	if err != nil {
+		return 0, err
+	}
+	return util, nil
+}
+
+// Normalize normalizes raw scores into the allowed range and inverts the value to correctly interpret higher utilization as lower preference score
+// High raw score (85) -> low normalized score (15); low raw score (05)  -> high normalized score (95)
+func (d *UtilizationDimension) Normalize(scores NodeDimensionScoreList) error {
+	for i := range scores {
+		rawUtil := scores[i].Score * 100
+		if rawUtil < 0 {
+			rawUtil = 0
+		}
+		if rawUtil > 100 {
+			rawUtil = 1
+		}
+		scores[i].Score = 100 - rawUtil
+	}
+	return nil
+}

--- a/pkg/core/static_autoscaler.go
+++ b/pkg/core/static_autoscaler.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/pdb"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/planner"
 	scaledownstatus "sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/status"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaleup"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaleup/orchestrator"
 	core_utils "sigs.k8s.io/cluster-autoscaler/pkg/core/utils"
@@ -169,7 +170,8 @@ func NewStaticAutoscaler(
 	quotasTrackerOptions resourcequotas.TrackerOptions,
 	minQuotasTrackerOptions resourcequotas.TrackerOptions,
 	csiProvider *csinodeprovider.Provider,
-	capacityBufferPodsRegistry *fakepods.Registry) *StaticAutoscaler {
+	capacityBufferPodsRegistry *fakepods.Registry,
+	scaleDownStrategy *strategy.Strategy) *StaticAutoscaler {
 
 	klog.V(4).Infof("Creating new static autoscaler with opts: %v", opts)
 
@@ -215,7 +217,7 @@ func NewStaticAutoscaler(
 	quotasTrackerFactory := resourcequotas.NewTrackerFactory(quotasTrackerOptions)
 	minQuotasTrackerFactory := resourcequotas.NewTrackerFactory(minQuotasTrackerOptions)
 
-	scaleDownPlanner := planner.New(autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory)
+	scaleDownPlanner := planner.New(autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory, scaleDownStrategy)
 	processorCallbacks.scaleDownPlanner = scaleDownPlanner
 
 	ndt := deletiontracker.NewNodeDeletionTracker(0 * time.Second)

--- a/pkg/core/static_autoscaler_csi_test.go
+++ b/pkg/core/static_autoscaler_csi_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -292,7 +293,8 @@ func TestStaticAutoscalerCSI(t *testing.T) {
 			deleteOptions := options.NewNodeDeleteOptions(autoscaler.AutoscalingOptions)
 			drainabilityRules := rules.Default(deleteOptions)
 			factory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{CustomResourcesProcessor: autoscaler.processors.CustomResourcesProcessor, QuotaProvider: resourcequotas.NewCloudMinProvider(autoscaler.AutoscalingContext.CloudProvider)})
-			newSDPlanner := sdplanner.New(autoscaler.AutoscalingContext, autoscaler.processors, deleteOptions, drainabilityRules, factory)
+			sdStrategy, _ := strategy.NewStrategy("")
+			newSDPlanner := sdplanner.New(autoscaler.AutoscalingContext, autoscaler.processors, deleteOptions, drainabilityRules, factory, sdStrategy)
 			autoscaler.scaleDownPlanner = newSDPlanner
 			autoscaler.processorCallbacks.scaleDownPlanner = newSDPlanner
 

--- a/pkg/core/static_autoscaler_test.go
+++ b/pkg/core/static_autoscaler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	cbv1beta1 "k8s.io/autoscaler/cluster-autoscaler/apis/capacitybuffer/autoscaling.x-k8s.io/v1beta1"
 	"sigs.k8s.io/cluster-autoscaler/pkg/capacitybuffer/fakepods"
+	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown/strategy"
 	"sigs.k8s.io/cluster-autoscaler/pkg/resourcequotas"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -344,8 +345,9 @@ func setupAutoscaler(config *autoscalerSetupConfig) (*StaticAutoscaler, error) {
 		CustomResourcesProcessor: processors.CustomResourcesProcessor,
 		QuotaProvider:            minQuotaProvider,
 	})
+	sdStrategy, _ := strategy.NewStrategy("")
 
-	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory)
+	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, minQuotasTrackerFactory, sdStrategy)
 
 	processorCallbacks.scaleDownPlanner = sdPlanner
 
@@ -3180,7 +3182,8 @@ func newScaleDownPlannerAndActuator(autoscalingCtx *ca_context.AutoscalingContex
 		nodeDeletionTracker = deletiontracker.NewNodeDeletionTracker(0 * time.Second)
 	}
 	quotasTrackerFactory := newQuotasTrackerFactory(autoscalingCtx, p)
-	planner := planner.New(autoscalingCtx, p, deleteOptions, nil, quotasTrackerFactory)
+	sdStrategy, _ := strategy.NewStrategy("")
+	planner := planner.New(autoscalingCtx, p, deleteOptions, nil, quotasTrackerFactory, sdStrategy)
 	actuator := actuation.NewActuator(autoscalingCtx, cs, nodeDeletionTracker, deleteOptions, nil, p.NodeGroupConfigProcessor)
 	return planner, actuator
 }
@@ -3314,7 +3317,8 @@ func buildStaticAutoscaler(t *testing.T, provider cloudprovider.CloudProvider, a
 	drainabilityRules := rules.Default(deleteOptions)
 
 	quotasTrackerFactory := newQuotasTrackerFactory(&autoscalingCtx, processors)
-	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, quotasTrackerFactory)
+	sdStrategy, _ := strategy.NewStrategy("")
+	sdPlanner := planner.New(&autoscalingCtx, processors, deleteOptions, drainabilityRules, quotasTrackerFactory, sdStrategy)
 
 	autoscaler := &StaticAutoscaler{
 		AutoscalingContext:   &autoscalingCtx,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR is a follow-up on #18 and introduces the actual Scaledown strategy framework, its primitives, engine and integration into existing CA code.

The main objective is to rank and sort scaledown candidate nodes marked by `Planner` based on configured `Strategy` (defined by dimension and weights) before they enter loop simulating scaledown candidate removal in `categorizeNodes` function. 

During a scaledown, the CA evaluates the cluster nodes to identify nodes that are underutilized and eligible for removal. Basic heuristics and defined rules are applied to filter scaledown candidates. Then, CA iterates over the list of scaledown candidates and simulates their removal in no particular order. Therefore, if a timeout happens or enough candidates have been found, iteration is stopped. It is not ensured that the optimal candidates were evaluated first and thus were at lower risk of being struck by timeout or other limits which may result in a suboptimal list of final nodes marked for scaledown. Sorted list will ensure "more suitable" candidates are evaluated first.

#### Structure
The scaledown strategy framework is introduced in its own `strategy` package under `scaledown` and includes:
##### interface.go
Defines primitives (structs and interfaces) that represent:
1. *Scoring Dimension* - a single characteristic of a Node that can be computed, normalized, and used as a contributing factor to total node score.
 2. *Node rank* - A structure that holds raw dimension scores, normalized dimension scores, weighted dimension scores and total score per each node

The design and implementation is heavily influenced by [Score phase of Kubernetes Scheduler Framework (SF)](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#scoring). Semantically same or similar structures are reused in CA for storing scored, normalized and weighted results for each Node as are used in the `Score` phase in K8s SF to record scoring, normalization and weighting results for each node for each scoring plugin ([NodeScoreList](https://github.com/kubernetes/kubernetes/blob/52ba90138eb40cab0987dac73e05c838149bdd1c/staging/src/k8s.io/kube-scheduler/framework/interface.go#L276), [NodePluginScores](https://github.com/kubernetes/kubernetes/blob/52ba90138eb40cab0987dac73e05c838149bdd1c/staging/src/k8s.io/kube-scheduler/framework/interface.go#L285), [PluginScore](https://github.com/kubernetes/kubernetes/blob/52ba90138eb40cab0987dac73e05c838149bdd1c/staging/src/k8s.io/kube-scheduler/framework/interface.go#L300), [PlacementPluginScore](https://github.com/kubernetes/kubernetes/blob/52ba90138eb40cab0987dac73e05c838149bdd1c/staging/src/k8s.io/kube-scheduler/framework/interface.go#L307)).  


To evaluate scaledown candidate nodes efficiently,  scoring relies on a dual-perspective data model that mimics the K8s SF. Data is grouped simultaneously by **Dimension** (column) and **Node** (row):
- `NodeDimensionScoreList `(One column in the matrix) represents one scoring Dimension, containing a list of `NodeDimensionScore` structs (the scores for every node evaluated by that dimension).
- `NodeRank` (One row in the matrix) represents one Node containing a list of raw `DimensionScore` (the evaluated scores from every dimension for that node), a list of normalized `DimensionScore` and the final aggregated `TotalScore` after weighting.

| **Node** | **Dimension** 1: Util | **Dimension** 2: PodCount |
| :--- | :--- | :--- |
| **Node** A<br>NodeRank | Column Op:<br>`NodeDimensionScore{NodeName:A, Score:80}`<br><br>Row Op:<br>`DimensionScore{DimensionName:Util, Score:80}` | Column Op:<br>`NodeDimensionScore{NodeName:A, Score:10}`<br><br>Row Op:<br>`DimensionScore{DimensionName:PodCount, Score:10}` |
| **Node** B<br>NodeRank | Column Op:<br>`NodeDimensionScore{NodeName:B, Score:20}`<br><br>Row Op:<br>`DimensionScore{DimensionName:Util, Score:20}` | Column Op:<br>`NodeDimensionScore{NodeName:B, Score:90}`<br><br>Row Op:<br>`DimensionScore{DimensionName:PodCount, Score:90}` |

**Column operations** operate on structure `NodeDimensionScore`. The data is used during the normalization phase when the normalizer iterates top-to-bottom through a single Dimension column. Normalizer needs to know which Node it is currently analyzing (hence `NodeDimensionScore` holds NodeName). It does not need the Dimension name, because the entire list belongs to one Dimension.

**Row operations** operate on structure `DimensionScore`. The data is used during weighting and aggregation when the orchestrator iterates left-to-right across a single Node. Weighting and aggregation need to know which Dimension is currently processed to apply correct weight (hence `DimensionScore` holds `DimensionName`). The process does not need the Node name, because the entire `NodeRank` struct belongs to one node.


##### ranking_session.go
Introduces engine orchestrating the Dimension scoring, normalizing, weighting and aggregating for scaledown candidates and performs final sorting. The `RankingSession` is a transient, short-lived object instantiated to hold calculations for a single evaluation cycle and statically references configured `Strategy`.

If any phase of node ranking fails (score, normalize, weight), original unsorted list is used for scaledown candidate node removal simulation.

##### strategy.go
A simple, stateless, immutable structure that holds instantiated Dimensions to evaluate and their weights. Passed in format `dimension1=weight1,dimension2=weight2,...`. Currently single scaledown strategy applies to whole cluster.

To avoid hardcoding recognized Dimensions directly into the parsing logic, the Dimensions register themselves into a package-scoped registry. A registry maps Dimension names directly to their instantiated struct instances. Individual Dimensions register themselves into the registry in `init()`.

##### utilization.go
The first implementation of the Dimension that can be expressed in a scaledown strategy as a weighted Dimension to evaluate for final score. The Dimension must comply with the core `ScoringDimension` interface to be even considered as an operational Dimension so it has to implement two functions, `Name, Score`. If the raw metric (e.g., here a utilization percentage) does not automatically align with the broader concept of "deletion preference" or fall within allowed values range, a Dimension may opt-in to the orchestrator's normalization phase by fulfilling the optional `DimensionNormalizer` interface , exposing a single `Normalize` function designed to sweep through all evaluated scores for the Dimension in that CA loop.

Objective of `UtilizationDimension` is to score the nodes and assign raw utilization as raw achieved score. It implements optional normalization to normalize raw scores to be in the allowed range and invert the meaning of raw scores which guarantees that the sorting will favor emptying and deleting the most idle nodes

#### Integration in CA

The strategy evaluation is integrated in the scaledown `Planner` as it is tightly scoped only to scaledown. 

Existing unit and benchmark tests were modified to accommodate the strategy requirement in the `Planner` structure. For the standard static autoscaler and `Planner` unit tests, an empty strategy is created and passed down simply to satisfy the updated constructor without changing the underlying test behavior. Scaledown efficiency benchmark introduced in #18 was updated to initialize and pass an actual `Strategy` configuration. The benchmark currently evaluates a hardcoded configuration with only `UtilizationDimension`, meaning the specific weight assigned to that dimension does not influence the final ranking outcomes but still sorts the list of scaledown candidate nodes. 


#### Does this PR introduce a user-facing change?
New flag `-scaledown-strategy` is added to pass down configured dimensions and weights to core CA engine. The flag is by default set to empty string. This ensures that default scaledown behaviour is not changed unless strategy is explicitly configured. 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [Benchmarking scaledown strategies]: https://github.com/kubernetes-sigs/cluster-autoscaler/pull/18
```
