### PR TITLE
Fix GPU detection for NVIDIA MIG resources

### DIFF
--- a/pkg/processors/customresources/gpu_processor.go
+++ b/pkg/processors/customresources/gpu_processor.go
@@ -117,8 +117,19 @@ func (p *GpuCustomResourcesProcessor) GetNodeGpuTarget(ctx context.Context, auto
 		logger.Error(err, "Failed to build template for getting GPU estimation for node", "node", klog.KObj(node))
 		return CustomResourceTarget{}, errors.ToAutoscalerError(errors.CloudProviderError, err)
 	}
+	gpuConfig := autoscalingCtx.CloudProvider.GetNodeGpuConfig(ctx, node)
+	if gpuConfig != nil && gpuConfig.ExtendedResourceName != "" {
+		if gpuCapacity, found := template.Node().Status.Capacity[gpuConfig.ExtendedResourceName]; found {
+			return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
+		}
+	}
 	for _, gpuVendorResourceName := range gpu.GPUVendorResourceNames {
 		if gpuCapacity, found := template.Node().Status.Capacity[gpuVendorResourceName]; found {
+			return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
+		}
+	}
+	for resourceName, gpuCapacity := range template.Node().Status.Capacity {
+		if gpu.IsGPUResource(resourceName) {
 			return CustomResourceTarget{gpuLabel, gpuCapacity.Value()}, nil
 		}
 	}

--- a/pkg/processors/customresources/gpu_processor_test.go
+++ b/pkg/processors/customresources/gpu_processor_test.go
@@ -26,9 +26,12 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
 	testprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
 	ca_context "sigs.k8s.io/cluster-autoscaler/pkg/context"
+	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/gpu"
+	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
 )
 
 const (
@@ -68,6 +71,16 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 	nodeGpuReady.Status.Allocatable[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
 	nodeGpuReady.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
 	expectedReadiness[nodeGpuReady.Name] = true
+
+	nodeMigGpuReady := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "nodeMigGpuReady", Labels: gpuLabels, CreationTimestamp: metav1.NewTime(start)},
+		Status: apiv1.NodeStatus{
+			Capacity:    apiv1.ResourceList{"nvidia.com/mig-2g.24gb": *resource.NewQuantity(1, resource.DecimalSI)},
+			Allocatable: apiv1.ResourceList{"nvidia.com/mig-2g.24gb": *resource.NewQuantity(1, resource.DecimalSI)},
+			Conditions:  []apiv1.NodeCondition{readyCondition},
+		},
+	}
+	expectedReadiness[nodeMigGpuReady.Name] = true
 
 	nodeGpuUnready := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -169,6 +182,7 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 
 	initialReadyNodes := []*apiv1.Node{
 		nodeGpuReady,
+		nodeMigGpuReady,
 		nodeGpuUnready,
 		nodeGpuUnready2,
 		nodeDirectXReady,
@@ -178,6 +192,7 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 	}
 	initialAllNodes := []*apiv1.Node{
 		nodeGpuReady,
+		nodeMigGpuReady,
 		nodeGpuUnready,
 		nodeGpuUnready2,
 		nodeDirectXReady,
@@ -210,4 +225,54 @@ func TestFilterOutNodesWithUnreadyResources(t *testing.T) {
 			assert.Equal(t, node.Status.Conditions[0].Status, apiv1.ConditionFalse, fmt.Sprintf("Unexpected ready condition value for node %s", node.Name))
 		}
 	}
