### PR TITLE
Add --unready-nodes-scope to scope the cluster-wide unready node check

### DIFF
--- a/pkg/clusterstate/clusterstate.go
+++ b/pkg/clusterstate/clusterstate.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/clusterstate/api"
 	"sigs.k8s.io/cluster-autoscaler/pkg/clusterstate/scaleupfailures"
 	"sigs.k8s.io/cluster-autoscaler/pkg/clusterstate/utils"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/core/scaledown"
 	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
 	"sigs.k8s.io/cluster-autoscaler/pkg/observers/nodegroupchange"
@@ -91,6 +92,10 @@ type ClusterStateRegistryConfig struct {
 	// Minimum number of nodes that must be unready for MaxTotalUnreadyPercentage to apply.
 	// This is to ensure that in very small clusters (e.g. 2 nodes) a single node's failure doesn't disable autoscaling.
 	OkTotalUnreadyCount int
+	// UnreadyNodesScope selects which nodes IsClusterHealthy counts. config.UnreadyNodesScopeAutoscaled
+	// restricts the check to nodes belonging to an autoscaled node group. Any other value, including the
+	// empty one, keeps the default behaviour of counting every node in the cluster.
+	UnreadyNodesScope string
 }
 
 // IncorrectNodeGroupSize contains information about how much the current size of the node group
