### PR TITLE
Cover errored nodes deletion with a distinct metric

### DIFF
--- a/pkg/core/static_autoscaler.go
+++ b/pkg/core/static_autoscaler.go
@@ -1143,6 +1143,7 @@ func (a *StaticAutoscaler) deleteCreatedNodesWithErrors(ctx context.Context) {
 		} else if len(nodesToDelete) > 0 {
 			deletedAny = true
 			a.clusterStateRegistry.InvalidateNodeInstancesCacheEntry(ctx, nodeGroup)
+			metrics.RegisterNodesWithCreateErrorsDeleted(len(nodesToDelete))
 		}
 	}
 

--- a/pkg/metrics/legacy_functions.go
+++ b/pkg/metrics/legacy_functions.go
@@ -198,6 +198,12 @@ func RegisterOldUnregisteredNodesRemoved(nodesCount int) {
 	DefaultMetrics.RegisterOldUnregisteredNodesRemoved(nodesCount)
 }
 
+// RegisterNodesWithCreateErrorsDeleted records number of nodes with
+// create errors that have been deleted by the cluster autoscaler
+func RegisterNodesWithCreateErrorsDeleted(nodesCount int) {
+	DefaultMetrics.RegisterNodesWithCreateErrorsDeleted(nodesCount)
+}
+
 // UpdateOverflowingControllers sets the number of controllers that could not
 // have their pods cached.
 func UpdateOverflowingControllers(count int) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -169,28 +169,29 @@ type caMetrics struct {
 	pendingNodeDeletions    *k8smetrics.Gauge
 
 	// Metrics related to autoscaler operations
-	errorsCount                      *k8smetrics.CounterVec
-	scaleUpCount                     *k8smetrics.CounterVec
-	gpuScaleUpCount                  *k8smetrics.CounterVec
-	failedScaleUpCount               *k8smetrics.CounterVec
-	failedNodeCreationCount          *k8smetrics.CounterVec
-	failedGPUScaleUpCount            *k8smetrics.CounterVec
-	scaleDownCount                   *k8smetrics.CounterVec
-	gpuScaleDownCount                *k8smetrics.CounterVec
-	evictionsCount                   *k8smetrics.CounterVec
-	unneededNodesCount               *k8smetrics.Gauge
-	unremovableNodesCount            *k8smetrics.GaugeVec
-	scaleDownInCooldown              *k8smetrics.Gauge
-	oldUnregisteredNodesRemovedCount *k8smetrics.Counter
-	overflowingControllersCount      *k8smetrics.Gauge
-	skippedScaleEventsCount          *k8smetrics.CounterVec
-	nodeGroupCreationCount           *k8smetrics.CounterVec
-	nodeGroupDeletionCount           *k8smetrics.CounterVec
-	nodeTaintsCount                  *k8smetrics.GaugeVec
-	inconsistentInstancesMigsCount   *k8smetrics.Gauge
-	binpackingHeterogeneity          *k8smetrics.HistogramVec
-	maxNodeSkipEvalDurationSeconds   *k8smetrics.Gauge
-	scaleDownNodeRemovalLatency      *k8smetrics.HistogramVec
+	errorsCount                       *k8smetrics.CounterVec
+	scaleUpCount                      *k8smetrics.CounterVec
+	gpuScaleUpCount                   *k8smetrics.CounterVec
+	failedScaleUpCount                *k8smetrics.CounterVec
+	failedNodeCreationCount           *k8smetrics.CounterVec
+	failedGPUScaleUpCount             *k8smetrics.CounterVec
+	scaleDownCount                    *k8smetrics.CounterVec
+	gpuScaleDownCount                 *k8smetrics.CounterVec
+	evictionsCount                    *k8smetrics.CounterVec
+	unneededNodesCount                *k8smetrics.Gauge
+	unremovableNodesCount             *k8smetrics.GaugeVec
+	scaleDownInCooldown               *k8smetrics.Gauge
+	oldUnregisteredNodesRemovedCount  *k8smetrics.Counter
+	nodesWithCreateErrorsDeletedCount *k8smetrics.Counter
+	overflowingControllersCount       *k8smetrics.Gauge
+	skippedScaleEventsCount           *k8smetrics.CounterVec
+	nodeGroupCreationCount            *k8smetrics.CounterVec
+	nodeGroupDeletionCount            *k8smetrics.CounterVec
+	nodeTaintsCount                   *k8smetrics.GaugeVec
+	inconsistentInstancesMigsCount    *k8smetrics.Gauge
+	binpackingHeterogeneity           *k8smetrics.HistogramVec
+	maxNodeSkipEvalDurationSeconds    *k8smetrics.Gauge
+	scaleDownNodeRemovalLatency       *k8smetrics.HistogramVec
 
 	// Metrics related to autoscaler prediction correctness
 	nodeTemplateResourcesMismatch *k8smetrics.GaugeVec
@@ -456,6 +457,14 @@ func newCaMetrics() *caMetrics {
 			},
 		),
 