+}
+
+func TestGetNodeGpuTargetForStaticMigNode(t *testing.T) {
+	node := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "static-mig-node", Labels: map[string]string{GPULabel: "nvidia-h100"}},
+		Status: apiv1.NodeStatus{Allocatable: apiv1.ResourceList{
+			"nvidia.com/mig-2g.24gb": *resource.NewQuantity(2, resource.DecimalSI),
+		}},
+	}
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider}
+
+	target, err := (&GpuCustomResourcesProcessor{}).GetNodeGpuTarget(context.Background(), autoscalingCtx, node, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, CustomResourceTarget{ResourceType: "nvidia-h100", ResourceCount: 2}, target)
+}
+
+func TestGetNodeGpuTargetForStaticNodeWithoutGpuCapacity(t *testing.T) {
+	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "static-unready-gpu-node", Labels: map[string]string{GPULabel: "nvidia-h100"},
+	}}
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider}
+
+	_, err := (&GpuCustomResourcesProcessor{}).GetNodeGpuTarget(context.Background(), autoscalingCtx, node, nil)
+
+	assert.Error(t, err)
+}
+
+func TestGetNodeGpuTargetUsesCloudProviderResourceInTemplate(t *testing.T) {
+	provider := testprovider.NewTestCloudProviderBuilder().
+		WithNodeGpuConfig(func(node *apiv1.Node) *cloudprovider.GpuConfig {
+			return &cloudprovider.GpuConfig{ExtendedResourceName: "example.com/custom-gpu"}
+		}).
+		Build()
+	node := test.BuildTestNode("node-with-gpu-label", 1000, 1000)
+	node.Labels[GPULabel] = "custom-gpu"
+	templateNode := test.BuildTestNode("template-with-custom-gpu", 1000, 1000)
+	templateNode.Status.Capacity["example.com/custom-gpu"] = *resource.NewQuantity(3, resource.DecimalSI)
+	nodeGroup := provider.BuildNodeGroup("custom-gpu-group", 1, 10, 1, true, false, "machine", nil)
+	provider.SetMachineTemplates(map[string]*framework.NodeInfo{
+		nodeGroup.Id(): framework.NewNodeInfo(templateNode, nil),
+	})
+	autoscalingCtx := &ca_context.AutoscalingContext{CloudProvider: provider}
+
+	target, err := (&GpuCustomResourcesProcessor{}).GetNodeGpuTarget(context.Background(), autoscalingCtx, node, nodeGroup)
+
+	assert.NoError(t, err)
+	assert.Equal(t, CustomResourceTarget{ResourceType: "custom-gpu", ResourceCount: 3}, target)
 }

