### PR TITLE
e2e: fix KWOK smoke test namespace

### DIFF
--- a/test/e2e/clusterautoscaling_test.go
+++ b/test/e2e/clusterautoscaling_test.go
@@ -37,7 +37,7 @@ func TestClusterAutoscaling(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fake-pod",
-			Namespace: "default",
+			Namespace: testEnv.EnvConf().Namespace(),
 			Labels: map[string]string{
 				"app": "fake-pod",
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Updates the `fake-pod` definition in `TestClusterAutoscaling` to use `testEnv.EnvConf().Namespace()` instead of the hardcoded `"default"` namespace, preventing test workloads from polluting the default namespace.

#### Which issue(s) this PR fixes:
Relates to #82

#### Special notes for your reviewer:
Run locally with:
```bash
go test -v -tags e2e -count=1 -run TestClusterAutoscaling ./test/e2e