### PR TITLE
dependabot: clean up GCE and Azure related config, improve labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,7 @@ updates:
     - dependency-name: "k8s.io/sample-cli-plugin"
     - dependency-name: "k8s.io/sample-controller"
   labels:
-    - "ok-to-test"
     - "area/cluster-autoscaler"
     - "area/dependency"
+    - "ok-to-test"
+    - "release-note-none"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,18 +22,6 @@ updates:
     prefix: "dependabot"
     include: scope
   ignore:
-    # Update providers manually.
-    # TODO(Choraden): Cleanup this after removal of GCE and Azure cloudproviders.
-    - dependency-name: "k8s.io/cloud-provider-gcp"
-    - dependency-name: "k8s.io/cloud-provider-gcp/*"
-    - dependency-name: "cloud.google.com/go/compute"
-    - dependency-name: "cloud.google.com/go/compute/*"
-    # Update dependencies exclusively used by providers manually
-    - dependency-name: "golang.org/x/oauth2"
-    - dependency-name: "golang.org/x/sys"
-    - dependency-name: "google.golang.org/api"
-    - dependency-name: "gopkg.in/gcfg.v1"
-    - dependency-name: "sigs.k8s.io/yaml"
     # Maintain k8s version skew compatibility manually.
     - dependency-name: "k8s.io/kubernetes"
     # Maintain k8s.io staging dependencies manually.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR cleans up GCE and Azure related config. It also enables adding release-note-none label to dependabot PRs to streamline the review and merging proces. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
