### PR TITLE
Honor scale-down-delay-after-failure for async deletion failures

### DIFF
--- a/pkg/core/static_autoscaler.go
+++ b/pkg/core/static_autoscaler.go
@@ -436,12 +436,24 @@ func (a *StaticAutoscaler) RunOnce(ctx context.Context, currentTime time.Time) c
 		if !scaleUpTriggered && a.processors.ScaleUpStatusProcessor != nil {
 			a.processors.ScaleUpStatusProcessor.Process(ctx, a.AutoscalingContext, scaleUpStatus)
 		}
+		// Gather status before scaledown status processor invocation.
+		// Node deletions run asynchronously after StartDeletion returns, so their
+		// outcomes never surface through the error returned by StartDeletion.
+		// Drain the deletion results here and refresh lastScaleDownFailTime when
+		// any of them failed, so that the cooldown configured via
+		// --scale-down-delay-after-failure is honored for such failures too.
+		nodeDeletionResults, nodeDeletionResultsAsOf := a.scaleDownActuator.DeletionResults()
+		scaleDownStatus.NodeDeleteResults = nodeDeletionResults
+		scaleDownStatus.NodeDeleteResultsAsOf = nodeDeletionResultsAsOf
+		a.scaleDownActuator.ClearResultsNotNewerThan(scaleDownStatus.NodeDeleteResultsAsOf)
+		for nodeName, nodeDeletionResult := range nodeDeletionResults {
+			if nodeDeletionResult.Err != nil {
+				logger.V(1).Info("Node deletion failed, starting scale down fail cooldown", "node", nodeName, "err", nodeDeletionResult.Err)
+				a.lastScaleDownFailTime = nodeDeletionResultsAsOf
+				break
+			}
+		}
 		if a.processors.ScaleDownStatusProcessor != nil {
-			// Gather status before scaledown status processor invocation
-			nodeDeletionResults, nodeDeletionResultsAsOf := a.scaleDownActuator.DeletionResults()
-			scaleDownStatus.NodeDeleteResults = nodeDeletionResults
-			scaleDownStatus.NodeDeleteResultsAsOf = nodeDeletionResultsAsOf
-			a.scaleDownActuator.ClearResultsNotNewerThan(scaleDownStatus.NodeDeleteResultsAsOf)
 			scaleDownStatus.SetUnremovableNodesInfo(ctx, a.scaleDownPlanner.UnremovableNodes(), a.scaleDownPlanner.NodeUtilizationMap(), a.CloudProvider)
 
 			a.processors.ScaleDownStatusProcessor.Process(ctx, a.AutoscalingContext, scaleDownStatus)

--- a/pkg/core/static_autoscaler_test.go
+++ b/pkg/core/static_autoscaler_test.go
@@ -3095,6 +3095,114 @@ func TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor(t *testing.T) {
 
 }
 
+func TestStaticAutoscalerRunOnceHonorsScaleDownDelayAfterAsyncDeletionFailure(t *testing.T) {
+	options := config.AutoscalingOptions{
+		NodeGroupDefaults: config.NodeGroupAutoscalingOptions{
+			ScaleDownUnneededTime:         -1 * time.Nanosecond, // enforce immediate scaledown/drain for ready
+			ScaleDownUnreadyTime:          -1 * time.Nanosecond, // enforce immediate scaledown/drain for unready
+			ScaleDownUtilizationThreshold: 0.5,
+			MaxNodeProvisionTime:          10 * time.Second,
+		},
+		EstimatorName:              estimator.BinpackingEstimatorName,
+		ScaleDownEnabled:           true,
+		MaxNodesTotal:              10,
+		MaxCoresTotal:              10,
+		MaxMemoryTotal:             100000,
+		ScaleDownDelayAfterFailure: 10 * time.Hour,
+	}
+	now := time.Now()
+	n1 := BuildTestNode("n1", 1000, 1000)
+	SetNodeReadyState(n1, true, now)
+	// A highly utilized pod keeps n1 from becoming a scale-down candidate, so
+	// this loop doesn't start any new deletions and we can observe how the
+	// deletion results from a previous loop are handled on their own.
+	utilizedPod := BuildTestPod("p1", 800, 800, WithNodeName("n1"))
+
+	testCases := map[string]struct {
+		deletionResult   status.NodeDeleteResult
+		wantFailCooldown bool
+	}{
+		"failed deletion starts scale down fail cooldown": {
+			// Simulate a node deletion that was started by a previous loop and
+			// failed asynchronously. Such a failure only surfaces through
+			// DeletionResults, never through the error returned by StartDeletion.
+			deletionResult: status.NodeDeleteResult{
+				Err:        errors.NewAutoscalerError(errors.TransientError, "simulated async node deletion failure"),
+				ResultType: status.NodeDeleteErrorFailedToDelete,
+			},
+			wantFailCooldown: true,
+		},
+		"successful deletion doesn't start scale down fail cooldown": {
+			deletionResult:   status.NodeDeleteResult{ResultType: status.NodeDeleteOk},
+			wantFailCooldown: false,
+		},
+	}
+
+	for testName, test := range testCases {
+		// prevent issues with scoping, we should be able to get rid of that with Go 1.22
+		test := test
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			mocks := newCommonMocks()
+			tracker := deletiontracker.NewNodeDeletionTracker(0 * time.Second)
+			tracker.StartDeletion("ng1", "n2")
+			tracker.EndDeletion(context.TODO(), "ng1", "n2", test.deletionResult)
+			mocks.nodeDeletionTracker = tracker
+
+			setupConfig := &autoscalerSetupConfig{
+				autoscalingOptions: options,
+				nodeGroups: []*nodeGroup{{
+					name:  "ng1",
+					min:   0,
+					max:   10,
+					nodes: []*apiv1.Node{n1},
+				}},
+				nodeStateUpdateTime: now,
+				mocks:               mocks,
+				clusterStateConfig: clusterstate.ClusterStateRegistryConfig{
+					OkTotalUnreadyCount: 1,
+				},
+			}
+			autoscaler, err := setupAutoscaler(setupConfig)
+			assert.NoError(t, err)
+
+			statusProcessor := &scaleDownStatusProcessorMock{}
+			autoscaler.processors.ScaleDownStatusProcessor = statusProcessor
+
+			setupConfig.mocks.readyNodeLister.SetNodes([]*apiv1.Node{n1})
+			setupConfig.mocks.allNodeLister.SetNodes([]*apiv1.Node{n1})
+			setupConfig.mocks.allPodLister.On("List").Return([]*apiv1.Pod{utilizedPod}, nil)
+			setupConfig.mocks.daemonSetLister.On("List", labels.Everything()).Return([]*appsv1.DaemonSet{}, nil)
+			setupConfig.mocks.podDisruptionBudgetLister.On("List").Return([]*policyv1.PodDisruptionBudget{}, nil)
+
+			assert.True(t, autoscaler.lastScaleDownFailTime.IsZero())
+
+			err = autoscaler.RunOnce(t.Context(), now)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, statusProcessor.called)
+
+			// The drained deletion result must have been consumed...
+			results, _ := autoscaler.scaleDownActuator.DeletionResults()
+			assert.Empty(t, results)
+
+			if test.wantFailCooldown {
+				// ...and a failure among the results must refresh
+				// lastScaleDownFailTime, so that a subsequent scale-down attempt
+				// is in cooldown while the configured
+				// --scale-down-delay-after-failure hasn't elapsed...
+				assert.False(t, autoscaler.lastScaleDownFailTime.IsZero())
+				assert.True(t, autoscaler.isScaleDownInCooldown(now.Add(time.Minute)))
+				// ...and the cooldown is lifted once it has.
+				assert.False(t, autoscaler.isScaleDownInCooldown(now.Add(11*time.Hour)))
+			} else {
+				assert.True(t, autoscaler.lastScaleDownFailTime.IsZero())
+				assert.False(t, autoscaler.isScaleDownInCooldown(now.Add(time.Minute)))
+			}
+		})
+	}
+}
+
 func TestFilterNodesFromSelectedGroups(t *testing.T) {
 	node1 := BuildTestNode("node1", 1000, 1000)
 	node1.Spec.ProviderID = "A"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes kubernetes/autoscaler#6313.

Node deletions run asynchronously: `Actuator.StartDeletion` returns an error only when node tainting fails synchronously, while the actual drain/delete work happens in goroutines. Failures from those async paths (e.g. failed pod eviction, failed node deletion at the cloud provider) are recorded through the `NodeDeletionTracker` but never propagate back to `StaticAutoscaler`, so `lastScaleDownFailTime` is never refreshed and the cooldown configured via `--scale-down-delay-after-failure` is silently bypassed after such failures.

This PR drains the deletion results at the end of every autoscaler loop (they were previously only collected when a `ScaleDownStatusProcessor` was set) and refreshes `lastScaleDownFailTime` when any of the drained results carries an error, so subsequent scale-down attempts honor the configured failure cooldown.

#### Which issue(s) this PR fixes:

Fixes kubernetes/autoscaler#6313

#### Special notes for your reviewer:

- All async deletion failures funnel through `AbortNodeDeletion` -> `NodeDeletionTracker.EndDeletion`, so draining `DeletionResults` covers every async failure path. The actuator side (failed async deletions producing `NodeDeleteErrorFailedToDelete` results) is already covered by `TestStartDeletion`.
- The new unit test injects a failed deletion result into the tracker, following the same pattern as `TestStaticAutoscalerRunOnceInvokesScaleDownStatusProcessor`, and asserts that the failure cooldown starts and expires as configured, plus that a successful deletion does not start the cooldown.
- Verified locally: `gofmt -s`, `hack/verify-boilerplate.sh`, `go vet`, and the full `go test -race ./...` suite (all packages pass).

#### Does this PR introduce a user-facing change?

```release-note
--scale-down-delay-after-failure now applies to node deletion failures that happen asynchronously (e.g. failed pod eviction or failed node removal from the cloud provider), not only to synchronous failures.
```