+		nodesWithCreateErrorsDeletedCount: k8smetrics.NewCounter(
+			&k8smetrics.CounterOpts{
+				Namespace: caNamespace,
+				Name:      "nodes_with_create_errors_deleted_total",
+				Help:      "Number of nodes with create errors deleted by CA.",
+			},
+		),
+
 		overflowingControllersCount: k8smetrics.NewGauge(
 			&k8smetrics.GaugeOpts{
 				Namespace: caNamespace,
@@ -588,6 +597,7 @@ func (m *caMetrics) RegisterAll(emitPerNodeGroupMetrics bool) {
 	m.mustRegister(m.unremovableNodesCount)
 	m.mustRegister(m.scaleDownInCooldown)
 	m.mustRegister(m.oldUnregisteredNodesRemovedCount)
+	m.mustRegister(m.nodesWithCreateErrorsDeletedCount)
 	m.mustRegister(m.overflowingControllersCount)
 	m.mustRegister(m.skippedScaleEventsCount)
 	m.mustRegister(m.nodeGroupCreationCount)
@@ -873,6 +883,12 @@ func (m *caMetrics) UpdateScaleDownInCooldown(inCooldown bool) {
 // nodes that have been removed by the cluster autoscaler
 func (m *caMetrics) RegisterOldUnregisteredNodesRemoved(nodesCount int) {
 	m.oldUnregisteredNodesRemovedCount.Add(float64(nodesCount))
+}
+
+// RegisterNodesWithCreateErrorsDeleted records number of nodes with
+// create errors that have been deleted by the cluster autoscaler
+func (m *caMetrics) RegisterNodesWithCreateErrorsDeleted(nodesCount int) {
+	m.nodesWithCreateErrorsDeletedCount.Add(float64(nodesCount))
 }
 
 // UpdateOverflowingControllers sets the number of controllers that could not

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -107,3 +107,33 @@ func TestUpdateScaleDownNodeRemovalLatency(t *testing.T) {
 	assert.Equal(t, uint64(1), metric2.Histogram.GetSampleCount())
 	assert.Equal(t, 20.0, metric2.Histogram.GetSampleSum())
 }
+
+func TestRegisterNodesWithCreateErrorsDeleted(t *testing.T) {
+	tests := map[string]struct {
+		nodesCounts []int
+		wantTotal   float64
+	}{
+		"SingleIncrement": {
+			nodesCounts: []int{5},
+			wantTotal:   5,
+		},
+		"MultipleIncrements": {
+			nodesCounts: []int{2, 3, 4},
+			wantTotal:   9,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			reg := metrics.NewKubeRegistry()
+			m := newCaMetricsWithRegistry(reg)
+			m.RegisterAll(false)
+
+			for _, count := range tc.nodesCounts {
+				m.RegisterNodesWithCreateErrorsDeleted(count)
+			}
+
+			assert.Equal(t, tc.wantTotal, testutil.ToFloat64(m.nodesWithCreateErrorsDeletedCount))
+		})
+	}
+}

--- a/pkg/proposals/metrics.md
+++ b/pkg/proposals/metrics.md
@@ -104,6 +104,7 @@ This metrics describe internal state and actions taken by Cluster Autoscaler.
 | unremovable_nodes_count | Gauge | `reason`=&lt;unremovable-reason&gt; | Number of nodes currently considered unremovable by CA, broken down by reason. |
 | scale_down_in_cooldown | Gauge | | Whether scale-down is currently in cooldown. 1 if it is, 0 otherwise. |
 | old_unregistered_nodes_removed_count | Counter | | Number of unregistered nodes removed by CA. |
+| nodes_with_create_errors_deleted_total | Counter | | Number of nodes with create errors deleted by CA. |
 | overflowing_controllers_count | Gauge | | Number of controllers that own a large set of heterogenous pods, preventing CA from treating these pods as equivalent during binpacking. |
 | skipped_scale_events_count | Counter | `direction`=&lt;scaling-direction&gt;, `reason`=&lt;skipped-scale-reason&gt; | Number of times scaling has been skipped due to a resource limit being reached, or similar event. |
 | created_node_groups_total | Counter | `group_type`=&lt;node-group-type&gt; | Number of node groups created by Node Autoprovisioning. |


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

All normal deletions in cluster autoscaler are going through the scale-down deletion pipeline or deleting errored nodes while regularly checking node states. This change adds a metric which gets incremented only when we are removing errored nodes. While it has a lot of intersection with failed_node_creations_total, it provides more accurate measurement of the nodes which actually got successfully scheduled for the deletion and doesn't get limited on only scaled-up node groups. 

Example blintspot present right now: nodes which entered errored state without CA applying any operation on them and getting deleted without bumping any metrics

The potential problem of the current implementation is that there's no mechanism preventing deletion calls from happening on each and every loop, one of the potential solutions to that is changing metric type to gauge, but that way we'll loose the ability of measuring the increase rate and would be locked to knowing only the current state of cluster

One of the ways to solve it is to make a TTL cache with instance id as the key, but adding it wouln't fundamentally change anything but rather wouldn't allow to accurely asses how many deletion calls were issued

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add nodes_with_create_errors_deleted_total metric tracking errored nodes deletion calls issued by cluster autoscaler
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
