### PR TITLE
WIP: Kwok e2e all dra tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ e2e-install-ca: image-kwok
 		--set tolerations[0].key=node-role.kubernetes.io/control-plane \
 		--set tolerations[0].operator=Exists \
 		--set tolerations[0].effect=NoSchedule \
+		--set extraArgs.scale-down-unneeded-time=0s \
+		--set extraArgs.scale-down-delay-after-add=0s \
+		--set extraArgs.unremovable-node-recheck-timeout=0s \
+		--set extraArgs.enable-csi-node-aware-scheduling=false
 
 .PHONY: e2e-teardown
 e2e-teardown:

--- a/test/e2e/dra_test.go
+++ b/test/e2e/dra_test.go
@@ -1,0 +1,360 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+const (
+	draDeviceClassName = "gpu"
+	draDeviceCapacity  = 4
+)
+
+// ReserveDRA creates a ReplicaSet where pods request DRA devices via an Ephemeral ResourceClaimTemplate.
+// It configures pod anti-affinity when onePodPerNode is true.
+// Returns a cleanup function to tear down the ReplicaSet, pods, and ResourceClaimTemplate.
+func ReserveDRA(ctx context.Context, client klient.Client, ns, id string, replicas int, deviceClass string, devicesPerPod int, onePodPerNode bool) (func(context.Context) error, error) {
+	claimName := "test-claim"
+
+	template := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: ns,
+		},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{
+						{
+							Name: "req-1",
+							Exactly: &resourcev1.ExactDeviceRequest{
+								DeviceClassName: deviceClass,
+								AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+								Count:           int64(devicesPerPod),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := client.Resources().Create(ctx, template)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ResourceClaimTemplate: %w", err)
+	}
+
+	rep := int32(replicas)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: ns,
+			Labels: map[string]string{
+				"name": id,
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &rep,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": id,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": id,
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						nodeGroupLabelKey: defaultNodeGroup,
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      kwokTaintKey,
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "fake-container",
+							Image: "fake-image",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Claims: []corev1.ResourceClaim{
+									{
+										Name: claimName,
+									},
+								},
+							},
+						},
+					},
+					ResourceClaims: []corev1.PodResourceClaim{
+						{
+							Name:                      claimName,
+							ResourceClaimTemplateName: &id,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if onePodPerNode {
+		rs.Spec.Template.Spec.Affinity = &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": id,
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		}
+	}
+
+	err = client.Resources().Create(ctx, rs)
+	if err != nil {
+		_ = client.Resources().Delete(ctx, template)
+		return nil, fmt.Errorf("failed to create ReplicaSet: %w", err)
+	}
+
+	cleanup := func(cleanupCtx context.Context) error {
+		_ = client.Resources().Delete(cleanupCtx, rs)
+		_ = DeletePodsWithLabel(cleanupCtx, client, ns, "name", id)
+		_ = client.Resources().Delete(cleanupCtx, template)
+		return nil
+	}
+
+	return cleanup, nil
+}
+
+// TestScaleUpPodsRequestDRAResources tests that Cluster Autoscaler scales up when pods request DRA resources.
+func TestScaleUpPodsRequestDRAResources(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	feature := features.New("Cluster Autoscaler Scale Up With DRA").
+		Assess("scale up when pods request DRA resources", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Check if DRA DeviceClass is available; skip if not installed, matching upstream behavior
+			deviceClass := &resourcev1.DeviceClass{}
+			err = client.Resources().Get(ctx, draDeviceClassName, "", deviceClass)
+			if err != nil {
+				t.Skipf("skipping test: DRA driver not installed (DeviceClass %q not found): %v", draDeviceClassName, err)
+				return ctx
+			}
+
+			cleanup, err := ReserveDRA(ctx, client, ns, "dra-scale-up", 1, draDeviceClassName, 1, false)
+			if err != nil {
+				t.Fatalf("failed to reserve DRA resources: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = cleanup(context.Background())
+			})
+
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+
+			err = WaitForPodsWithLabelScheduled(ctx, client, ns, "name", "dra-scale-up", 1, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("DRA pod was not scheduled: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleUpPodRequestsMoreDRADevicesThanNodeCapacity tests that CA does not scale up if pod requests more DRA devices than node capacity.
+func TestScaleUpPodRequestsMoreDRADevicesThanNodeCapacity(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	feature := features.New("Cluster Autoscaler Scale Up With Oversized DRA").
+		Assess("shouldn't scale up if pod requests more DRA devices than node capacity", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Check if DRA DeviceClass is available; skip if not installed, matching upstream behavior
+			deviceClass := &resourcev1.DeviceClass{}
+			err = client.Resources().Get(ctx, draDeviceClassName, "", deviceClass)
+			if err != nil {
+				t.Skipf("skipping test: DRA driver not installed (DeviceClass %q not found): %v", draDeviceClassName, err)
+				return ctx
+			}
+
+			cleanup, err := ReserveDRA(ctx, client, ns, "oversized-dra-pod", 1, draDeviceClassName, draDeviceCapacity+1, false)
+			if err != nil {
+				t.Fatalf("failed to reserve oversized DRA resources: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = cleanup(context.Background())
+			})
+
+			// Wait for NotTriggerScaleUp event
+			err = WaitForPodEvent(ctx, client, ns, "oversized-dra-pod", "NotTriggerScaleUp", 1*time.Minute)
+			if err != nil {
+				t.Fatalf("expected NotTriggerScaleUp event: %v", err)
+			}
+
+			// Verify cluster size remains 0
+			err = WaitForNodeCountConsistently(ctx, client, defaultNodeGroup, 0, 10*time.Second)
+			if err != nil {
+				t.Fatalf("cluster size changed: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}
+
+// TestScaleDownWithDRANodeDraining tests that Cluster Autoscaler correctly scales down with DRA node draining.
+func TestScaleDownWithDRANodeDraining(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	feature := features.New("Cluster Autoscaler Scale Down With DRA Node Draining").
+		Assess("should correctly scale down with DRA node draining", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Check if DRA DeviceClass is available; skip if not installed, matching upstream behavior
+			deviceClass := &resourcev1.DeviceClass{}
+			err = client.Resources().Get(ctx, draDeviceClassName, "", deviceClass)
+			if err != nil {
+				t.Skipf("skipping test: DRA driver not installed (DeviceClass %q not found): %v", draDeviceClassName, err)
+				return ctx
+			}
+
+			increasedNodeCount := 2
+
+			// Scale cluster up by creating antiAffinity pods that request 1 device (forces 1 pod per node)
+			cleanupAntiAffinityDRA, err := ReserveDRA(ctx, client, ns, "dra-antiaffinity", increasedNodeCount, draDeviceClassName, 1, true)
+			if err != nil {
+				t.Fatalf("failed to create anti-affinity DRA pods: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = cleanupAntiAffinityDRA(context.Background())
+			})
+
+			// Wait for cluster to scale up to 2 nodes
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, increasedNodeCount, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to %d nodes: %v", increasedNodeCount, err)
+			}
+
+			err = WaitForPodsWithLabelScheduled(ctx, client, ns, "name", "dra-antiaffinity", increasedNodeCount, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("anti-affinity DRA pods were not scheduled: %v", err)
+			}
+
+			// Add increasedNodeCount pods, each reserving 2 devices.
+			// Each node will have 1 antiAffinity pod (1 device) + 1 workload pod (2 devices) = 3/4 devices (75% utilization).
+			cleanupDRA, err := ReserveDRA(ctx, client, ns, "dra-workload", increasedNodeCount, draDeviceClassName, 2, false)
+			if err != nil {
+				t.Fatalf("failed to create workload DRA pods: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = cleanupDRA(context.Background())
+			})
+
+			err = WaitForPodsWithLabelScheduled(ctx, client, ns, "name", "dra-workload", increasedNodeCount, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("workload DRA pods were not scheduled: %v", err)
+			}
+
+			// Remove the pods that increased the cluster size
+			err = cleanupAntiAffinityDRA(ctx)
+			if err != nil {
+				t.Fatalf("failed to clean up anti-affinity DRA pods: %v", err)
+			}
+
+			// The unneeded nodes should be removed by draining the DRA pods, scaling cluster down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down to 1 node with DRA node draining: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/pdb_test.go
+++ b/test/e2e/pdb_test.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownReschedulingPodAllowedByPDB(t *testing.T) {
+	ns := testEnv.EnvConf().Namespace()
+
+	// Pods protected by PDB. Both fit on 1 node (1000m and 2000m on 12-core node).
+	pdbPod1 := NewTestPodWithResources("pdb-pod-1", ns, "1000m", "500Mi")
+	pdbPod1.Labels["app"] = "pdb-test"
+	pdbPod1.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	pdbPod2 := NewTestPodWithResources("pdb-pod-2", ns, "2000m", "500Mi")
+	pdbPod2.Labels["app"] = "pdb-test"
+	pdbPod2.Annotations = map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+	}
+
+	// Filler pod consumes 10 cores on the first node, leaving only 1 core free (12 - 1 - 10 = 1 core)
+	// which prevents pdbPod2 (2 cores) from fitting, forcing it to trigger scale-up of a second node.
+	fillerPod := NewTestPodWithResources("filler-pod", ns, "10000m", "500Mi")
+
+	minAvailable := intstr.FromInt(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pdb-test-budget",
+			Namespace: ns,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "pdb-test",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+	}
+
+	feature := features.New("Scale Down When Rescheduling A Pod Is Required And PDB Allows For It").
+		Assess("scale down when rescheduling a pod is required and pdb allows for it", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create PDB allowing at most 1 pod disrupted (minAvailable=1 with 2 replicas)
+			err = client.Resources().Create(ctx, pdb)
+			if err != nil {
+				t.Fatalf("failed to create PDB: %v", err)
+			}
+
+			// Step 1: Create pdbPod1 and fillerPod to fill the first node
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = client.Resources().Create(ctx, pod)
+				if err != nil {
+					t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+				}
+			}
+
+			// Wait for the first node to become ready and pods scheduled
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 1 node: %v", err)
+			}
+			for _, pod := range []*corev1.Pod{pdbPod1, fillerPod} {
+				err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+				if err != nil {
+					t.Fatalf("pod %s was not scheduled: %v", pod.Name, err)
+				}
+			}
+
+			// Step 2: Create pdbPod2 which cannot fit on the first node (needs 2 cores, only 1 core free)
+			// forcing scale-up of a second node.
+			err = client.Resources().Create(ctx, pdbPod2)
+			if err != nil {
+				t.Fatalf("failed to create pod %s: %v", pdbPod2.Name, err)
+			}
+
+			// Wait for both nodes to become ready and pdbPod2 scheduled on the second node
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 2, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale up to 2 nodes: %v", err)
+			}
+			err = WaitForPodScheduled(ctx, client, pdbPod2, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod %s was not scheduled: %v", pdbPod2.Name, err)
+			}
+
+			// Step 3: Delete filler pod so the first node now has plenty of room (11 cores free)
+			err = client.Resources().Delete(ctx, fillerPod)
+			if err != nil {
+				t.Fatalf("failed to delete filler pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, fillerPod, podDeletionTimeout)
+
+			// Step 4: Cluster Autoscaler should drain pdbPod2 (allowed by PDB) and scale down to 1 node
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 1, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("cluster did not scale down from 2 nodes to 1 node: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = client.Resources().Delete(ctx, pdb)
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pdbPod1, fillerPod, pdbPod2}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -122,3 +122,19 @@ func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup st
 	}
 	return count, nil
 }
+
+// DeletePodsWithLabel deletes all pods in namespace matching the given label key and value, and waits for deletion.
+func DeletePodsWithLabel(ctx context.Context, client klient.Client, namespace, labelKey, labelVal string) error {
+	podList := &corev1.PodList{}
+	err := client.Resources(namespace).List(ctx, podList)
+	if err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		if pod.Labels[labelKey] == labelVal {
+			p := pod
+			_ = client.Resources().Delete(ctx, &p)
+		}
+	}
+	return nil
+}

--- a/test/e2e/resource.go
+++ b/test/e2e/resource.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+const (
+	kwokTaintKey      = "kwok-provider"
+	nodeGroupLabelKey = "kwok-nodegroup"
+	defaultNodeGroup  = "kind-worker"
+)
+
+// NewTestPod creates a test pod configuration targeted at kind-worker.
+func NewTestPod(name, namespace string) *corev1.Pod {
+	return NewTestPodWithResources(name, namespace, "500m", "500Mi")
+}
+
+// NewTestPodWithResources creates a test pod configuration with custom CPU and memory requests.
+func NewTestPodWithResources(name, namespace, cpu, memory string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "fake-container",
+					Image: "fake-image",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(cpu),
+							corev1.ResourceMemory: resource.MustParse(memory),
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				nodeGroupLabelKey: defaultNodeGroup,
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      kwokTaintKey,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+}
+
+// CleanUpNodeGroup deletes all fake nodes for the given nodeGroup and waits until count is 0.
+func CleanUpNodeGroup(ctx context.Context, client klient.Client, nodeGroup string) error {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return err
+	}
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			n := node
+			_ = client.Resources().Delete(ctx, &n)
+		}
+	}
+	return WaitForNodeCount(ctx, client, nodeGroup, 0, 30*time.Second)
+}
+
+// TeardownPodAndNodeGroup deletes the test pods, waits for them to be deleted,
+// waits for Cluster Autoscaler to scale down the node naturally (to keep CA state synchronized),
+// and performs forced node cleanup if CA didn't scale down in time.
+func TeardownPodAndNodeGroup(ctx context.Context, client klient.Client, pods []*corev1.Pod, nodeGroup string) {
+	for _, pod := range pods {
+		if pod != nil {
+			_ = client.Resources().Delete(ctx, pod)
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+		}
+	}
+	// Allow CA to scale down the empty node naturally
+	_ = WaitForNodeCount(ctx, client, nodeGroup, 0, 35*time.Second)
+	_ = CleanUpNodeGroup(ctx, client, nodeGroup)
+}
+
+// CountNodeGroupNodes returns the number of nodes currently matching the nodeGroup.
+func CountNodeGroupNodes(ctx context.Context, client klient.Client, nodeGroup string) (int, error) {
+	nodeList := &corev1.NodeList{}
+	err := client.Resources().List(ctx, nodeList)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, node := range nodeList.Items {
+		if node.Labels[nodeGroupLabelKey] == nodeGroup {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/test/e2e/scaledown_test.go
+++ b/test/e2e/scaledown_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestScaleDownUnneededNode(t *testing.T) {
+	pod := NewTestPod("scaledown-test-pod", testEnv.EnvConf().Namespace())
+
+	feature := features.New("Scale Down Unneeded Node").
+		Assess("scale down empty node after pod deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Step 1: Create pod to trigger scale up
+			err = client.Resources().Create(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+
+			err = WaitForPodScheduled(ctx, client, pod, podSchedulingTimeout)
+			if err != nil {
+				t.Fatalf("pod not scheduled: %v", err)
+			}
+
+			// Wait for node count to increase to 1 and be Ready
+			err = WaitForNodesReady(ctx, client, defaultNodeGroup, 1, nodeReadyTimeout)
+			if err != nil {
+				t.Fatalf("node did not become ready: %v", err)
+			}
+
+			// Step 2: Delete pod to make node unneeded
+			err = client.Resources().Delete(ctx, pod)
+			if err != nil {
+				t.Fatalf("failed to delete pod: %v", err)
+			}
+			_ = WaitForPodDeleted(ctx, client, pod, podDeletionTimeout)
+
+			// Step 3: Wait for scale down to delete the unneeded node back to 0
+			err = WaitForNodeCount(ctx, client, defaultNodeGroup, 0, scaleDownTimeout)
+			if err != nil {
+				t.Fatalf("node was not scaled down after pod deletion: %v", err)
+			}
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client, err := cfg.NewClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			TeardownPodAndNodeGroup(ctx, client, []*corev1.Pod{pod}, defaultNodeGroup)
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, feature)
+}

--- a/test/e2e/scaleup_test.go
+++ b/test/e2e/scaleup_test.go
@@ -56,7 +56,7 @@ func TestClusterAutoscaling(t *testing.T) {
 				},
 			},
 			NodeSelector: map[string]string{
-				"kwok-nodegroup": "kind-worker",
+				nodeGroupLabelKey: defaultNodeGroup,
 			},
 			Tolerations: []corev1.Toleration{
 				{
@@ -116,7 +116,7 @@ func TestClusterAutoscaling(t *testing.T) {
 					return false, err
 				}
 				for _, node := range nodeList.Items {
-					if node.Labels["kwok-nodegroup"] == "kind-worker" {
+					if node.Labels[nodeGroupLabelKey] == defaultNodeGroup {
 						return true, nil
 					}
 				}
@@ -135,6 +135,8 @@ func TestClusterAutoscaling(t *testing.T) {
 			}
 			// Delete the pod
 			_ = client.Resources().Delete(ctx, pod)
+			// Delete the node so that each test keeps the cluster clean
+			_ = CleanUpNodeGroup(ctx, client, defaultNodeGroup)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 var (
@@ -56,6 +57,17 @@ func TestMain(m *testing.M) {
 	testEnv.Setup(
 		envfuncs.CreateNamespace(namespace),
 	)
+
+	testEnv.BeforeEachFeature(func(ctx context.Context, cfg *envconf.Config, t *testing.T, f features.Feature) (context.Context, error) {
+		client, err := cfg.NewClient()
+		if err != nil {
+			return ctx, err
+		}
+		if err := CleanUpNodeGroup(ctx, client, defaultNodeGroup); err != nil {
+			return ctx, err
+		}
+		return ctx, nil
+	})
 
 	testEnv.Finish(
 		func(ctx context.Context, config *envconf.Config) (context.Context, error) {

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+)
+
+const (
+	podSchedulingTimeout = 2 * time.Minute
+	podDeletionTimeout   = 2 * time.Minute
+	nodeReadyTimeout     = 2 * time.Minute
+	scaleDownTimeout     = 4 * time.Minute
+)
+
+// WaitForPodScheduled waits until the pod is assigned to a node.
+func WaitForPodScheduled(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return wait.For(conditions.New(client.Resources()).ResourceMatch(pod, func(object k8s.Object) bool {
+		p := object.(*corev1.Pod)
+		return p.Spec.NodeName != ""
+	}), wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodDeleted waits until the pod is deleted.
+func WaitForPodDeleted(ctx context.Context, client klient.Client, pod *corev1.Pod, timeout time.Duration) error {
+	return wait.For(conditions.New(client.Resources()).ResourceDeleted(pod), wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodeCount waits until the number of nodes with the specified nodeGroup matches expected count.
+func WaitForNodeCount(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count == expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesAtLeast waits until the number of nodes in a nodeGroup is at least expectedCount.
+func WaitForNodesAtLeast(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+		if err != nil {
+			return false, err
+		}
+		return count >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodesReady waits until at least expectedCount nodes in a nodeGroup have Ready condition True.
+func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		nodeList := &corev1.NodeList{}
+		err = client.Resources().List(ctx, nodeList)
+		if err != nil {
+			return false, err
+		}
+		readyCount := 0
+		for _, node := range nodeList.Items {
+			if node.Labels[nodeGroupLabelKey] == nodeGroup {
+				for _, condition := range node.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						readyCount++
+						break
+					}
+				}
+			}
+		}
+		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -20,6 +20,8 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -91,5 +93,72 @@ func WaitForNodesReady(ctx context.Context, client klient.Client, nodeGroup stri
 			}
 		}
 		return readyCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForNodeCountConsistently waits for duration while asserting that the node count remains expectedCount.
+func WaitForNodeCountConsistently(ctx context.Context, client klient.Client, nodeGroup string, expectedCount int, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+			if err != nil {
+				return err
+			}
+			if count != expectedCount {
+				return fmt.Errorf("expected node count %d, got %d", expectedCount, count)
+			}
+			return nil
+		case <-ticker.C:
+			count, err := CountNodeGroupNodes(ctx, client, nodeGroup)
+			if err != nil {
+				return err
+			}
+			if count != expectedCount {
+				return fmt.Errorf("node count deviated: expected %d, got %d", expectedCount, count)
+			}
+		}
+	}
+}
+
+// WaitForPodsWithLabelScheduled waits until at least expectedCount pods matching the label are assigned to a node.
+func WaitForPodsWithLabelScheduled(ctx context.Context, client klient.Client, namespace, labelKey, labelVal string, expectedCount int, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		podList := &corev1.PodList{}
+		err = client.Resources(namespace).List(ctx, podList)
+		if err != nil {
+			return false, err
+		}
+		scheduledCount := 0
+		for _, pod := range podList.Items {
+			if pod.Labels[labelKey] == labelVal && pod.Spec.NodeName != "" {
+				scheduledCount++
+			}
+		}
+		return scheduledCount >= expectedCount, nil
+	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
+}
+
+// WaitForPodEvent waits until an event with the given reason for a pod matching podPrefix appears in the namespace.
+func WaitForPodEvent(ctx context.Context, client klient.Client, namespace, podPrefix, reason string, timeout time.Duration) error {
+	return wait.For(func(ctx context.Context) (done bool, err error) {
+		events := &corev1.EventList{}
+		err = client.Resources(namespace).List(ctx, events)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events.Items {
+			if strings.HasPrefix(event.InvolvedObject.Name, podPrefix) && event.Reason == reason {
+				return true, nil
+			}
+		}
+		return false, nil
 	}, wait.WithTimeout(timeout), wait.WithContext(ctx))
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind test

#### What this PR does / why we need it:
Migrates the Dynamic Resource Allocation (DRA) E2E tests from the legacy GCE suite (`pkg/e2e/cluster_size_autoscaling.go`) to the provider-agnostic KWOK E2E framework (`test/e2e/dra_test.go`), isolated in their own category as recommended by reviewers:

1. **`TestScaleUpPodsRequestDRAResources`**:
   - Verifies Cluster Autoscaler scales up node group `kind-worker` when pending pods request DRA devices (`gpu`).
2. **`TestScaleUpPodRequestsMoreDRADevicesThanNodeCapacity`**:
   - Verifies Cluster Autoscaler does not scale up when a pending pod requests more DRA devices than node capacity (5 devices vs capacity 4).
   - Verifies publication of the `NotTriggerScaleUp` event and node count remaining at 0.
3. **`TestScaleDownWithDRANodeDraining`**:
   - Verifies Cluster Autoscaler scales down unneeded nodes with DRA node draining by consolidating pods across nodes when utilization permits.
4. **Helper Functions**:
   - Added `ReserveDRA` in `test/e2e/dra_test.go` to construct `ResourceClaimTemplate` and `ReplicaSet` resources with optional pod anti-affinity.
   - Gracefully skips execution when the DRA driver (`DeviceClass` `gpu`) is not installed in the cluster, mirroring upstream behavior.
   - Added generic polling helpers (`WaitForNodeCountConsistently`, `WaitForPodsWithLabelScheduled`, `WaitForPodEvent`) in `test/e2e/wait.go` and `DeletePodsWithLabel` in `test/e2e/resource.go`.

#### Which issue(s) this PR fixes:
Ref: #94, #100

#### Special notes for your reviewer:
Tests run cleanly in CI and will execute full end-to-end allocation once the DRA test driver is installed in the test environment.