### PR TITLE
WIP: Kwok e2e all scaleup tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ e2e-install-ca: image-kwok
 		--set tolerations[0].key=node-role.kubernetes.io/control-plane \
 		--set tolerations[0].operator=Exists \
 		--set tolerations[0].effect=NoSchedule \
+		--set extraArgs.scale-down-unneeded-time=0s \
+		--set extraArgs.scale-down-delay-after-add=0s \
+		--set extraArgs.unremovable-node-recheck-timeout=0s \
+		--set extraArgs.enable-csi-node-aware-scheduling=false
 
 .PHONY: e2e-teardown
 e2e-teardown:

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ format:
 
 .PHONY: run-e2e
 run-e2e: e2e-kwok-cluster e2e-install-ca
-	@go test -tags e2e -v ./test/e2e/... -args -v=4
+	@go test -tags e2e -timeout=30m -v ./test/e2e/... -args -v=4
 	@$(MAKE) e2e-teardown
 
 E2E_CLUSTER_NAME ?= ca-e2e-kwok
@@ -96,7 +96,8 @@ e2e-install-ca: image-kwok
 		--set extraArgs.scale-down-unneeded-time=0s \
 		--set extraArgs.scale-down-delay-after-add=0s \
 		--set extraArgs.unremovable-node-recheck-timeout=0s \
-		--set extraArgs.enable-csi-node-aware-scheduling=false
+		--set extraArgs.enable-csi-node-aware-scheduling=false \
+		--set extraArgs.bypassed-scheduler-names=non-existing-bypassed-scheduler
 
 .PHONY: e2e-teardown
 e2e-teardown:

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownReschedulingPodAllowedByPDB(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Pods protected by PDB. Both fit on 1 node (1000m and 2000m on 12-core node).
+	pdbPod1 := NewTestPodWithResources("pdb-pod-1", ns, "1000m", "500Mi")
+	pdbPod1.Labels["app"] = "pdb-test"
+	pdbPod1.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	pdbPod2 := NewTestPodWithResources("pdb-pod-2", ns, "2000m", "500Mi")
+	pdbPod2.Labels["app"] = "pdb-test"
+	pdbPod2.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	// Filler pod consumes 10 cores on the first node, leaving only 1 core free (12 - 1 - 10 = 1 core)
+	// which prevents pdbPod2 (2 cores) from fitting, forcing it to trigger scale-up of a second node.
+	fillerPod := NewTestPodWithResources("filler-pod", ns, "10000m", "500Mi")
+
+	minAvailable := intstr.FromInt(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pdb-test-budget",
+			Namespace: ns,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "pdb-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down When Rescheduling A Pod Is Required And PDB Allows For It").
+		Assess("scale down when rescheduling a pod is required and pdb allows for it", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB allowing at most 1 pod disrupted (minAvailable=1 with 2 replicas)
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB: %v", err)
+			}
+
+			// Step 1: Create pdbPod1 and fillerPod to fill the first node
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// Wait for the first node to become ready and pods scheduled
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			// Step 2: Create pdbPod2 which cannot fit on the first node (needs 2 cores, only 1 core free)
+			// forcing scale-up of a second node.
+			err = client.Resources().Create(ctx, pdbPod2)
+			if err != nil {
+				t.Fatalf("failed to create pod %s: %v", pdbPod2.Name, err)
+			}
+
+			// Wait for both nodes to become ready and pdbPod2 scheduled on the second node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, pdbPod2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod %s was not scheduled: %v", pdbPod2.Name, err)
+			}
+
+			// Step 3: Delete filler pod so the first node now has plenty of room (11 cores free)
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should drain pdbPod2 (allowed by PDB) and scale down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down from 2 nodes to 1 node: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pdbPod1, fillerPod, pdbPod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient"
@@ -121,4 +123,177 @@ func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup st
 		}
 	}
 	return count, nil
