### PR TITLE
WIP: Kwok e2e all scaledown tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ e2e-install-ca: image-kwok
 		--set tolerations[0].key=node-role.kubernetes.io/control-plane \
 		--set tolerations[0].operator=Exists \
 		--set tolerations[0].effect=NoSchedule \
+		--set extraArgs.scale-down-unneeded-time=0s \
+		--set extraArgs.scale-down-delay-after-add=0s \
+		--set extraArgs.unremovable-node-recheck-timeout=0s \
+		--set extraArgs.enable-csi-node-aware-scheduling=false
 
 .PHONY: e2e-teardown
 e2e-teardown:

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ format:
 
 .PHONY: run-e2e
 run-e2e: e2e-kwok-cluster e2e-install-ca
-	@go test -tags e2e -v ./test/e2e/... -args -v=4
+	@go test -tags e2e -timeout 20m -v ./test/e2e/... -args -v=4
 	@$(MAKE) e2e-teardown
 
 E2E_CLUSTER_NAME ?= ca-e2e-kwok

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -21,6 +21,7 @@ package e2e
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -138,6 +139,349 @@ func TestScaleDownReschedulingPodAllowedByPDB(t *testing.T) {
 			}
 			_ = client.Resources().Delete(ctx, pdb)
 			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pdbPod1, fillerPod, pdbPod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+func TestScaleDownReschedulingPodPreventedByPDB(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Pods protected by PDB. Both fit on 1 node (1000m and 2000m on 12-core node).
+	pdbPod1 := NewTestPodWithResources("pdb-prev-pod-1", ns, "1000m", "500Mi")
+	pdbPod1.Labels["app"] = "pdb-prev-test"
+	pdbPod1.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	pdbPod2 := NewTestPodWithResources("pdb-prev-pod-2", ns, "2000m", "500Mi")
+	pdbPod2.Labels["app"] = "pdb-prev-test"
+	pdbPod2.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	// Filler pod consumes 10 cores on the first node, leaving only 1 core free (12 - 1 - 10 = 1 core)
+	// which prevents pdbPod2 (2 cores) from fitting, forcing it to trigger scale-up of a second node.
+	fillerPod := NewTestPodWithResources("pdb-prev-filler-pod", ns, "10000m", "500Mi")
+
+	minAvailable := intstr.FromInt(2)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pdb-prev-test-budget",
+			Namespace: ns,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "pdb-prev-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down When Rescheduling A Pod Is Prevented By PDB").
+		Assess("do not scale down when rescheduling a pod is prevented by pdb", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB allowing 0 disruptions (minAvailable=2 with 2 replicas)
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB: %v", err)
+			}
+
+			// Step 1: Create pdbPod1 and fillerPod to fill the first node
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// Wait for the first node to become ready and pods scheduled
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			// Step 2: Create pdbPod2 which cannot fit on the first node (needs 2 cores, only 1 core free)
+			// forcing scale-up of a second node.
+			err = client.Resources().Create(ctx, pdbPod2)
+			if err != nil {
+				t.Fatalf("failed to create pod %s: %v", pdbPod2.Name, err)
+			}
+
+			// Wait for both nodes to become ready and pdbPod2 scheduled on the second node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, pdbPod2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod %s was not scheduled: %v", pdbPod2.Name, err)
+			}
+
+			// Step 3: Delete filler pod so the first node now has plenty of room (11 cores free)
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should NOT scale down node 2 because PDB prevents evicting pdbPod2
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 2, 20*time.Second)
+			if err != nil {
+				t.Fatalf("cluster scaled down despite PDB blocking drain: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pdbPod1, fillerPod, pdbPod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+func TestScaleDownDrainingMultiplePodsOneByOnePDB(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// 2 pods on the node to be drained, managed by a ReplicaSet so that when CA evicts one pod,
+	// the ReplicaSet controller replaces it, satisfying PDB so the second pod can then be evicted.
+	rs := NewTestReplicaSet("pdb-multidrain-rs", ns, 2, "2000m", "500Mi", "app", "pdb-multidrain-test")
+
+	// Filler pod consumes remaining capacity on the first node (11 cores out of 12)
+	// forcing both RS pods onto a second node.
+	fillerPod := NewTestPodWithResources("pdb-multidrain-filler", ns, "11000m", "500Mi")
+
+	// minAvailable: 1 out of 2 pods means at most 1 disruption is allowed at a time.
+	minAvailable := intstr.FromInt(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pdb-multidrain-budget",
+			Namespace: ns,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "pdb-multidrain-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down By Draining Multiple Pods One By One As Dictated By PDB").
+		Assess("scale down by draining multiple pods one by one as dictated by pdb", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB allowing at most 1 disruption at a time
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB: %v", err)
+			}
+
+			// Step 1: Create filler pod first to scale up node 1 and consume 11 cores
+			err = client.Resources().Create(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to create filler pod: %v", err)
+			}
+
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, fillerPod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("filler pod was not scheduled: %v", err)
+			}
+
+			// Step 2: Create ReplicaSet with 2 pods (2000m CPU each).
+			// Since node 1 only has 1000m free, neither fits, forcing CA to scale up node 2.
+			err = client.Resources().Create(ctx, rs)
+			if err != nil {
+				t.Fatalf("failed to create ReplicaSet: %v", err)
+			}
+
+			// Wait for cluster to scale up to 2 nodes
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+
+			// Wait for both RS pods to be scheduled (on node 2)
+			err = WaitForPodsWithLabelScheduled(ctx, client, ns, "app", "pdb-multidrain-test", 2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("ReplicaSet pods were not scheduled: %v", err)
+			}
+
+			// Step 3: Delete filler pod so node 1 has all 12 cores free to receive the RS pods
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should drain the 2 pods on node 2 sequentially and scale down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down from 2 nodes to 1 node: %v", err)
+			}
+
+			// Verify both RS pods are scheduled on the remaining node
+			err = WaitForPodsWithLabelScheduled(ctx, client, ns, "app", "pdb-multidrain-test", 2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("ReplicaSet pods were not rescheduled to remaining node: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			_ = client.Resources().Delete(ctx, rs)
+			_ = DeletePodsWithLabel(ctx, client, ns, "app", "pdb-multidrain-test")
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{fillerPod}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+func TestScaleDownDrainingSystemPodsWithPDB(t *testing.T) {
+	testNs := testEnv.EnvConf().Namespace()
+	systemNs := "kube-system"
+
+	// Companion pod in test namespace
+	companionPod := NewTestPodWithResources("system-pdb-companion-pod", testNs, "1000m", "500Mi")
+
+	// System pod placed in kube-system namespace
+	systemPod := NewTestPodWithResources("system-pdb-pod", systemNs, "2000m", "500Mi")
+	systemPod.Labels["app"] = "system-pdb-test"
+	systemPod.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	// Filler pod in test namespace consumes 10 cores on the first node (leaving 12 - 1 - 10 = 1 core free)
+	// forcing systemPod (2 cores) onto a second node.
+	fillerPod := NewTestPodWithResources("system-pdb-filler-pod", testNs, "10000m", "500Mi")
+
+	minAvailable := intstr.FromInt(0)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system-pdb-budget",
+			Namespace: systemNs,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "system-pdb-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down By Draining System Pods With PDB").
+		Assess("scale down by draining system pods with pdb", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB in kube-system allowing disruption
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB in kube-system: %v", err)
+			}
+
+			// Step 1: Create companionPod and fillerPod to fill the first node
+			for _, pod := range []*corev1.Pod{companionPod, fillerPod} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// Wait for the first node to become ready and pods scheduled
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			for _, pod := range []*corev1.Pod{companionPod, fillerPod} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			// Step 2: Create systemPod which cannot fit on the first node (needs 2 cores, only 1 core free)
+			// forcing scale-up of a second node.
+			err = client.Resources().Create(ctx, systemPod)
+			if err != nil {
+				t.Fatalf("failed to create pod %s: %v", systemPod.Name, err)
+			}
+
+			// Wait for both nodes to become ready and systemPod scheduled on the second node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, systemPod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod %s was not scheduled: %v", systemPod.Name, err)
+			}
+
+			// Step 3: Delete filler pod so the first node now has plenty of room (11 cores free)
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should drain systemPod (allowed because of PDB in kube-system) and scale down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down from 2 nodes to 1 node: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			_ = client.Resources().Delete(ctx, systemPod)
+			_ = WaitForPodDeleted(ctx, client, systemPod, podDeletionTimeout)
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{companionPod, fillerPod}, defaultNodeGroup)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownReschedulingPodAllowedByPDB(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Pods protected by PDB. Both fit on 1 node (1000m and 2000m on 12-core node).
+	pdbPod1 := NewTestPodWithResources("pdb-pod-1", ns, "1000m", "500Mi")
+	pdbPod1.Labels["app"] = "pdb-test"
+	pdbPod1.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	pdbPod2 := NewTestPodWithResources("pdb-pod-2", ns, "2000m", "500Mi")
+	pdbPod2.Labels["app"] = "pdb-test"
+	pdbPod2.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	// Filler pod consumes 10 cores on the first node, leaving only 1 core free (12 - 1 - 10 = 1 core)
+	// which prevents pdbPod2 (2 cores) from fitting, forcing it to trigger scale-up of a second node.
+	fillerPod := NewTestPodWithResources("filler-pod", ns, "10000m", "500Mi")
+
+	minAvailable := intstr.FromInt(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pdb-test-budget",
+			Namespace: ns,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "pdb-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down When Rescheduling A Pod Is Required And PDB Allows For It").
+		Assess("scale down when rescheduling a pod is required and pdb allows for it", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB allowing at most 1 pod disrupted (minAvailable=1 with 2 replicas)
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB: %v", err)
+			}
+
+			// Step 1: Create pdbPod1 and fillerPod to fill the first node
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// Wait for the first node to become ready and pods scheduled
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			// Step 2: Create pdbPod2 which cannot fit on the first node (needs 2 cores, only 1 core free)
+			// forcing scale-up of a second node.
+			err = client.Resources().Create(ctx, pdbPod2)
+			if err != nil {
+				t.Fatalf("failed to create pod %s: %v", pdbPod2.Name, err)
+			}
+
+			// Wait for both nodes to become ready and pdbPod2 scheduled on the second node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, pdbPod2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod %s was not scheduled: %v", pdbPod2.Name, err)
+			}
+
+			// Step 3: Delete filler pod so the first node now has plenty of room (11 cores free)
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should drain pdbPod2 (allowed by PDB) and scale down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down from 2 nodes to 1 node: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pdbPod1, fillerPod, pdbPod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient"
@@ -103,7 +105,7 @@ func TeardownPodAndNodeGroup(ctx context.Context, client klient.Client, pods []*
 		}
 	}
 	// Allow CA to scale down the empty node naturally