--- a/pkg/utils/gpu/gpu.go
+++ b/pkg/utils/gpu/gpu.go
@@ -19,6 +19,7 @@ package gpu
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -50,6 +51,17 @@ var GPUVendorResourceNames = []apiv1.ResourceName{
 	ResourceIntelGPU,
 	ResourceAMDGPU,
 	ResourceDirectX,
+}
+
+// IsGPUResource returns true for known GPU resources and NVIDIA extended resources.
+// NVIDIA uses additional resource names for MIG and time-sliced devices.
+func IsGPUResource(resourceName apiv1.ResourceName) bool {
+	for _, gpuVendorResourceName := range GPUVendorResourceNames {
+		if resourceName == gpuVendorResourceName {
+			return true
+		}
+	}
+	return strings.HasPrefix(string(resourceName), "nvidia.com/")
 }
 
 const (
@@ -135,12 +147,17 @@ func NodeHasGpu(GPULabel string, node *apiv1.Node) bool {
 }
 
 // NodeHasGpuAllocatable returns the GPU allocatable value and whether the node has GPU allocatable resources.
-// It checks all known GPU vendor resource names and returns the first non-zero allocatable GPU value found.
+// It checks known GPU vendor resource names first, then other NVIDIA extended resources.
 func NodeHasGpuAllocatable(node *apiv1.Node) (gpuAllocatableValue int64, hasGpuAllocatable bool) {
 	for _, gpuVendorResourceName := range GPUVendorResourceNames {
 		gpuAllocatable, found := node.Status.Allocatable[gpuVendorResourceName]
 		if found && !gpuAllocatable.IsZero() {
 			return gpuAllocatable.Value(), true
+		}
+	}
+	for resourceName, allocatable := range node.Status.Allocatable {
+		if IsGPUResource(resourceName) && !allocatable.IsZero() {
+			return allocatable.Value(), true
 		}
 	}
 	return 0, false
@@ -149,8 +166,8 @@ func NodeHasGpuAllocatable(node *apiv1.Node) (gpuAllocatableValue int64, hasGpuA
 // PodRequestsGpu returns true if a given pod has GPU request.
 func PodRequestsGpu(pod *apiv1.Pod) bool {
 	podRequests := podutils.PodRequests(pod)
-	for _, gpuVendorResourceName := range GPUVendorResourceNames {
-		if _, found := podRequests[gpuVendorResourceName]; found {
+	for resourceName := range podRequests {
+		if IsGPUResource(resourceName) {
 			return true
 		}
 	}
@@ -158,15 +175,19 @@ func PodRequestsGpu(pod *apiv1.Pod) bool {
 }
 
 // DetectNodeGPUResourceName inspects the node's allocatable resources and returns the first
-// known GPU extended resource name that has non-zero allocatable. Falls back to Nvidia for
-// backward compatibility if none are found but a GPU label is present.
+// known GPU extended resource name that has non-zero allocatable. Known resource names are
+// preferred for deterministic results. Falls back to Nvidia if none are found.
 func DetectNodeGPUResourceName(node *apiv1.Node) apiv1.ResourceName {
 	for _, rn := range GPUVendorResourceNames {
 		if qty, ok := node.Status.Allocatable[rn]; ok && !qty.IsZero() {
 			return rn
 		}
 	}
-	// Fallback: preserve previous behavior (defaulting to Nvidia) if label existed
+	for resourceName, allocatable := range node.Status.Allocatable {
+		if IsGPUResource(resourceName) && !allocatable.IsZero() {
+			return resourceName
+		}
+	}
 	return ResourceNvidiaGPU
 }
 

--- a/pkg/utils/gpu/gpu_test.go
+++ b/pkg/utils/gpu/gpu_test.go
@@ -77,15 +77,43 @@ func TestNodeHasGpu(t *testing.T) {
 		},
 	}
 	assert.False(t, gpu.NodeHasGpu(GPULabel, nodeNoGpu))
+
+	nodeWithMigGpu := test.BuildTestNode("nodeWithMigGpu", 1000, 1000)
+	nodeWithMigGpu.Status.Allocatable["nvidia.com/mig-2g.24gb"] = *resource.NewQuantity(1, resource.DecimalSI)
+	assert.True(t, gpu.NodeHasGpu(GPULabel, nodeWithMigGpu))
+}
+
+func TestIsGPUResource(t *testing.T) {
+	testCases := []struct {
+		name         string
+		resourceName apiv1.ResourceName
+		want         bool
+	}{
+		{name: "known GPU", resourceName: gpu.ResourceNvidiaGPU, want: true},
+		{name: "MIG GPU", resourceName: "nvidia.com/mig-2g.24gb", want: true},
+		{name: "time-sliced GPU", resourceName: "nvidia.com/gpu.shared", want: true},
+		{name: "unrelated resource", resourceName: "example.com/fpga", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, gpu.IsGPUResource(tc.resourceName))
+		})
+	}
 }
 
 func TestPodRequestsGpu(t *testing.T) {
 	podNoGpu := test.BuildTestPod("podNoGpu", 0, 1000)
 	podWithGpu := test.BuildTestPod("pod1AnyGpu", 0, 1000)
+	podWithMigGpu := test.BuildTestPod("podWithMigGpu", 0, 1000)
+	podWithSharedGpu := test.BuildTestPod("podWithSharedGpu", 0, 1000)
 	podWithGpu.Spec.Containers[0].Resources.Requests[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	podWithMigGpu.Spec.Containers[0].Resources.Requests["nvidia.com/mig-2g.24gb"] = *resource.NewQuantity(1, resource.DecimalSI)
+	podWithSharedGpu.Spec.Containers[0].Resources.Requests["nvidia.com/gpu.shared"] = *resource.NewQuantity(1, resource.DecimalSI)
 
 	assert.False(t, gpu.PodRequestsGpu(podNoGpu))
 	assert.True(t, gpu.PodRequestsGpu(podWithGpu))
+	assert.True(t, gpu.PodRequestsGpu(podWithMigGpu))
+	assert.True(t, gpu.PodRequestsGpu(podWithSharedGpu))
 }
 
 func TestGetGpuInfoForMetrics(t *testing.T) {
@@ -279,6 +307,21 @@ func TestDetectNodeGPUResourceName(t *testing.T) {
 				},
 			},
 			expectedResourceName: gpu.ResourceAMDGPU,
+		},
+		{
+			name: "nvidia MIG GPU",
+			node: &apiv1.Node{Status: apiv1.NodeStatus{Allocatable: apiv1.ResourceList{
+				"nvidia.com/mig-2g.24gb": *resource.NewQuantity(2, resource.DecimalSI),
+			}}},
+			expectedResourceName: "nvidia.com/mig-2g.24gb",
+		},
+		{
+			name: "known resource takes precedence",
+			node: &apiv1.Node{Status: apiv1.NodeStatus{Allocatable: apiv1.ResourceList{
+				gpu.ResourceNvidiaGPU:   *resource.NewQuantity(1, resource.DecimalSI),
+				"nvidia.com/gpu.shared": *resource.NewQuantity(4, resource.DecimalSI),
+			}}},
+			expectedResourceName: gpu.ResourceNvidiaGPU,
 		},
 		{
 			name: "test default gpu resource name",


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Recognizes NVIDIA MIG and time-sliced extended resources as GPU resources. Without this, nodes advertising resources such as `nvidia.com/mig-*` can be treated as having an unready GPU and block Cluster Autoscaler scale-up.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/autoscaler/issues/8095

#### Special notes for your reviewer:

This migrates https://github.com/kubernetes/autoscaler/pull/9673 to the new Cluster Autoscaler repository and adds coverage for static MIG nodes.

#### Does this PR introduce a user-facing change?

```release-note
Fix Cluster Autoscaler GPU detection for NVIDIA MIG and time-sliced resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
