### PR TITLE
test(e2e): add sequential KWOK scale-down tests (unneeded node & PDB)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ e2e-install-ca: image-kwok
 		--set tolerations[0].key=node-role.kubernetes.io/control-plane \
 		--set tolerations[0].operator=Exists \
 		--set tolerations[0].effect=NoSchedule \
+		--set extraArgs.scale-down-unneeded-time=10s \
+		--set extraArgs.scale-down-delay-after-add=0s \
+		--set extraArgs.unremovable-node-recheck-timeout=0s \
+		--set extraArgs.enable-csi-node-aware-scheduling=false
 
 .PHONY: e2e-teardown
 e2e-teardown:

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -1,0 +1,144 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownReschedulingPodAllowedByPDB(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Pods protected by PDB. Both fit on 1 node (1000m and 2000m on 12-core node).
+	pdbPod1 := NewTestPodWithResources("pdb-pod-1", ns, "1000m", "500Mi")
+	pdbPod1.Labels["app"] = "pdb-test"
+	pdbPod1.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	pdbPod2 := NewTestPodWithResources("pdb-pod-2", ns, "2000m", "500Mi")
+	pdbPod2.Labels["app"] = "pdb-test"
+	pdbPod2.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	// Filler pod consumes 10 cores on the first node, leaving only 1 core free (12 - 1 - 10 = 1 core)
+	// which prevents pdbPod2 (2 cores) from fitting, forcing it to trigger scale-up of a second node.
+	fillerPod := NewTestPodWithResources("filler-pod", ns, "10000m", "500Mi")
+
+	minAvailable := intstr.FromInt(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pdb-test-budget",
+			Namespace: ns,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "pdb-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down When Rescheduling A Pod Is Required And PDB Allows For It").
+		Assess("scale down when rescheduling a pod is required and pdb allows for it", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB allowing at most 1 pod disrupted (minAvailable=1 with 2 replicas)
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB: %v", err)
+			}
+
+			// Step 1: Create pdbPod1 and fillerPod to fill the first node
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// Wait for the first node to become ready and pods scheduled
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			err = WaitForPodsScheduled(ctx, client, []*corev1.Pod{pdbPod1, fillerPod}, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pods were not scheduled: %v", err)
+			}
+
+			// Step 2: Create pdbPod2 which cannot fit on the first node (needs 2 cores, only 1 core free)
+			// forcing scale-up of a second node.
+			err = client.Resources().Create(ctx, pdbPod2)
+			if err != nil {
+				t.Fatalf("failed to create pod %s: %v", pdbPod2.Name, err)
+			}
+
+			// Wait for both nodes to become ready and pdbPod2 scheduled on the second node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, pdbPod2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod %s was not scheduled: %v", pdbPod2.Name, err)
+			}
+
+			// Step 3: Delete filler pod so the first node now has plenty of room (11 cores free)
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should drain pdbPod2 (allowed by PDB) and scale down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down from 2 nodes to 1 node: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pdbPod1, fillerPod, pdbPod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+const (
+	kwokTaintKey      = "kwok-provider"
+	nodeGroupLabelKey = "kwok-nodegroup"
+	defaultNodeGroup  = "kind-worker"
+)
+
+// NewTestPod creates a test pod configuration targeted at kind-worker.
+func NewTestPod(name, namespace string) *corev1.Pod {
+	return NewTestPodWithResources(name, namespace, "500m", "500Mi")
+}
+
+// NewTestPodWithResources creates a test pod configuration with custom CPU and memory requests.
+func NewTestPodWithResources(name, namespace, cpu, memory string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "fake-container",
+					Image: "fake-image",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(cpu),
+							corev1.ResourceMemory: resource.MustParse(memory),
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				nodeGroupLabelKey: defaultNodeGroup,
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      kwokTaintKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+}
+
+// CleanUpNodeGroup deletes all fake nodes for the given nodeGroup and waits until count is 0.
+func CleanUpNodeGroup(ctx context.Context, client klient.Client, nodeGroup string) error {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return err
+	}
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			n := node
+			_ = client.Resources().Delete(ctx, &n)
+		}
+	}
+	return WaitForNodeCount(ctx, client, nodeGroup, 0, 30*time.Second)
+}
+
+// TeardownPodAndNodeGroup deletes the test pods, waits for them to be deleted,
+// waits for Cluster Autoscaler to scale down the node naturally (to keep CA state synchronized),
+// and performs forced node cleanup if CA didn't scale down in time.
+func TeardownPodAndNodeGroup(ctx context.Context, client klient.Client, pods []*corev1.Pod, nodeGroup string) {
+	for _, pod := range pods {
+		if pod != nil {
+			_ = client.Resources().Delete(ctx, pod)
+		}
+	}
+	_ = WaitForPodsDeleted(ctx, client, pods, podDeletionTimeout)
+	// Allow CA to scale down the empty node naturally
+	_ = WaitForNodeCount(ctx, client, nodeGroup, 0, 45*time.Second)
+	_ = CleanUpNodeGroup(ctx, client, nodeGroup)
+}
+
+// CountNodeGroupNodes returns the number of nodes currently matching the nodeGroup.
+func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup string) (int, error) {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/test/e2e/scaledown_test.go
+++ b/test/e2e/scaledown_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownUnneededNode(t *testing.T) {
+	pod := NewTestPod("scaledown-test-pod", testEnv.EnvConf().Namespace())
+
+	feature := features.New("Scale Down Unneeded Node").
+		Assess("scale down empty node after pod deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Step 1: Create pod to trigger scale up
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod not scheduled: %v", err)
+			}
+
+			// Wait for node count to increase to 1 and be Ready
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("node did not become ready: %v", err)
+			}
+
+			// Step 2: Delete pod to make node unneeded
+			err = client.Resources().Delete(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to delete pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+
+			// Step 3: Wait for scale down to delete the unneeded node back to 0
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 0, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("node was not scaled down after pod deletion: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/scaleup_test.go
+++ b/test/e2e/scaleup_test.go
@@ -56,7 +56,7 @@ func TestClusterAutoscaling(t *testing.T) {
 				},
 			},
 			NodeSelector: map[string]string{
-				"kwok-nodegroup": "kind-worker",
+				nodeGroupLabelKey: defaultNodeGroup,
 			},
 			Tolerations: []corev1.Toleration{
 				{
@@ -116,7 +116,7 @@ func TestClusterAutoscaling(t *testing.T) {
 					return false, err
 				}
 				for _, node := range nodeList.Items {
-					if node.Labels["kwok-nodegroup"] == "kind-worker" {
+					if node.Labels[nodeGroupLabelKey] == defaultNodeGroup {
 						return true, nil
 					}
 				}
@@ -135,6 +135,8 @@ func TestClusterAutoscaling(t *testing.T) {
 			}
 			// Delete the pod
 			_ = client.Resources().Delete(ctx, pod)
+			// Delete the node so that each test keeps the cluster clean
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 var (
@@ -56,6 +57,17 @@ func TestMain(m *testing.M) {
 	testEnv.Setup(
 		envfuncs.CreateNamespace(namespace),
 	)
+
+	testEnv.BeforeEachFeature(func(ctx context.Context, cfg *envconf.Config, t *testing.T, f features.Feature) (context.Context, error) {
+		client, err := cfg.NewClient()
+		if err != nil {
+			return ctx, err
+		}
+		if err := CleanUpNodeGroup(ctx, client, defaultNodeGroup); err != nil {
+			return ctx, err
+		}
+		return ctx, nil
+	})
 
 	testEnv.Finish(
 		func(ctx context.Context, config *envconf.Config) (context.Context, error) {

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -1,0 +1,131 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+)
+
+const (
+	podSchedulingTimeout = 2 * time.Minute
+	podDeletionTimeout   = 2 * time.Minute
+	nodeReadyTimeout     = 2 * time.Minute
+	scaleDownTimeout     = 4 * time.Minute
+)
+
+// WaitForPodsScheduled waits until all specified pods are assigned to nodes.
+func WaitForPodsScheduled(ctx context.Context, client klient.Client, pods []*corev1.Pod, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		for _, pod := range pods {
+			if pod == nil {
+				continue
+			}
+			p := &corev1.Pod{}
+			err := client.Resources().Get(ctx, pod.Name, pod.Namespace, p)
+			if err != nil {
+				return false, err
+			}
+			if p.Spec.NodeName == "" {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodScheduled waits until the pod is assigned to a node.
+func WaitForPodScheduled(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return WaitForPodsScheduled(ctx, client, []*corev1.Pod{pod}, timeout)
+}
+
+// WaitForPodsDeleted waits until all specified pods are deleted.
+func WaitForPodsDeleted(ctx context.Context, client klient.Client, pods []*corev1.Pod, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		for _, pod := range pods {
+			if pod == nil {
+				continue
+			}
+			p := &corev1.Pod{}
+			err := client.Resources().Get(ctx, pod.Name, pod.Namespace, p)
+			if err == nil {
+				return false, nil
+			}
+			if !apierrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		return true, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodDeleted waits until the pod is deleted.
+func WaitForPodDeleted(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return WaitForPodsDeleted(ctx, client, []*corev1.Pod{pod}, timeout)
+}
+
+// WaitForNodeCount waits until the number of nodes with the specified nodeGroup matches expected count.
+func WaitForNodeCount(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count == expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesAtLeast waits until the number of nodes in a nodeGroup is at least expectedCount.
+func WaitForNodesAtLeast(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesReady waits until at least expectedCount nodes in a nodeGroup have Ready condition True.
+func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		nodeList := &corev1.NodeList{}
+		err = client.Resources().List(ctx, nodeList)
+		if err != nil {
+			return false, err
+		}
+		readyCount := 0
+		for _, node := range nodeList.Items {
+			if node.Labels[nodeGroupLabelKey] == nodeGroup {
+				for _, condition := range node.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						readyCount++
+						break
+					}
+				}
+			}
+		}
+		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Migrates scale-down E2E tests from the legacy GCE suite (`pkg/e2e/cluster_size_autoscaling.go`) to the provider-agnostic KWOK E2E framework, running them in **sequential order** on a single node pool (`kind-worker`).

Specifically, this PR introduces:
1. **Sequential Scale-Down Tests** (`test/e2e/scaledown_test.go`):
   * `TestScaleDownUnneededNode`: Verifies that an unneeded simulated node is cleanly scaled down to 0 after its pending pod is deleted.
   * `TestScaleDownWithPDB`: Verifies that node scale-down correctly respects PodDisruptionBudget (PDB) constraints.
2. **Sequential Teardown & Isolation**:
   * Omit `t.Parallel()` to guarantee strict serial execution on `kind-worker`.
   * Include inter-test teardown to ensure the cluster cleanly resets to 0 worker nodes before the next test begins.
3. **KWOK Harness Support**:
   * Add test helper functions in `test/e2e/helpers.go` for node count assertion and resource cleanup.
   * Add `--set extraArgs.enable-csi-node-aware-scheduling=false` in the Makefile to prevent the autoscaler from waiting on CSI storage nodes.
   * Ensure simulated node templates include `kwok.x-k8s.io/node: fake` for reliable KWOK lifecycle simulation.

#### Which issue(s) this PR fixes:

Relates to #82

#### Special notes for reviewer:

* This PR provides the **sequential baseline** execution model on a single node pool (`kind-worker`).
* Local verification passes in **~155s (2m 35s)**:
  * `TestScaleDownUnneededNode`: ~95s (assessment: 50s + teardown: 45s)
  * `TestScaleDownWithPDB`: ~60s (assessment: 30s + teardown: 30s)
* Test command:
  ```bash
  go test -v -tags e2e -count=1 -parallel 1 -run "TestScaleDownUnneededNode|TestScaleDownWithPDB" ./test/e2e

```release-note
NONE
```