@@ -494,10 +499,19 @@ func (csr *ClusterStateRegistry) IsClusterHealthy() bool {
 	csr.Lock()
 	defer csr.Unlock()
 
-	totalUnready := len(csr.totalReadiness.Unready)
+	unready, registered := len(csr.totalReadiness.Unready), len(csr.nodes)
+	if csr.config.UnreadyNodesScope == config.UnreadyNodesScopeAutoscaled {
+		// Nodes outside of any autoscaled node group are not tracked in perNodeGroupReadiness,
+		// so aggregating it yields the same counts restricted to the nodes CA manages.
+		unready, registered = 0, 0
+		for _, readiness := range csr.perNodeGroupReadiness {
+			unready += len(readiness.Unready)
+			registered += len(readiness.Registered)
+		}
+	}
 
-	if totalUnready > csr.config.OkTotalUnreadyCount &&
-		float64(totalUnready) > csr.config.MaxTotalUnreadyPercentage/100.0*float64(len(csr.nodes)) {
+	if unready > csr.config.OkTotalUnreadyCount &&
+		float64(unready) > csr.config.MaxTotalUnreadyPercentage/100.0*float64(registered) {
 		return false
 	}
 

--- a/pkg/clusterstate/clusterstate_test.go
+++ b/pkg/clusterstate/clusterstate_test.go
@@ -471,6 +471,85 @@ func TestTooManyUnready(t *testing.T) {
 	assert.True(t, clusterstate.IsNodeGroupHealthy(context.Background(), "ng1"))
 }
 
+func TestIsClusterHealthyUnreadyNodesScope(t *testing.T) {
+	now := time.Now()
+
+	testCases := []struct {
+		name               string
+		unreadyNodesScope  string
+		ngNodesReady       bool
+		externalNodes      int
+		externalNodesReady bool
+		wantHealthy        bool
+	}{
+		{
+			name:          "unset scope counts unready nodes outside node groups",
+			ngNodesReady:  true,
+			externalNodes: 3,
+			wantHealthy:   false,
+		},
+		{
+			name:              "cluster scope counts unready nodes outside node groups",
+			unreadyNodesScope: config.UnreadyNodesScopeCluster,
+			ngNodesReady:      true,
+			externalNodes:     3,
+			wantHealthy:       false,
+		},
+		{
+			name:              "autoscaled scope ignores unready nodes outside node groups",
+			unreadyNodesScope: config.UnreadyNodesScopeAutoscaled,
+			ngNodesReady:      true,
+			externalNodes:     3,
+			wantHealthy:       true,
+		},
+		{
+			name:               "cluster scope dilutes unready autoscaled nodes with ready nodes outside node groups",
+			unreadyNodesScope:  config.UnreadyNodesScopeCluster,
+			externalNodes:      30,
+			externalNodesReady: true,
+			wantHealthy:        true,
+		},
+		{
+			name:               "autoscaled scope counts unready autoscaled nodes against autoscaled nodes only",
+			unreadyNodesScope:  config.UnreadyNodesScopeAutoscaled,
+			externalNodes:      30,
+			externalNodesReady: true,
+			wantHealthy:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := testprovider.NewTestCloudProviderBuilder().Build()
+			provider.AddNodeGroup("ng1", 1, 10, 2)
+			var nodes []*apiv1.Node
+			for i := 0; i < 2; i++ {
+				node := BuildTestNode(fmt.Sprintf("ng1-%d", i), 1000, 1000)
+				SetNodeReadyState(node, tc.ngNodesReady, now.Add(-time.Minute))
+				provider.AddNode("ng1", node)
+				nodes = append(nodes, node)
+			}
+			for i := 0; i < tc.externalNodes; i++ {
+				node := BuildTestNode(fmt.Sprintf("external-%d", i), 1000, 1000)
+				SetNodeReadyState(node, tc.externalNodesReady, now.Add(-time.Minute))
+				// "no-ng" is not a registered node group, so the node belongs to none.
+				provider.AddNode("no-ng", node)
+				nodes = append(nodes, node)
+			}
+
+			fakeClient := &fake.Clientset{}
+			fakeLogRecorder, _ := utils.NewStatusMapRecorder(fakeClient, "kube-system", kube_record.NewFakeRecorder(5), false, "my-cool-configmap")
+			clusterstate := NewClusterStateRegistry(provider, fakeLogRecorder, newBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(config.NodeGroupAutoscalingOptions{MaxNodeProvisionTime: 15 * time.Minute}), &emptyTemplateNodeInfoRegistry{}, WithConfig(ClusterStateRegistryConfig{
+				MaxTotalUnreadyPercentage: 10,
+				OkTotalUnreadyCount:       1,
+				UnreadyNodesScope:         tc.unreadyNodesScope,
+			}))
+			assert.NoError(t, clusterstate.UpdateNodes(context.Background(), nodes, now))
+			assert.Equal(t, tc.wantHealthy, clusterstate.IsClusterHealthy())
+		})
+	}
+}
+
 func TestUnreadyLongAfterCreation(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/config/autoscaling_options.go
+++ b/pkg/config/autoscaling_options.go
@@ -145,6 +145,10 @@ type AutoscalingOptions struct {
 	MaxTotalUnreadyPercentage float64
 	// OkTotalUnreadyCount is the number of allowed unready nodes, irrespective of max-total-unready-percentage
 	OkTotalUnreadyCount int
+	// UnreadyNodesScope selects which nodes the cluster-wide unready node check counts.
+	// UnreadyNodesScopeCluster counts every node in the cluster, UnreadyNodesScopeAutoscaled
+	// counts only nodes belonging to an autoscaled node group.
+	UnreadyNodesScope string
 	// ScaleUpFromZero defines if CA should scale up when there 0 ready nodes.
 	ScaleUpFromZero bool
 	// ParallelScaleUp defines whether CA can scale up node groups in parallel.

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -54,4 +54,14 @@ const (
 	DefaultScaleDownDelayAfterFailure = 3 * time.Minute
 	// DefaultScanInterval is the default scan interval for CA
 	DefaultScanInterval = 10 * time.Second
+
+	// UnreadyNodesScopeCluster makes the cluster-wide unready node check count
+	// unready nodes across every node in the cluster.
+	UnreadyNodesScopeCluster = "cluster"
+	// UnreadyNodesScopeAutoscaled makes the cluster-wide unready node check count
+	// only the nodes that belong to an autoscaled node group.
+	UnreadyNodesScopeAutoscaled = "autoscaled"
 )
+
+// AvailableUnreadyNodesScopes is a list of available scopes for the cluster-wide unready node check.
+var AvailableUnreadyNodesScopes = []string{UnreadyNodesScopeCluster, UnreadyNodesScopeAutoscaled}

--- a/pkg/config/flags/flags.go
+++ b/pkg/config/flags/flags.go
@@ -122,6 +122,7 @@ func (p *AutoscalingFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&p.o.MaxBulkSoftTaintTime, "max-bulk-soft-taint-time", 3*time.Second, "Maximum duration of tainting/untainting nodes as PreferNoSchedule at the same time.")
 	fs.Float64Var(&p.o.MaxTotalUnreadyPercentage, "max-total-unready-percentage", 45, "Maximum percentage of unready nodes in the cluster.  After this is exceeded, CA halts operations")
 	fs.IntVar(&p.o.OkTotalUnreadyCount, "ok-total-unready-count", 3, "Number of allowed unready nodes, irrespective of max-total-unready-percentage")
+	fs.StringVar(&p.o.UnreadyNodesScope, "unready-nodes-scope", config.UnreadyNodesScopeCluster, "Which nodes the cluster-wide unready check gating autoscaling counts. Available values: ["+strings.Join(config.AvailableUnreadyNodesScopes, ",")+"]. \""+config.UnreadyNodesScopeCluster+"\" counts every node in the cluster, \""+config.UnreadyNodesScopeAutoscaled+"\" counts only nodes belonging to an autoscaled node group.")
 	fs.BoolVar(&p.o.ScaleUpFromZero, "scale-up-from-zero", true, "Should CA scale up when there are 0 ready nodes.")
 	fs.BoolVar(&p.o.ParallelScaleUp, "parallel-scale-up", false, "Whether to allow parallel node groups scale up. Experimental: may not work on some cloud providers, enable at your own risk.")
 	fs.DurationVar(&p.o.NodeGroupDefaults.MaxNodeProvisionTime, "max-node-provision-time", 15*time.Minute, "The default maximum time CA waits for node to be provisioned - the value can be overridden per node group")
@@ -288,6 +289,10 @@ func (p *AutoscalingFlags) Options() (config.AutoscalingOptions, error) {
 
 	if p.o.PredicateParallelism < 1 {
 		return config.AutoscalingOptions{}, fmt.Errorf("Invalid value for --predicate-parallelism flag: %d", p.o.PredicateParallelism)
+	}
+
+	if !slices.Contains(config.AvailableUnreadyNodesScopes, p.o.UnreadyNodesScope) {
+		return config.AutoscalingOptions{}, fmt.Errorf("Invalid value for --unready-nodes-scope flag: %q, available values: [%s]", p.o.UnreadyNodesScope, strings.Join(config.AvailableUnreadyNodesScopes, ","))
 	}
 
 	if p.o.DynamicResourceAllocationEnabled == false {

--- a/pkg/config/flags/flags_test.go
+++ b/pkg/config/flags/flags_test.go
@@ -175,6 +175,13 @@ func TestCreateAutoscalingOptions(t *testing.T) {
 			},
 		},
 		{
+			testName: "UnreadyNodesScope defaults to the whole cluster when the flag isn't passed",
+			flags:    []string{},
+			wantOptionsAsserter: func(t *testing.T, gotOptions config.AutoscalingOptions) {
+				assert.Equal(t, config.UnreadyNodesScopeCluster, gotOptions.UnreadyNodesScope)
+			},
+		},
+		{
 			testName: "CSI node aware scheduling is enabled by default",
 			flags:    []string{},
 			wantOptionsAsserter: func(t *testing.T, gotOptions config.AutoscalingOptions) {
@@ -298,6 +305,7 @@ func TestAutoscalingFlagsAllPossible(t *testing.T) {
 				"--max-bulk-soft-taint-time=1s",
 				"--max-total-unready-percentage=30",
 				"--ok-total-unready-count=5",
+				"--unready-nodes-scope=autoscaled",
 				"--scale-up-from-zero=false",
 				"--parallel-scale-up=true",
 				"--max-node-provision-time=10m",
@@ -422,6 +430,7 @@ func TestAutoscalingFlagsAllPossible(t *testing.T) {
 				assert.Equal(t, 1*time.Second, opts.MaxBulkSoftTaintTime)
 				assert.Equal(t, float64(30), opts.MaxTotalUnreadyPercentage)
 				assert.Equal(t, 5, opts.OkTotalUnreadyCount)
+				assert.Equal(t, config.UnreadyNodesScopeAutoscaled, opts.UnreadyNodesScope)
 				assert.False(t, opts.ScaleUpFromZero)
 				assert.True(t, opts.ParallelScaleUp)
 				assert.Equal(t, 10*time.Minute, opts.NodeGroupDefaults.MaxNodeProvisionTime)
@@ -648,6 +657,22 @@ func TestAutoscalingFlagsValidationEdgeCases(t *testing.T) {
 		},
 		"InvalidCoresTotal": {
 			Flags:   []string{"--cores-total=10:5"},
+			WantErr: true,
+		},
+		"UnreadyNodesScopeCluster": {
+			Flags:   []string{"--unready-nodes-scope=cluster"},
+			WantErr: false,
+		},
+		"UnreadyNodesScopeAutoscaled": {
+			Flags:   []string{"--unready-nodes-scope=autoscaled"},
+			WantErr: false,
+		},
+		"InvalidUnreadyNodesScope": {
+			Flags:   []string{"--unready-nodes-scope=nodegroup"},
+			WantErr: true,
+		},
+		"EmptyUnreadyNodesScope": {
+			Flags:   []string{"--unready-nodes-scope="},
 			WantErr: true,
 		},
 	}

--- a/pkg/core/static_autoscaler.go
+++ b/pkg/core/static_autoscaler.go
@@ -147,6 +147,15 @@ func (callbacks *staticAutoscalerProcessorCallbacks) reset() {
 	callbacks.extraValues = make(map[string]interface{})
 }
 
+// clusterStateRegistryConfig maps the autoscaling options onto the cluster state registry config.
+func clusterStateRegistryConfig(opts config.AutoscalingOptions) clusterstate.ClusterStateRegistryConfig {
+	return clusterstate.ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: opts.MaxTotalUnreadyPercentage,
+		OkTotalUnreadyCount:       opts.OkTotalUnreadyCount,
+		UnreadyNodesScope:         opts.UnreadyNodesScope,
+	}
+}
+
 // NewStaticAutoscaler creates an instance of Autoscaler filled with provided parameters
 func NewStaticAutoscaler(
 	opts config.AutoscalingOptions,
@@ -175,10 +184,7 @@ func NewStaticAutoscaler(
 
 	templateNodeInfoRegistry := nodeinfosprovider.NewTemplateNodeInfoRegistry(processors.TemplateNodeInfoProvider)
 
-	clusterStateConfig := clusterstate.ClusterStateRegistryConfig{
-		MaxTotalUnreadyPercentage: opts.MaxTotalUnreadyPercentage,
-		OkTotalUnreadyCount:       opts.OkTotalUnreadyCount,
-	}
+	clusterStateConfig := clusterStateRegistryConfig(opts)
 	// Register the scale up failures registry before CSR so that it is updated before the node group is sent to the backoff.
 	processors.ScaleStateNotifier.Register(scaleUpFailuresRegistry)
 	clusterStateRegistry := clusterstate.NewNotifiedClusterStateRegistry(cloudProvider, autoscalingKubeClients.LogRecorder, backoff, processors.NodeGroupConfigProcessor, templateNodeInfoRegistry, clusterstate.WithScaleUpFailuresRegistry(scaleUpFailuresRegistry), clusterstate.WithConfig(clusterStateConfig), clusterstate.WithAsyncNodeGroupStateChecker(processors.AsyncNodeGroupStateChecker), clusterstate.WithScaleStateNotifier(processors.ScaleStateNotifier))

--- a/pkg/core/static_autoscaler_test.go
+++ b/pkg/core/static_autoscaler_test.go
@@ -3998,3 +3998,17 @@ func TestShouldScaleDown(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterStateRegistryConfig(t *testing.T) {
+	opts := config.AutoscalingOptions{
+		MaxTotalUnreadyPercentage: 30,
+		OkTotalUnreadyCount:       5,
+		UnreadyNodesScope:         config.UnreadyNodesScopeAutoscaled,
+	}
+	want := clusterstate.ClusterStateRegistryConfig{
+		MaxTotalUnreadyPercentage: 30,
+		OkTotalUnreadyCount:       5,
+		UnreadyNodesScope:         config.UnreadyNodesScopeAutoscaled,
+	}
+	assert.Equal(t, want, clusterStateRegistryConfig(opts))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`IsClusterHealthy()` counts unready nodes across every node in the cluster, including nodes that belong to no autoscaled node group:

```go
totalUnready := len(csr.totalReadiness.Unready)
if totalUnready > csr.config.OkTotalUnreadyCount &&
	float64(totalUnready) > csr.config.MaxTotalUnreadyPercentage/100.0*float64(len(csr.nodes)) {
	return false
}
```

On clusters that mix autoscaled node groups with a fleet of externally managed nodes joined by other means, unready nodes that CA can neither reason about nor act on halt autoscaling for the node groups it does manage.

The impact is larger than the pause itself. The same branch in `RunOnce` calls `scaleDownPlanner.CleanUpUnneededNodes()` before returning, which resets unneeded-since tracking. External-fleet events recurring more often than `--scale-down-unneeded-time` therefore starve scale-down indefinitely, while the status ConfigMap reports the cluster healthy between episodes — so the symptom is "scale-down silently never happens" rather than an obvious outage.

The existing knobs cannot be tuned around this:

- The check is a proportion of *all* nodes, so the threshold needed to be immune to the external fleet is a function of that fleet's share of the cluster. As the fleet grows to dominate the node count, the required value approaches the point where the check can never fire at all — there is no setting that both ignores the external fleet and leaves the check meaningful.
- External-node failures are typically correlated rather than independent. A single connectivity or control-plane event can take the whole fleet unready simultaneously, so the threshold has to clear the entire fleet, not some fraction of it.
- `--max-total-unready-percentage` and `--ok-total-unready-count` are both shared with `IsNodeGroupHealthy`, which needs them to move in the opposite direction to stay useful.

This PR adds a flag that scopes the cluster-wide check to the nodes CA manages, defaulting to today's behaviour:

```
--unready-nodes-scope=cluster|autoscaled     (default: cluster)
```

When set to `autoscaled`, `IsClusterHealthy()` aggregates `Unready` and registered-node counts over `csr.perNodeGroupReadiness`, and also includes registered nodes whose node-group lookup failed.

`updateReadinessStats` distinguishes a successful `NodeGroupForNode` lookup returning no group from a failed lookup. Nodes confirmed to be outside autoscaled node groups remain excluded. Nodes whose lookup fails have unknown ownership, so their names are tracked separately and included in the scoped check.

The failed-lookup nodes use their existing classification in `totalReadiness`, preserving startup, deletion, and suspension handling. The lookup-error set is rebuilt on each readiness refresh so recovered or removed nodes do not remain in the fallback accounting. Known node groups continue to use the same readiness data consumed by `IsNodeGroupHealthy`.

Readiness collection resolves node-group ownership and the startup timeout once per registered node before updating either summary. This keeps per-group and cluster-wide classification consistent under transient lookup failures. Each node starts with the existing 15-minute fallback timeout, so nodes without a resolved group or startup options cannot inherit the preceding node group's timeout.

**Backward compatibility.** The flag defaults to `cluster`. The zero value of the new `ClusterStateRegistryConfig.UnreadyNodesScope` field also selects cluster-wide accounting, so downstream library consumers retain that scope without changes. The correction to startup-time classification applies to both scopes.

**Scope.** `IsNodeGroupHealthy` is unchanged. The `ClusterWide` node counts in the status ConfigMap continue to report whole-cluster inventory — only the health verdict is scoped — since `api.ClusterHealthCondition.NodeCounts` is defined as an inventory of nodes in the cluster and CA never reads the ConfigMap back to make decisions. That interaction is called out in the companion FAQ PR.

**Tests.** Regression coverage includes:

- Default and explicit scopes, flag validation, and options-to-registry wiring.
- Unready managed and external nodes, including the percentage denominator and dilution by a ready external fleet.
- Complete and partial ownership lookup failures, ready failed-lookup nodes in the denominator, and startup/deletion/suspension handling.
- Readiness refresh while failures persist, lookup recovery, and removal from Kubernetes while cloud instances remain.
- Consistent per-group and cluster-wide classification under transient lookup errors, and startup grace independent of node ordering.

#### Which issue(s) this PR fixes:

Fixes kubernetes/autoscaler#10161

#### Special notes for your reviewer:

Documentation lives in `kubernetes/autoscaler`, which still owns `cluster-autoscaler/FAQ.md` after the core was split out. Companion PR: https://github.com/kubernetes/autoscaler/pull/10226

`clusterStateRegistryConfig()` was extracted from the body of `NewStaticAutoscaler` so that the `AutoscalingOptions` → `ClusterStateRegistryConfig` mapping is unit-testable; without it, deleting the new mapping line leaves every test green while the shipped flag does nothing. It is otherwise a behaviour-preserving move of the existing struct literal.

I am happy to adjust the flag name or the value vocabulary if maintainers prefer something else — the semantics are the part I care about.

#### Does this PR introduce a user-facing change?

```release-note
Added `--unready-nodes-scope=cluster|autoscaled` (default: `cluster`, matching previous behaviour). When set to `autoscaled`, the cluster-wide unready node health check that gates autoscaling counts nodes belonging to autoscaled node groups and nodes whose group lookup failed, so nodes confirmed to be outside every node group no longer halt autoscaling for the node groups Cluster Autoscaler manages. Readiness accounting also uses a consistent startup timeout per node, preventing transient lookup errors or node ordering from producing inconsistent health results.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: https://github.com/kubernetes/autoscaler/pull/10226
```
