### PR TITLE
Do not propagate NodeGroupForNode error in quota tracker

### DIFF
--- a/pkg/resourcequotas/usage.go
+++ b/pkg/resourcequotas/usage.go
@@ -18,9 +18,9 @@ package resourcequotas
 
 import (
 	gocontext "context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-autoscaler/pkg/context"
 )
 
@@ -66,6 +66,7 @@ func newUsageCalculator(nodeFilter NodeFilter, nodeCache *nodeResourcesCache) *u
 // calculateUsages calculates resources used by nodes for every quota.
 // Returns a map with quota ID as a key and resources used in the corresponding quota as a value.
 func (u *usageCalculator) calculateUsages(ctx gocontext.Context, autoscalingCtx *context.AutoscalingContext, nodes []*corev1.Node, quotas []Quota) (map[string]resourceList, error) {
+	logger := klog.FromContext(ctx)
 	usages := make(map[string]resourceList)
 	for _, rl := range quotas {
 		usages[rl.ID()] = make(resourceList)
@@ -78,7 +79,7 @@ func (u *usageCalculator) calculateUsages(ctx gocontext.Context, autoscalingCtx 
 
 		ng, err := autoscalingCtx.CloudProvider.NodeGroupForNode(ctx, node)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get node group for node %q: %w", node.Name, err)
+			logger.Error(err, "calculateUsages: failed to get node group for node, falling back to node capacity", "node", klog.KObj(node))
 		}
 		delta, err := u.nodeCache.totalNodeResources(ctx, autoscalingCtx, node, ng)
 		if err != nil {


### PR DESCRIPTION
Current logic causes issue in some cloud providers, in which NodeGroupForNode can return error when called with a template node. The template node should contain all the resources already present in the capacity

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Current logic causes issue in some cloud providers (e.g. GCE), in which NodeGroupForNode can return error when called with a template node. In this case, the error is propagated up to the scale up orchestrator, which causes the scale up to fail. The template node should contain all the resources already present in the capacity, so the usage calculation logic should work just fine when called with nil NodeGroup

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #56 
Fixes https://github.com/kubernetes/autoscaler/issues/10140

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed quota tracker blocking the scale up when NodeGroupForNode returns an error
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
