### PR TITLE
Add new metrics for benchmarking scaledown strategies

### DIFF
--- a/pkg/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
+++ b/pkg/core/bench/scaledown/efficiency/benchmark_scaledown_test.go
@@ -200,6 +200,10 @@ func BenchmarkScaledownEfficiency(b *testing.B) {
 		MetricsTracker: metrics.NewTracker(
 			metrics.NewResourceUtilizationMetric(apiv1.ResourceCPU),
 			metrics.NewResourceUtilizationMetric(apiv1.ResourceMemory),
+			metrics.NewResourceFragmentationMetric(apiv1.ResourceCPU),
+			metrics.NewResourceFragmentationMetric(apiv1.ResourceMemory),
+			metrics.NewClusterCostMetric(),
+			metrics.NewNodeCountMetric(),
 		),
 		AutoscalingOptsSetup: func(opts *config.AutoscalingOptions) {
 			opts.NodeGroupDefaults.ScaleDownUtilizationThreshold = 0.75

--- a/pkg/core/bench/scaledown/efficiency/metrics/clustercost.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/clustercost.go
@@ -1,0 +1,68 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+)
+
+// clusterCostMetric computes cluster cost for every loop.
+type clusterCostMetric struct{}
+
+// NewClusterCostMetric creates a new instance of nodeCostMetric.
+func NewClusterCostMetric() *clusterCostMetric {
+	return &clusterCostMetric{}
+}
+
+func (m *clusterCostMetric) Name() string {
+	return "cluster_cost"
+}
+
+func (m *clusterCostMetric) Compute(clusterState ClusterState) (float64, error) {
+	var totalClusterCost float64
+	for _, nodeInfo := range clusterState.nodeInfos {
+		if nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		cost, err := calculateNodeCost(nodeInfo.Node())
+		if err == nil {
+			totalClusterCost += cost
+		}
+	}
+	klog.V(5).Infof("Metric: %s, Total hourly: $%.5f", m.Name(), totalClusterCost)
+	return totalClusterCost, nil
+}
+
+// Summarize reports diff < 0 if total cost decreased. If total cost increased, diff > 0.
+func (m *clusterCostMetric) Summarize(metricValues []float64) map[string]float64 {
+	first := metricValues[0]
+	last := metricValues[len(metricValues)-1]
+	costDiff := last - first
+	costDiffPerc := 0.0
+	if first > 0 {
+		costDiffPerc = (costDiff / first) * 100
+	}
+	r := map[string]float64{
+		fmt.Sprintf("%s_init", m.Name()):    first,
+		fmt.Sprintf("%s_final", m.Name()):   last,
+		fmt.Sprintf("%s_diff", m.Name()):    costDiff,
+		fmt.Sprintf("%s_%%_diff", m.Name()): costDiffPerc,
+	}
+	return r
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics/fragmentation.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/fragmentation.go
@@ -1,0 +1,107 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+func (m *resourceFragmentationMetric) computeResourceFragmentation(clusterState ClusterState) (float64, error) {
+	var totalFree, hhi float64
+	nodesFree := make(map[string]float64)
+	for _, nodeInfo := range clusterState.nodeInfos {
+		if nodeInfo == nil || nodeInfo.Node() == nil {
+			continue
+		}
+		nodeName := nodeInfo.Node().Name
+		res, err := resourceAllocatableRequested(m.resourceName, nodeInfo, clusterState.currentTime)
+		if err != nil {
+			return 0, err
+		}
+		freeOnNode := res.allocatable - res.utilization*res.allocatable
+		// may signal overcommit, where packing may be dangerous and add to the node throttling
+		if freeOnNode < 0 {
+			freeOnNode = 0
+		}
+		nodesFree[nodeName] = freeOnNode
+		totalFree += freeOnNode
+	}
+	frag := -1.0
+	if totalFree <= 0 {
+		klog.V(5).Infof("Metric %s, Total free: 0.00, HHI: N/A, Fragmentation: Undefined (cluster fully allocated)", m.Name())
+		return frag, nil
+	}
+	for _, freeOnNode := range nodesFree {
+		nodeShare := freeOnNode / totalFree
+		hhi += nodeShare * nodeShare
+	}
+	frag = 1.0 - hhi
+	klog.V(5).Infof("Metric: %s, Total free: %.2f, HHI: %.2f, Fragmentation: %.2f", m.Name(), totalFree, hhi, frag)
+	return frag, nil
+}
+
+// resourceFragmentationMetric computes fragmentation for given resource of generic ResourceName using Herfindahl-Hirschman Index.
+// HHI originally measures market concentration and competitiveness, here repurposed to measure consolidation of free resource in the cluster.
+// If HHI is lower, it indicates more competition, if higher it indicates consolidation.
+// In this context, higher values mean free resource are consolidated to fewer nodes, meaning lower fragmentation.
+// Fragmentation is therefore computed as 1-HHI.
+type resourceFragmentationMetric struct {
+	resourceName apiv1.ResourceName
+}
+
+// NewResourceFragmentationMetric creates a new instance of resourceFragmentationMetric.
+func NewResourceFragmentationMetric(rn apiv1.ResourceName) *resourceFragmentationMetric {
+	return &resourceFragmentationMetric{resourceName: rn}
+}
+
+func (m *resourceFragmentationMetric) Name() string {
+	return fmt.Sprintf("%s_fragmentation", m.resourceName.String())
+}
+
+func (m *resourceFragmentationMetric) Compute(clusterState ClusterState) (float64, error) {
+	frag, err := m.computeResourceFragmentation(clusterState)
+	if err != nil {
+		return 0, err
+	}
+	return frag, nil
+}
+
+// Summarize for resourceFragmentationMetric has to handle edge cases (fully allocated cluster).
+// For initial and final states -1 denotes fully allocated cluster - in such case, delta is reset to 0.
+// If -1 < finalDelta < 0 = fragmentation decreased. If finalDelta > 0 = fragmentation increased.
+func (m *resourceFragmentationMetric) Summarize(metricValues []float64) map[string]float64 {
+	first := metricValues[0]
+	last := metricValues[len(metricValues)-1]
+	initialDelta := first
+	finalDelta := last
+	if initialDelta == -1.0 {
+		initialDelta = 0.0
+	}
+	if finalDelta == -1.0 {
+		finalDelta = 0.0
+	}
+	fragDelta := finalDelta - initialDelta
+	r := map[string]float64{
+		fmt.Sprintf("%s_init", m.Name()):  first,
+		fmt.Sprintf("%s_final", m.Name()): last,
+		fmt.Sprintf("%s_diff", m.Name()):  fragDelta,
+	}
+	return r
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics/machine_types.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/machine_types.go
@@ -1,0 +1,115 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+type pricingInfo struct {
+	CPUPerHour         float64
+	MemoryPerHourPerGB float64
+}
+
+// getCPUPrice returns the CPU core hourly price.
+func (p pricingInfo) getCPUPrice() float64 {
+	return p.CPUPerHour
+}
+
+// getMemoryPrice returns the memory GiB hourly price.
+func (p pricingInfo) getMemoryPrice() float64 {
+	return p.MemoryPerHourPerGB
+}
+
+// machineFamily represents a cloud instances family and its pricing details.
+type machineFamily struct {
+	FamilyName  string
+	PricingInfo pricingInfo
+}
+
+// machineFamilies maps the machine family prefix to pricing information.
+// Fixed ratio of 1 CPU/h = 7.5*mem/h/GB with imaginary prices.
+var machineFamilies = map[string]*machineFamily{
+	"s": {
+		FamilyName: "s",
+		PricingInfo: pricingInfo{
+			CPUPerHour:         1,
+			MemoryPerHourPerGB: 0.13,
+		},
+	},
+	"m": {
+		FamilyName: "m",
+		PricingInfo: pricingInfo{
+			CPUPerHour:         2.5,
+			MemoryPerHourPerGB: 0.33,
+		},
+	},
+	"l": {
+		FamilyName: "l",
+		PricingInfo: pricingInfo{
+			CPUPerHour:         4.2,
+			MemoryPerHourPerGB: 0.56,
+		},
+	},
+	"xl": {
+		FamilyName: "xl",
+		PricingInfo: pricingInfo{
+			CPUPerHour:         8,
+			MemoryPerHourPerGB: 1.06,
+		},
+	},
+}
+
+// getMachineFamily retrieves the machine family of a node based on the labels.
+// if "node.kubernetes.io/instance-type" not in labels => try "beta.kubernetes.io/instance-type"
+func getMachineFamily(node *apiv1.Node) (*machineFamily, error) {
+	instanceType, ok := node.Labels[apiv1.LabelInstanceTypeStable]
+	if !ok {
+		instanceType, ok = node.Labels[apiv1.LabelInstanceType]
+		if !ok {
+			return nil, fmt.Errorf("node %s has no instance type label", node.Name)
+		}
+	}
+	chunks := strings.Split(instanceType, "-")
+	if len(chunks) == 0 {
+		return nil, fmt.Errorf("invalid instance type label value: %s for node %s", instanceType, node.Name)
+	}
+	familyName := chunks[0]
+	family, ok := machineFamilies[familyName]
+	if !ok {
+		return nil, fmt.Errorf("unknown pricing for machine family %s parsed from instance type %s, node %s", familyName, instanceType, node.Name)
+	}
+	return family, nil
+}
+
+// calculateNodeCost returns the hourly cost of the node as node_CPU_allocatable*CPU_cost + node_mem_allocatable*mem_cost.
+func calculateNodeCost(node *apiv1.Node) (float64, error) {
+	family, err := getMachineFamily(node)
+	if err != nil {
+		return 0, err
+	}
+	nodeAllocatableCPU := node.Status.Allocatable[apiv1.ResourceCPU]
+	nodeAllocatableMem := node.Status.Allocatable[apiv1.ResourceMemory]
+	cpuCores := float64(nodeAllocatableCPU.MilliValue()) / 1000.0
+	memGiB := float64(nodeAllocatableMem.MilliValue()) / (1024.0 * 1024.0 * 1024.0)
+	cpuCost := cpuCores * family.PricingInfo.getCPUPrice()
+	memCost := memGiB * family.PricingInfo.getMemoryPrice()
+	return cpuCost + memCost, nil
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics/nodecount.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/nodecount.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "fmt"
+
+// nodeCountMetric counts number of nodes in the cluster snapshot.
+type nodeCountMetric struct{}
+
+// NewNodeCountMetric creates a new instance of nodeCountMetric.
+func NewNodeCountMetric() *nodeCountMetric {
+	return &nodeCountMetric{}
+}
+
+func (m *nodeCountMetric) Name() string {
+	return "node_count"
+}
+
+func (m *nodeCountMetric) Compute(clusterState ClusterState) (float64, error) {
+	return float64(len(clusterState.nodeInfos)), nil
+}
+
+// Summarize reports diff < 0 if total number of nodes decreased. If total number of nodes increased, diff > 0.
+func (m *nodeCountMetric) Summarize(metricValues []float64) map[string]float64 {
+	first := metricValues[0]
+	last := metricValues[len(metricValues)-1]
+	nodesDiff := last - first
+	r := map[string]float64{
+		fmt.Sprintf("%s_init", m.Name()):  first,
+		fmt.Sprintf("%s_final", m.Name()): last,
+		fmt.Sprintf("%s_diff", m.Name()):  nodesDiff,
+	}
+	return r
+}

--- a/pkg/core/bench/scaledown/efficiency/metrics/utilization.go
+++ b/pkg/core/bench/scaledown/efficiency/metrics/utilization.go
@@ -104,9 +104,9 @@ func (m *resourceUtilizationMetric) Summarize(metricValues []float64) map[string
 	last := metricValues[len(metricValues)-1]
 	diff := last - first
 	r := map[string]float64{
-		fmt.Sprintf("%s_%%_init", m.Name()):     first * 100,
-		fmt.Sprintf("%s_%%_final", m.Name()):    last * 100,
-		fmt.Sprintf("%s_%%_improved", m.Name()): diff * 100,
+		fmt.Sprintf("%s_%%_init", m.Name()):  first * 100,
+		fmt.Sprintf("%s_%%_final", m.Name()): last * 100,
+		fmt.Sprintf("%s_%%_diff", m.Name()):  diff * 100,
 	}
 	return r
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR introduces three new metrics for benchmarking scaledown strategies (added in #18): 
- Cluster cost (accompanied by sample machine pricing) - aggregated individual node_cost/h.
- Resource fragmentation - how fragmented (scattered) remaining resources of given resource type are. Lower fragmentation means resources are consolidated to less nodes. Lower fragmentation could enable easier future Pod scheduling.
- Node count - total number of nodes in cluster.

The metrics are instantiated in the actual scaledown efficiency benchmark to provide a more comprehensive comparison of initial and post-scaledown cluster state. Benchmark reports initial, final values and the difference between the two. In the case of `clusterCost`, the difference is also reported as percentual difference (improvement or regression).

Existing utilization metric is updated to return its change as neutral differential, labeled with `_diff` suffix to be consistent with the rest of the metrics.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[PR#18 Benchmarking scaledown strategies]: https://github.com/kubernetes-sigs/cluster-autoscaler/pull/18 
```
