### PR TITLE
Update mutex lock/unlock mechanism in NodeGroupChangeObserversList

### DIFF
--- a/pkg/observers/nodegroupchange/scale_state_observer.go
+++ b/pkg/observers/nodegroupchange/scale_state_observer.go
@@ -18,6 +18,7 @@ package nodegroupchange
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -51,20 +52,23 @@ type NodeGroupChangeObserver interface {
 type NodeGroupChangeObserversList struct {
 	observers []NodeGroupChangeObserver
 	// TODO(vadasambar): consider using separate mutexes for functions not related to each other
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // Register adds new observer to the list.
 func (l *NodeGroupChangeObserversList) Register(o NodeGroupChangeObserver) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
 	l.observers = append(l.observers, o)
 }
 
 // RegisterScaleUp calls RegisterScaleUp for each observer.
 func (l *NodeGroupChangeObserversList) RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	delta int, currentTime time.Time) {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-	for _, observer := range l.observers {
+	l.mutex.RLock()
+	observers := slices.Clone(l.observers)
+	l.mutex.RUnlock()
+	for _, observer := range observers {
 		observer.RegisterScaleUp(ctx, nodeGroup, delta, currentTime)
 	}
 }
@@ -72,18 +76,20 @@ func (l *NodeGroupChangeObserversList) RegisterScaleUp(ctx context.Context, node
 // RegisterScaleDown calls RegisterScaleDown for each observer.
 func (l *NodeGroupChangeObserversList) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
 	nodeName string, currentTime time.Time, expectedDeleteTime time.Time) {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-	for _, observer := range l.observers {
+	l.mutex.RLock()
+	observers := slices.Clone(l.observers)
+	l.mutex.RUnlock()
+	for _, observer := range observers {
 		observer.RegisterScaleDown(nodeGroup, nodeName, currentTime, expectedDeleteTime)
 	}
 }
 
 // RegisterFailedScaleUp calls RegisterFailedScaleUp for each observer.
 func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup, delta int, errorInfo cloudprovider.InstanceErrorInfo, currentTime time.Time) {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-	for _, observer := range l.observers {
+	l.mutex.RLock()
+	observers := slices.Clone(l.observers)
+	l.mutex.RUnlock()
+	for _, observer := range observers {
 		observer.RegisterFailedScaleUp(ctx, nodeGroup, delta, errorInfo, currentTime)
 	}
 }
@@ -91,9 +97,10 @@ func (l *NodeGroupChangeObserversList) RegisterFailedScaleUp(ctx context.Context
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.
 func (l *NodeGroupChangeObserversList) RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup,
 	reason string, currentTime time.Time) {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-	for _, observer := range l.observers {
+	l.mutex.RLock()
+	observers := slices.Clone(l.observers)
+	l.mutex.RUnlock()
+	for _, observer := range observers {
 		observer.RegisterFailedScaleDown(nodeGroup, reason, currentTime)
 	}
 }

--- a/pkg/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
+++ b/pkg/processors/scaledowncandidates/scale_down_candidates_delay_processor.go
@@ -18,6 +18,7 @@ package scaledowncandidates
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -31,6 +32,7 @@ import (
 // ScaleDownCandidatesDelayProcessor is a processor to filter out
 // nodes according to scale down delay per nodegroup
 type ScaleDownCandidatesDelayProcessor struct {
+	mutex             sync.RWMutex
 	scaleUps          map[string]time.Time
 	scaleDowns        map[string]time.Time
 	scaleDownFailures map[string]time.Time
@@ -45,6 +47,8 @@ func (p *ScaleDownCandidatesDelayProcessor) GetPodDestinationCandidates(autoscal
 // GetScaleDownCandidates returns filter nodes based on if scale down is enabled or disabled per nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) GetScaleDownCandidates(ctx context.Context, autoscalingCtx *ca_context.AutoscalingContext,
 	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
 	logger := klog.FromContext(ctx)
 	result := []*apiv1.Node{}
 	alreadyLoggedGroups := make(map[string]bool)
@@ -98,12 +102,16 @@ func (p *ScaleDownCandidatesDelayProcessor) CleanUp() {
 // RegisterScaleUp records when the last scale up happened for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleUp(ctx context.Context, nodeGroup cloudprovider.NodeGroup,
 	_ int, currentTime time.Time) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	p.scaleUps[nodeGroup.Id()] = currentTime
 }
 
 // RegisterScaleDown records when the last scale down happened for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterScaleDown(nodeGroup cloudprovider.NodeGroup,
 	nodeName string, currentTime time.Time, _ time.Time) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	p.scaleDowns[nodeGroup.Id()] = currentTime
 }
 
@@ -114,6 +122,8 @@ func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleUp(ctx context.Co
 // RegisterFailedScaleDown records failed scale-down for a nodegroup.
 func (p *ScaleDownCandidatesDelayProcessor) RegisterFailedScaleDown(nodeGroup cloudprovider.NodeGroup,
 	reason string, currentTime time.Time) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	p.scaleDownFailures[nodeGroup.Id()] = currentTime
 }
 


### PR DESCRIPTION


#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Changed from a mutex to an RWMutex and added a new write lock to the `Register()` method in `NodeGroupChangeObserversList `.

Inside `RegisterScaleUp()`, `RegisterScaleDown()`, `RegisterFailedScaleUp()`, and `RegisterFailedScaleDown()`, a read lock is now used to read observers. The lock is immediately released after taking a clone of the observers, before iterating through the slice.

This prevents a deadlock situation that could arise where one goroutine attempts to acquire the `CSR` mutex while holding the `NodeGroupChangeObserversList` mutex, while another goroutine attempts to acquire the `NodeGroupChangeObserversList` mutex while holding the `CSR` mutex.

- Add mutex protection to `ScaleDownCandidatesDelayProcessor`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Cluster Autoscaler gets stuck in a deadlock state, causing it to freeze and stop autoscaling loops. Eventually, it is killed by kubelet after failing its liveness probe.

This is caused by a circular locking dependency between the `ClusterStateRegistry (CSR)` mutex and the `NodeGroupChangeObserversList` mutex involving the main CA goroutine and background scale-down goroutines.

The deadlock occurs via the following sequence of events:

1. [Main CA goroutine] Calls `ClusterStateRegistry.UpdateNodes()`, which locks and holds the `CSR` mutex.
2. [Scale-Down goroutine] Spawned in a previous iteration, this goroutine calls `NodeGroupChangeObserversList.RegisterScaleDown()`, which locks and holds the `NodeGroupChangeObserversList` mutex.
3. [Main CA goroutine] Progresses through `UpdateNodes()` and eventually calls `NodeGroupChangeObserversList.RegisterFailedScaleUp()`. It attempts to acquire the `NodeGroupChangeObserversList` mutex, but is forced to block because it is held by the scale-down goroutine (from Step 2).
4. [Scale-Down goroutine] Progresses through `RegisterScaleDown()` and eventually calls `ClusterStateRegistry.RegisterScaleDown()`. It attempts to acquire the `CSR` mutex, but is forced to block because it is held by the main goroutine (from Step 1).

Both goroutines await locks held by each other indefinitely, resulting in a deadlock.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a deadlock arise between CSR and NodeGroupChangeObserversList
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