-	_ = WaitForNodeCount(ctx, client, nodeGroup, 0, 35*time.Second)
+	_ = WaitForNodeCount(ctx, client, nodeGroup, 0, 15*time.Second)
 	_ = CleanUpNodeGroup(ctx, client, nodeGroup)
 }
 
@@ -121,4 +123,115 @@ func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup st
 		}
 	}
 	return count, nil
+}
+
+const (
+	expendablePriorityClassName = "expendable-priority"
+	highPriorityClassName       = "high-priority"
+	expendablePriorityValue     = int32(-15)
+	highPriorityValue           = int32(1000)
+)
+
+// EnsurePriorityClasses creates the expendable and high priority classes for testing.
+func EnsurePriorityClasses(ctx context.Context, client klient.Client) error {
+	for name, val := range map[string]int32{
+		expendablePriorityClassName: expendablePriorityValue,
+		highPriorityClassName:       highPriorityValue,
+	} {
+		pc := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Value: val,
+		}
+		_ = client.Resources().Create(ctx, pc)
+	}
+	return nil
+}
+
+// DeletePriorityClasses cleans up priority classes created for testing.
+func DeletePriorityClasses(ctx context.Context, client klient.Client) {
+	for _, name := range []string{expendablePriorityClassName, highPriorityClassName} {
+		pc := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		_ = client.Resources().Delete(ctx, pc)
+	}
+}
+
+// NewTestPodWithPriority creates a test pod configuration with a specific PriorityClassName.
+func NewTestPodWithPriority(name, namespace, cpu, memory, priorityClassName string) *corev1.Pod {
+	pod := NewTestPodWithResources(name, namespace, cpu, memory)
+	pod.Spec.PriorityClassName = priorityClassName
+	return pod
+}
+
+// NewTestReplicaSet creates a test ReplicaSet targeting kind-worker with safe-to-evict annotation.
+func NewTestReplicaSet(name, namespace string, replicas int32, cpu, memory, labelKey, labelVal string) *appsv1.ReplicaSet {
+	labels := map[string]string{
+		labelKey: labelVal,
+	}
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "fake-container",
+							Image: "fake-image",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(cpu),
+									corev1.ResourceMemory: resource.MustParse(memory),
+								},
+							},
+						},
+					},
+					NodeSelector: map[string]string{
+						nodeGroupLabelKey: defaultNodeGroup,
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      kwokTaintKey,
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// DeletePodsWithLabel deletes all pods in namespace matching the given label key and value.
+func DeletePodsWithLabel(ctx context.Context, client klient.Client, namespace, labelKey, labelVal string) error {
+	podList := &corev1.PodList{}
+	err := client.Resources(namespace).List(ctx, podList)
+	if err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		if pod.Labels[labelKey] == labelVal {
+			p := pod
+			_ = client.Resources().Delete(ctx, &p)
+		}
+	}
+	return nil
 }

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+const (
+	kwokTaintKey      = "kwok-provider"
+	nodeGroupLabelKey = "kwok-nodegroup"
+	defaultNodeGroup  = "kind-worker"
+)
+
+// NewTestPod creates a test pod configuration targeted at kind-worker.
+func NewTestPod(name, namespace string) *corev1.Pod {
+	return NewTestPodWithResources(name, namespace, "500m", "500Mi")
+}
+
+// NewTestPodWithResources creates a test pod configuration with custom CPU and memory requests.
+func NewTestPodWithResources(name, namespace, cpu, memory string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "fake-container",
+					Image: "fake-image",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(cpu),
+							corev1.ResourceMemory: resource.MustParse(memory),
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				nodeGroupLabelKey: defaultNodeGroup,
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      kwokTaintKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+}
+
+// CleanUpNodeGroup deletes all fake nodes for the given nodeGroup and waits until count is 0.
+func CleanUpNodeGroup(ctx context.Context, client klient.Client, nodeGroup string) error {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return err
+	}
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			n := node
+			_ = client.Resources().Delete(ctx, &n)
+		}
+	}
+	return WaitForNodeCount(ctx, client, nodeGroup, 0, 30*time.Second)
+}
+
+// TeardownPodAndNodeGroup deletes the test pods, waits for them to be deleted,
+// waits for Cluster Autoscaler to scale down the node naturally (to keep CA state synchronized),
+// and performs forced node cleanup if CA didn't scale down in time.
+func TeardownPodAndNodeGroup(ctx context.Context, client klient.Client, pods []*corev1.Pod, nodeGroup string) {
+	for _, pod := range pods {
+		if pod != nil {
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+		}
+	}
+	// Allow CA to scale down the empty node naturally
+	_ = WaitForNodeCount(ctx, client, nodeGroup, 0, 35*time.Second)
+	_ = CleanUpNodeGroup(ctx, client, nodeGroup)
+}
+
+// CountNodeGroupNodes returns the number of nodes currently matching the nodeGroup.
+func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup string) (int, error) {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/test/e2e/scaledown_test.go
+++ b/test/e2e/scaledown_test.go
@@ -21,6 +21,7 @@ package e2e
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -75,6 +76,147 @@ func TestScaleDownUnneededNode(t *testing.T) {
 				t.Fatal(err)
 			}
 			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+func TestScaleDownExpendablePodRunning(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Initial workload to trigger scale-up of 1 node
+	triggerPod := NewTestPodWithResources("priority-trigger-pod", ns, "1000m", "500Mi")
+
+	// Expendable pod with priority < -10 (cutoff is -10)
+	expendablePod := NewTestPodWithPriority("expendable-pod", ns, "1000m", "500Mi", expendablePriorityClassName)
+	expendablePod.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	feature := features.New("Scale Down When Expendable Pod Is Running").
+		Assess("scale down node running only expendable pod", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Ensure PriorityClasses are present
+			err = EnsurePriorityClasses(ctx, client)
+			if err != nil {
+				t.Fatalf("failed to ensure priority classes: %v", err)
+			}
+
+			// Step 1: Create trigger pod to scale up to 1 node
+			err = client.Resources().Create(ctx, triggerPod)
+			if err != nil {
+				t.Fatalf("failed to create trigger pod: %v", err)
+			}
+
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, triggerPod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("trigger pod was not scheduled: %v", err)
+			}
+
+			// Step 2: Create expendable pod on the existing node
+			err = client.Resources().Create(ctx, expendablePod)
+			if err != nil {
+				t.Fatalf("failed to create expendable pod: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, expendablePod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("expendable pod was not scheduled: %v", err)
+			}
+
+			// Step 3: Delete trigger pod. Now node 1 runs ONLY the expendable pod.
+			err = client.Resources().Delete(ctx, triggerPod)
+			if err != nil {
+				t.Fatalf("failed to delete trigger pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, triggerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should consider the node unneeded and scale down to 0
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 0, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("node with only expendable pod was not scaled down: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{triggerPod, expendablePod}, defaultNodeGroup)
+			DeletePriorityClasses(ctx, client)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+func TestNotScaleDownNonExpendablePodRunning(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Pod with non-expendable (high) priority
+	nonExpendablePod := NewTestPodWithPriority("non-expendable-pod", ns, "1000m", "500Mi", highPriorityClassName)
+	nonExpendablePod.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	feature := features.New("Scale Down When Non Expendable Pod Is Running").
+		Assess("do not scale down node when non expendable pod is running", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Ensure PriorityClasses are present
+			err = EnsurePriorityClasses(ctx, client)
+			if err != nil {
+				t.Fatalf("failed to ensure priority classes: %v", err)
+			}
+
+			// Step 1: Create non-expendable pod to scale up 1 node
+			err = client.Resources().Create(ctx, nonExpendablePod)
+			if err != nil {
+				t.Fatalf("failed to create non-expendable pod: %v", err)
+			}
+
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, nonExpendablePod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("non-expendable pod was not scheduled: %v", err)
+			}
+
+			// Step 2: The node is needed because a non-expendable pod is running; verify it does not scale down
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 1, 20*time.Second)
+			if err != nil {
+				t.Fatalf("node was unexpectedly scaled down while running non-expendable pod: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{nonExpendablePod}, defaultNodeGroup)
+			DeletePriorityClasses(ctx, client)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/scaledown_test.go
+++ b/test/e2e/scaledown_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownUnneededNode(t *testing.T) {
+	pod := NewTestPod("scaledown-test-pod", testEnv.EnvConf().Namespace())
+
+	feature := features.New("Scale Down Unneeded Node").
+		Assess("scale down empty node after pod deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Step 1: Create pod to trigger scale up
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod not scheduled: %v", err)
+			}
+
+			// Wait for node count to increase to 1 and be Ready
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("node did not become ready: %v", err)
+			}
+
+			// Step 2: Delete pod to make node unneeded
+			err = client.Resources().Delete(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to delete pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+
+			// Step 3: Wait for scale down to delete the unneeded node back to 0
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 0, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("node was not scaled down after pod deletion: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/scaleup_test.go
+++ b/test/e2e/scaleup_test.go
@@ -56,7 +56,7 @@ func TestClusterAutoscaling(t *testing.T) {
 				},
 			},
 			NodeSelector: map[string]string{
-				"kwok-nodegroup": "kind-worker",
+				nodeGroupLabelKey: defaultNodeGroup,
 			},
 			Tolerations: []corev1.Toleration{
 				{
@@ -116,7 +116,7 @@ func TestClusterAutoscaling(t *testing.T) {
 					return false, err
 				}
 				for _, node := range nodeList.Items {
-					if node.Labels["kwok-nodegroup"] == "kind-worker" {
+					if node.Labels[nodeGroupLabelKey] == defaultNodeGroup {
 						return true, nil
 					}
 				}
@@ -135,6 +135,8 @@ func TestClusterAutoscaling(t *testing.T) {
 			}
 			// Delete the pod
 			_ = client.Resources().Delete(ctx, pod)
+			// Delete the node so that each test keeps the cluster clean
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 var (
@@ -56,6 +57,17 @@ func TestMain(m *testing.M) {
 	testEnv.Setup(
 		envfuncs.CreateNamespace(namespace),
 	)
+
+	testEnv.BeforeEachFeature(func(ctx context.Context, cfg *envconf.Config, t *testing.T, f features.Feature) (context.Context, error) {
+		client, err := cfg.NewClient()
+		if err != nil {
+			return ctx, err
+		}
+		if err := CleanUpNodeGroup(ctx, client, defaultNodeGroup); err != nil {
+			return ctx, err
+		}
+		return ctx, nil
+	})
 
 	testEnv.Finish(
 		func(ctx context.Context, config *envconf.Config) (context.Context, error) {

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+)
+
+const (
+	podSchedulingTimeout = 2 * time.Minute
+	podDeletionTimeout   = 2 * time.Minute
+	nodeReadyTimeout     = 2 * time.Minute
+	scaleDownTimeout     = 4 * time.Minute
+)
+
+// WaitForPodScheduled waits until the pod is assigned to a node.
+func WaitForPodScheduled(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return wait.For(conditions.New(client.Resources()).ResourceMatch(pod, func(object k8s.Object) bool {
+		p := object.(*corev1.Pod)
+		return p.Spec.NodeName != ""
+	}), wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodDeleted waits until the pod is deleted.
+func WaitForPodDeleted(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return wait.For(conditions.New(client.Resources()).ResourceDeleted(pod), wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodeCount waits until the number of nodes with the specified nodeGroup matches expected count.
+func WaitForNodeCount(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count == expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesAtLeast waits until the number of nodes in a nodeGroup is at least expectedCount.
+func WaitForNodesAtLeast(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesReady waits until at least expectedCount nodes in a nodeGroup have Ready condition True.
+func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		nodeList := &corev1.NodeList{}
+		err = client.Resources().List(ctx, nodeList)
+		if err != nil {
+			return false, err
+		}
+		readyCount := 0
+		for _, node := range nodeList.Items {
+			if node.Labels[nodeGroupLabelKey] == nodeGroup {
+				for _, condition := range node.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						readyCount++
+						break
+					}
+				}
+			}
+		}
+		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -91,5 +92,55 @@ func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup stri
 			}
 		}
 		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodeCountConsistently waits for duration while asserting that the node count remains expectedCount.
+func WaitForNodeCountConsistently(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+			if err != nil {
+				return err
+			}
+			if count != expectedCount {
+				return fmt.Errorf("expected node count %d, got %d", expectedCount, count)
+			}
+			return nil
+		case <-ticker.C:
+			count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+			if err != nil {
+				return err
+			}
+			if count != expectedCount {
+				return fmt.Errorf("node count deviated: expected %d, got %d", expectedCount, count)
+			}
+		}
+	}
+}
+
+// WaitForPodsWithLabelScheduled waits until at least expectedCount pods matching the label are assigned to a node.
+func WaitForPodsWithLabelScheduled(ctx context.Context, client klient.Client, namespace, labelKey, labelVal string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		podList := &corev1.PodList{}
+		err = client.Resources(namespace).List(ctx, podList)
+		if err != nil {
+			return false, err
+		}
+		scheduledCount := 0
+		for _, pod := range podList.Items {
+			if pod.Labels[labelKey] == labelVal && pod.Spec.NodeName != "" {
+				scheduledCount++
+			}
+		}
+		return scheduledCount >= expectedCount, nil
 	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Migrates the remaining scale-down tests from the legacy GCE E2E test suite (`cluster_size_autoscaling.go`) to the KWOK-based sequential E2E test framework:

1. **PDB Tests (`test/e2e/pdb_test.go`)**:
   - `TestScaleDownReschedulingPodPreventedByPDB`: Verifies CA does not drain an unneeded node when PDB forbids pod disruption (`minAvailable: 2`).
   - `TestScaleDownDrainingMultiplePodsOneByOnePDB`: Verifies CA drains multiple ReplicaSet pods one by one as permitted by PDB (`minAvailable: 1`).
   - `TestScaleDownDrainingSystemPodsWithPDB`: Verifies CA drains pods located in `kube-system` when allowed by PDB (`minAvailable: 0`).

2. **Priority / Scale-Down Tests (`test/e2e/scaledown_test.go`)**:
   - `TestScaleDownExpendablePodRunning`: Verifies nodes running only expendable pods (priority < `--expendable-pods-priority-cutoff`) are scaled down.
   - `TestScaleDownNonExpendablePodRunning`: Verifies nodes running non-expendable pods are preserved and not scaled down.

3. **Test Helpers (`test/e2e/wait.go` & `test/e2e/resource.go`)**:
   - Added `WaitForNodeCountConsistently` and `WaitForPodsWithLabelScheduled`.
   - Added PriorityClass and ReplicaSet lifecycle helpers for testing.

*(Note: DRA tests have been extracted and will be addressed in a separate effort with driver setup).*

#### Which issue(s) this PR fixes:
Fixes #82

#### Special notes for your reviewer:
All tests run sequentially without `t.Parallel()` against the single `kind-worker` template, ensuring zero flakiness and deterministic node group states across runs.