+}
+
+const (
+	expendablePriorityClassName      = "expendable-priority"
+	highPriorityClassName            = "high-priority"
+	expendablePriorityValue          = int32(-15)
+	highPriorityValue                = int32(1000)
+	nonExistingBypassedSchedulerName = "non-existing-bypassed-scheduler"
+)
+
+// EnsurePriorityClasses creates the expendable and high priority classes for testing.
+func EnsurePriorityClasses(ctx context.Context, client klient.Client) error {
+	for name, val := range map[string]int32{
+		expendablePriorityClassName: expendablePriorityValue,
+		highPriorityClassName:       highPriorityValue,
+	} {
+		pc := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Value: val,
+		}
+		_ = client.Resources().Create(ctx, pc)
+	}
+	return nil
+}
+
+// DeletePriorityClasses cleans up priority classes created for testing.
+func DeletePriorityClasses(ctx context.Context, client klient.Client) {
+	for _, name := range []string{expendablePriorityClassName, highPriorityClassName} {
+		pc := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		_ = client.Resources().Delete(ctx, pc)
+	}
+}
+
+// NewTestPodWithPriority creates a test pod configuration with a specific PriorityClassName.
+func NewTestPodWithPriority(name, namespace, cpu, memory, priorityClassName string) *corev1.Pod {
+	pod := NewTestPodWithResources(name, namespace, cpu, memory)
+	pod.Spec.PriorityClassName = priorityClassName
+	return pod
+}
+
+// NewTestPodWithHostPort creates a test pod configuration with a specific HostPort.
+func NewTestPodWithHostPort(name, namespace, cpu, memory string, hostPort int32) *corev1.Pod {
+	pod := NewTestPodWithResources(name, namespace, cpu, memory)
+	pod.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{
+			ContainerPort: hostPort,
+			HostPort:      hostPort,
+		},
+	}
+	return pod
+}
+
+// NewTestPodWithAntiAffinity creates a test pod configuration with pod anti-affinity.
+func NewTestPodWithAntiAffinity(name, namespace, cpu, memory, labelKey, labelVal string) *corev1.Pod {
+	pod := NewTestPodWithResources(name, namespace, cpu, memory)
+	pod.Labels[labelKey] = labelVal
+	pod.Spec.Affinity = &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelKey: labelVal,
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+	return pod
+}
+
+// NewTestPodWithEmptyDirAndAntiAffinity creates a test pod with EmptyDir volume and anti-affinity.
+func NewTestPodWithEmptyDirAndAntiAffinity(name, namespace, cpu, memory, labelKey, labelVal string) *corev1.Pod {
+	pod := NewTestPodWithAntiAffinity(name, namespace, cpu, memory, labelKey, labelVal)
+	pod.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "empty-volume",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+		{
+			Name:      "empty-volume",
+			MountPath: "/scratch",
+		},
+	}
+	return pod
+}
+
+// NewTestPodWithScheduler creates a test pod configuration with a custom SchedulerName.
+func NewTestPodWithScheduler(name, namespace, cpu, memory, schedulerName string) *corev1.Pod {
+	pod := NewTestPodWithResources(name, namespace, cpu, memory)
+	pod.Spec.SchedulerName = schedulerName
+	return pod
+}
+
+// NewTestReplicaSetWithPriority creates a test ReplicaSet targeting kind-worker with priority.
+func NewTestReplicaSetWithPriority(name, namespace string, replicas int32, cpu, memory, labelKey, labelVal, priorityClassName string) *appsv1.ReplicaSet {
+	labels := map[string]string{
+		labelKey: labelVal,
+	}
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					PriorityClassName: priorityClassName,
+					Containers: []corev1.Container{
+						{
+							Name:  "fake-container",
+							Image: "fake-image",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(cpu),
+									corev1.ResourceMemory: resource.MustParse(memory),
+								},
+							},
+						},
+					},
+					NodeSelector: map[string]string{
+						nodeGroupLabelKey: defaultNodeGroup,
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      kwokTaintKey,
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// DeletePodsWithLabel deletes all pods in namespace matching the given label key and value.
+func DeletePodsWithLabel(ctx context.Context, client klient.Client, namespace, labelKey, labelVal string) error {
+	podList := &corev1.PodList{}
+	err := client.Resources(namespace).List(ctx, podList)
+	if err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		if pod.Labels[labelKey] == labelVal {
+			p := pod
+			_ = client.Resources().Delete(ctx, &p)
+		}
+	}
+	return nil
 }

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+const (
+	kwokTaintKey      = "kwok-provider"
+	nodeGroupLabelKey = "kwok-nodegroup"
+	defaultNodeGroup  = "kind-worker"
+)
+
+// NewTestPod creates a test pod configuration targeted at kind-worker.
+func NewTestPod(name, namespace string) *corev1.Pod {
+	return NewTestPodWithResources(name, namespace, "500m", "500Mi")
+}
+
+// NewTestPodWithResources creates a test pod configuration with custom CPU and memory requests.
+func NewTestPodWithResources(name, namespace, cpu, memory string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "fake-container",
+					Image: "fake-image",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(cpu),
+							corev1.ResourceMemory: resource.MustParse(memory),
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				nodeGroupLabelKey: defaultNodeGroup,
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      kwokTaintKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+}
+
+// CleanUpNodeGroup deletes all fake nodes for the given nodeGroup and waits until count is 0.
+func CleanUpNodeGroup(ctx context.Context, client klient.Client, nodeGroup string) error {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return err
+	}
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			n := node
+			_ = client.Resources().Delete(ctx, &n)
+		}
+	}
+	return WaitForNodeCount(ctx, client, nodeGroup, 0, 30*time.Second)
+}
+
+// TeardownPodAndNodeGroup deletes the test pods, waits for them to be deleted,
+// waits for Cluster Autoscaler to scale down the node naturally (to keep CA state synchronized),
+// and performs forced node cleanup if CA didn't scale down in time.
+func TeardownPodAndNodeGroup(ctx context.Context, client klient.Client, pods []*corev1.Pod, nodeGroup string) {
+	for _, pod := range pods {
+		if pod != nil {
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+		}
+	}
+	// Allow CA to scale down the empty node naturally
+	_ = WaitForNodeCount(ctx, client, nodeGroup, 0, 35*time.Second)
+	_ = CleanUpNodeGroup(ctx, client, nodeGroup)
+}
+
+// CountNodeGroupNodes returns the number of nodes currently matching the nodeGroup.
+func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup string) (int, error) {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/test/e2e/scaledown_test.go
+++ b/test/e2e/scaledown_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownUnneededNode(t *testing.T) {
+	pod := NewTestPod("scaledown-test-pod", testEnv.EnvConf().Namespace())
+
+	feature := features.New("Scale Down Unneeded Node").
+		Assess("scale down empty node after pod deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Step 1: Create pod to trigger scale up
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod not scheduled: %v", err)
+			}
+
+			// Wait for node count to increase to 1 and be Ready
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("node did not become ready: %v", err)
+			}
+
+			// Step 2: Delete pod to make node unneeded
+			err = client.Resources().Delete(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to delete pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+
+			// Step 3: Wait for scale down to delete the unneeded node back to 0
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 0, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("node was not scaled down after pod deletion: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/scaleup_test.go
+++ b/test/e2e/scaleup_test.go
@@ -143,3 +143,551 @@ func TestClusterAutoscaling(t *testing.T) {
 
 	testEnv.Test(t, scaleUpFeature)
 }
+
+// TestScaleUpPendingPodTooLarge verifies CA doesn't increase cluster size if pending pod is too large for any node group.
+func TestScaleUpPendingPodTooLarge(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	// Pod requests 100 CPUs (node allocatable is 12 CPUs)
+	pod := NewTestPodWithResources("too-large-pod", ns, "100", "100Mi")
+
+	feature := features.New("Scale Up Pending Pod Too Large").
+		Assess("shouldn't increase cluster size if pending pod is too large", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			// Wait for NotTriggerScaleUp event
+			err = WaitForPodEvent(ctx, client, ns, pod.Name, "NotTriggerScaleUp", 1*time.Minute)
+			if err != nil {
+				t.Fatalf("expected NotTriggerScaleUp event: %v", err)
+			}
+
+			// Verify that cluster size is not changed
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 0, 10*time.Second)
+			if err != nil {
+				t.Fatalf("cluster size changed: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpNoAdditionalScaleUpsDuringProcessing verifies CA does not trigger extra scale-ups once target nodes are added.
+func TestScaleUpNoAdditionalScaleUpsDuringProcessing(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod := NewTestPodWithResources("stabilize-pod", ns, "500m", "500Mi")
+
+	feature := features.New("Scale Up No Additional Scale-Ups").
+		Assess("shouldn't trigger additional scale-ups during processing scale-up", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			// Cluster should scale up to exactly 1 node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not reach 1 node: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod not scheduled: %v", err)
+			}
+
+			// Verify that cluster size remains consistently 1 (no extra scale-ups triggered)
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 1, 15*time.Second)
+			if err != nil {
+				t.Fatalf("unexpected additional scale-up triggered: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpHostPortConflict verifies CA increases cluster size when pods conflict on host ports.
+func TestScaleUpHostPortConflict(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod1 := NewTestPodWithHostPort("hostport-pod-1", ns, "100m", "100Mi", 8080)
+	pod2 := NewTestPodWithHostPort("hostport-pod-2", ns, "100m", "100Mi", 8080)
+
+	feature := features.New("Scale Up Host Port Conflict").
+		Assess("should increase cluster size if pods are pending due to host port conflict", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create both pods with the same hostPort
+			for _, pod := range []*corev1.Pod{pod1, pod2} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// CA should scale up 2 nodes because hostPort cannot be shared on 1 node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+
+			for _, pod := range []*corev1.Pod{pod1, pod2} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod1, pod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpPodAntiAffinity verifies CA increases cluster size when pods have mutual anti-affinity.
+func TestScaleUpPodAntiAffinity(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod1 := NewTestPodWithAntiAffinity("anti-affinity-pod-1", ns, "100m", "100Mi", "anti-affinity", "yes")
+	pod2 := NewTestPodWithAntiAffinity("anti-affinity-pod-2", ns, "100m", "100Mi", "anti-affinity", "yes")
+
+	feature := features.New("Scale Up Pod Anti-Affinity").
+		Assess("should increase cluster size if pods are pending due to pod anti-affinity", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, pod := range []*corev1.Pod{pod1, pod2} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// CA should scale up to 2 nodes due to anti-affinity
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+
+			for _, pod := range []*corev1.Pod{pod1, pod2} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod1, pod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpEmptyDirVolume verifies CA increases cluster size when pending pod requests EmptyDir volume.
+func TestScaleUpEmptyDirVolume(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod1 := NewTestPodWithAntiAffinity("emptydir-base-pod", ns, "100m", "100Mi", "anti-affinity-emptydir", "yes")
+	pod2 := NewTestPodWithEmptyDirAndAntiAffinity("emptydir-volume-pod", ns, "100m", "100Mi", "anti-affinity-emptydir", "yes")
+
+	feature := features.New("Scale Up EmptyDir Volume").
+		Assess("should increase cluster size if pod requesting EmptyDir volume is pending", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, pod := range []*corev1.Pod{pod1, pod2} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+
+			for _, pod := range []*corev1.Pod{pod1, pod2} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod1, pod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpExpendablePodCreated verifies CA does not scale up when an expendable pod is created.
+func TestScaleUpExpendablePodCreated(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod := NewTestPodWithPriority("expendable-pod", ns, "500m", "500Mi", expendablePriorityClassName)
+
+	feature := features.New("Scale Up Expendable Pod Created").
+		Assess("shouldn't scale up when expendable pod is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_ = EnsurePriorityClasses(ctx, client)
+
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create expendable pod: %v", err)
+			}
+
+			// Cluster size must remain 0
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 0, 15*time.Second)
+			if err != nil {
+				t.Fatalf("cluster scaled up for expendable pod: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+			DeletePriorityClasses(ctx, client)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpNonExpendablePodCreated verifies CA scales up when a non-expendable pod is created.
+func TestScaleUpNonExpendablePodCreated(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod := NewTestPodWithPriority("non-expendable-pod", ns, "500m", "500Mi", highPriorityClassName)
+
+	feature := features.New("Scale Up Non Expendable Pod Created").
+		Assess("should scale up when non expendable pod is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_ = EnsurePriorityClasses(ctx, client)
+
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create non-expendable pod: %v", err)
+			}
+
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod not scheduled: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+			DeletePriorityClasses(ctx, client)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpExpendablePodPreempted verifies CA does not scale up when an expendable pod is preempted.
+func TestScaleUpExpendablePodPreempted(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	basePod := NewTestPodWithResources("preemption-base-pod", ns, "100m", "100Mi")
+	expendableRS := NewTestReplicaSetWithPriority("expendable-rs", ns, 1, "10000m", "100Mi", "app", "expendable-rs", expendablePriorityClassName)
+	highPriorityPod := NewTestPodWithPriority("preempting-high-priority-pod", ns, "10000m", "100Mi", highPriorityClassName)
+
+	feature := features.New("Scale Up Expendable Pod Preempted").
+		Assess("shouldn't scale up when expendable pod is preempted", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_ = EnsurePriorityClasses(ctx, client)
+
+			// Step 1: Scale up 1 node with basePod
+			err = client.Resources().Create(ctx, basePod)
+			if err != nil {
+				t.Fatalf("failed to create base pod: %v", err)
+			}
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, basePod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("base pod not scheduled: %v", err)
+			}
+
+			// Step 2: Schedule expendable ReplicaSet pod on the node
+			err = client.Resources().Create(ctx, expendableRS)
+			if err != nil {
+				t.Fatalf("failed to create expendable RS: %v", err)
+			}
+			err = WaitForPodsWithLabelScheduled(ctx, client, ns, "app", "expendable-rs", 1, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("expendable pod was not scheduled: %v", err)
+			}
+
+			// Step 3: Create high-priority pod that preempts the expendable pod on the node
+			err = client.Resources().Create(ctx, highPriorityPod)
+			if err != nil {
+				t.Fatalf("failed to create high-priority pod: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, highPriorityPod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("high-priority pod was not scheduled: %v", err)
+			}
+
+			// Step 4: The preempted expendable pod is recreated by RS and stays unschedulable.
+			// CA must NOT scale up for the preempted expendable pod. Node count remains 1.
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 1, 15*time.Second)
+			if err != nil {
+				t.Fatalf("cluster scaled up for preempted expendable pod: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, expendableRS)
+			_ = DeletePodsWithLabel(ctx, client, ns, "app", "expendable-rs")
+			_ = client.Resources().Delete(ctx, highPriorityPod)
+			_ = client.Resources().Delete(ctx, basePod)
+			_ = WaitForPodDeleted(ctx, client, basePod, podDeletionTimeout)
+			DeletePriorityClasses(ctx, client)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpUnprocessedPodUnschedulable verifies CA scales up when unprocessed pod is created with bypassed scheduler.
+func TestScaleUpUnprocessedPodUnschedulable(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	pod := NewTestPodWithScheduler("unprocessed-unschedulable-pod", ns, "500m", "500Mi", nonExistingBypassedSchedulerName)
+
+	feature := features.New("Scale Up Unprocessed Pod Unschedulable").
+		Assess("should scale up when unprocessed pod is created and is going to be unschedulable", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create unprocessed pod: %v", err)
+			}
+
+			// Cluster should scale up to 1 node because CA bypasses scheduler check for this scheduler
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node for bypassed scheduler pod: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpUnprocessedPodSchedulable verifies CA does not scale up when unprocessed pod is schedulable on existing nodes.
+func TestScaleUpUnprocessedPodSchedulable(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	basePod := NewTestPodWithResources("schedulable-base-pod", ns, "100m", "100Mi")
+	unprocessedPod := NewTestPodWithScheduler("unprocessed-schedulable-pod", ns, "500m", "500Mi", nonExistingBypassedSchedulerName)
+
+	feature := features.New("Scale Up Unprocessed Pod Schedulable").
+		Assess("shouldn't scale up when unprocessed pod is created and is going to be schedulable", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Step 1: Scale up 1 node
+			err = client.Resources().Create(ctx, basePod)
+			if err != nil {
+				t.Fatalf("failed to create base pod: %v", err)
+			}
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, basePod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("base pod not scheduled: %v", err)
+			}
+
+			// Step 2: Create unprocessed pod that fits on the existing node (~11.9 cores free)
+			err = client.Resources().Create(ctx, unprocessedPod)
+			if err != nil {
+				t.Fatalf("failed to create unprocessed pod: %v", err)
+			}
+
+			// Step 3: Verify node count remains 1 (CA does not scale up since pod is schedulable)
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 1, 15*time.Second)
+			if err != nil {
+				t.Fatalf("cluster scaled up unexpectedly: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, unprocessedPod)
+			_ = client.Resources().Delete(ctx, basePod)
+			_ = WaitForPodDeleted(ctx, client, basePod, podDeletionTimeout)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpUnprocessedPodSchedulerNotBypassed verifies CA does not scale up when unprocessed pod targets a non-bypassed scheduler.
+func TestScaleUpUnprocessedPodSchedulerNotBypassed(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+	nonBypassedScheduler := "non-existing-custom-scheduler"
+	pod := NewTestPodWithScheduler("unprocessed-not-bypassed-pod", ns, "500m", "500Mi", nonBypassedScheduler)
+
+	feature := features.New("Scale Up Unprocessed Pod Scheduler Not Bypassed").
+		Assess("shouldn't scale up when unprocessed pod is created and scheduler is not specified to be bypassed", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			// Verify node count remains 0 because the scheduler is not bypassed
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 0, 15*time.Second)
+			if err != nil {
+				t.Fatalf("cluster scaled up for non-bypassed scheduler pod: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/scaleup_test.go
+++ b/test/e2e/scaleup_test.go
@@ -56,7 +56,7 @@ func TestClusterAutoscaling(t *testing.T) {
 				},
 			},
 			NodeSelector: map[string]string{
-				"kwok-nodegroup": "kind-worker",
+				nodeGroupLabelKey: defaultNodeGroup,
 			},
 			Tolerations: []corev1.Toleration{
 				{
@@ -116,7 +116,7 @@ func TestClusterAutoscaling(t *testing.T) {
 					return false, err
 				}
 				for _, node := range nodeList.Items {
-					if node.Labels["kwok-nodegroup"] == "kind-worker" {
+					if node.Labels[nodeGroupLabelKey] == defaultNodeGroup {
 						return true, nil
 					}
 				}
@@ -135,6 +135,8 @@ func TestClusterAutoscaling(t *testing.T) {
 			}
 			// Delete the pod
 			_ = client.Resources().Delete(ctx, pod)
+			// Delete the node so that each test keeps the cluster clean
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 var (
@@ -56,6 +57,17 @@ func TestMain(m *testing.M) {
 	testEnv.Setup(
 		envfuncs.CreateNamespace(namespace),
 	)
+
+	testEnv.BeforeEachFeature(func(ctx context.Context, cfg *envconf.Config, t *testing.T, f features.Feature) (context.Context, error) {
+		client, err := cfg.NewClient()
+		if err != nil {
+			return ctx, err
+		}
+		if err := CleanUpNodeGroup(ctx, client, defaultNodeGroup); err != nil {
+			return ctx, err
+		}
+		return ctx, nil
+	})
 
 	testEnv.Finish(
 		func(ctx context.Context, config *envconf.Config) (context.Context, error) {

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+)
+
+const (
+	podSchedulingTimeout = 2 * time.Minute
+	podDeletionTimeout   = 2 * time.Minute
+	nodeReadyTimeout     = 2 * time.Minute
+	scaleDownTimeout     = 4 * time.Minute
+)
+
+// WaitForPodScheduled waits until the pod is assigned to a node.
+func WaitForPodScheduled(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return wait.For(conditions.New(client.Resources()).ResourceMatch(pod, func(object k8s.Object) bool {
+		p := object.(*corev1.Pod)
+		return p.Spec.NodeName != ""
+	}), wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodDeleted waits until the pod is deleted.
+func WaitForPodDeleted(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return wait.For(conditions.New(client.Resources()).ResourceDeleted(pod), wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodeCount waits until the number of nodes with the specified nodeGroup matches expected count.
+func WaitForNodeCount(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count == expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesAtLeast waits until the number of nodes in a nodeGroup is at least expectedCount.
+func WaitForNodesAtLeast(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesReady waits until at least expectedCount nodes in a nodeGroup have Ready condition True.
+func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		nodeList := &corev1.NodeList{}
+		err = client.Resources().List(ctx, nodeList)
+		if err != nil {
+			return false, err
+		}
+		readyCount := 0
+		for _, node := range nodeList.Items {
+			if node.Labels[nodeGroupLabelKey] == nodeGroup {
+				for _, condition := range node.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						readyCount++
+						break
+					}
+				}
+			}
+		}
+		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -91,5 +92,72 @@ func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup stri
 			}
 		}
 		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodeCountConsistently waits for duration while asserting that the node count remains expectedCount.
+func WaitForNodeCountConsistently(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+			if err != nil {
+				return err
+			}
+			if count != expectedCount {
+				return fmt.Errorf("expected node count %d, got %d", expectedCount, count)
+			}
+			return nil
+		case <-ticker.C:
+			count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+			if err != nil {
+				return err
+			}
+			if count != expectedCount {
+				return fmt.Errorf("node count deviated: expected %d, got %d", expectedCount, count)
+			}
+		}
+	}
+}
+
+// WaitForPodsWithLabelScheduled waits until at least expectedCount pods matching the label are assigned to a node.
+func WaitForPodsWithLabelScheduled(ctx context.Context, client klient.Client, namespace, labelKey, labelVal string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		podList := &corev1.PodList{}
+		err = client.Resources(namespace).List(ctx, podList)
+		if err != nil {
+			return false, err
+		}
+		scheduledCount := 0
+		for _, pod := range podList.Items {
+			if pod.Labels[labelKey] == labelVal && pod.Spec.NodeName != "" {
+				scheduledCount++
+			}
+		}
+		return scheduledCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodEvent waits until an event with the given reason for the pod appears in the namespace.
+func WaitForPodEvent(ctx context.Context, client klient.Client, namespace, podName, reason string, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		events := &corev1.EventList{}
+		err = client.Resources(namespace).List(ctx, events)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events.Items {
+			if event.InvolvedObject.Name == podName && event.Reason == reason {
+				return true, nil
+			}
+		}
+		return false, nil
 	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind test

#### What this PR does / why we need it:
Migrates the remaining scale-up E2E tests from the legacy GCE suite (`pkg/e2e/cluster_size_autoscaling.go`) to the provider-agnostic KWOK E2E framework, running sequentially on a single node pool (`kind-worker`).

Specifically, this PR introduces:

1. **Standard Autoscaling Tests (`test/e2e/scaleup_test.go`)**:
   - `TestScaleUpPendingPodTooLarge`: Verifies CA does not increase cluster size if a pending pod is too large for any node group (`NotTriggerScaleUp` event published, node count remains 0).
   - `TestScaleUpPendingPodsAreSmall`: Verifies CA increases cluster size from 0 to 1 node when a small pending pod is created (also maintains `TestClusterAutoscaling` for backward compatibility).
   - `TestScaleUpNoAdditionalScaleUpsDuringProcessing`: Verifies CA stabilizes at the target node count (1 node) and does not trigger additional scale-up cycles once target nodes are added.
   - `TestScaleUpHostPortConflict`: Verifies CA scales up 2 distinct nodes when pending pods conflict on identical `hostPort` bindings (port 8080).
   - `TestScaleUpPodAntiAffinity`: Verifies CA scales up 2 separate nodes when pending pods define mutual `podAntiAffinity` on `kubernetes.io/hostname`.
   - `TestScaleUpEmptyDirVolume`: Verifies CA scales up a new node when a pending pod requesting an `EmptyDir` volume has anti-affinity to existing pods.
   - `TestScaleUpExpendablePodCreated`: Verifies CA ignores unschedulable expendable pods (`priorityClassName: expendable-priority`, value `-15` < cutoff `-10`) and does not trigger scale-up.
   - `TestScaleUpNonExpendablePodCreated`: Verifies CA scales up when a non-expendable pod (`priorityClassName: high-priority`, value `1000`) is created.
   - `TestScaleUpExpendablePodPreempted`: Verifies CA does not scale up a 2nd node when an expendable pod is preempted by a high-priority pod on an existing node.
   - `TestScaleUpUnprocessedPodUnschedulable`: Verifies CA bypasses the scheduler and scales up when an unprocessed pod targets a bypassed scheduler (`non-existing-bypassed-scheduler`).
   - `TestScaleUpUnprocessedPodSchedulable`: Verifies CA does not scale up when an unprocessed pod targeting a bypassed scheduler is schedulable on an existing node.
   - `TestScaleUpUnprocessedPodSchedulerNotBypassed`: Verifies CA does not scale up when an unprocessed pod targets a scheduler that is not configured to be bypassed.

2. **Harness & Helper Support (`test/e2e/wait.go`, `test/e2e/resource.go`, `Makefile`)**:
   - `test/e2e/wait.go`: Added `WaitForNodeCountConsistently`, `WaitForPodsWithLabelScheduled`, and `WaitForPodEvent`.
   - `test/e2e/resource.go`: Added helpers for PriorityClasses (`EnsurePriorityClasses`, `DeletePriorityClasses`, `NewTestPodWithPriority`), host ports (`NewTestPodWithHostPort`), anti-affinity (`NewTestPodWithAntiAffinity`), EmptyDir volumes (`NewTestPodWithEmptyDirAndAntiAffinity`), custom schedulers (`NewTestPodWithScheduler`), and ReplicaSets (`NewTestReplicaSetWithPriority`, `DeletePodsWithLabel`).
   - `Makefile`: Configured `--set extraArgs.bypassed-scheduler-names=non-existing-bypassed-scheduler` in `e2e-install-ca` and added `-timeout=30m` in `run-e2e`.

3. **Sequential Isolation & Clean Teardown**:
   - Omits `t.Parallel()` to enforce deterministic sequential execution on `kind-worker`.
   - Each test cleans up its workloads and invokes `CleanUpNodeGroup` in `Teardown` to reset the cluster to 0 worker nodes before the next test begins.

#### Which issue(s) this PR fixes:
Fixes #82 

#### Special notes for your reviewer:
- Built on top of PR #94 (`kwok-e2e-scaledown-sequential`).
- All 17 E2E tests (scale-down + scale-up) pass sequentially on the KWOK test cluster (`697s` total execution time).

#### Does this PR introduce a user-facing change?
```release-note
NONE