### PR TITLE
DRA provider: deep copy claims from the lister before snapshotting

### DIFF
--- a/pkg/simulator/dynamicresources/provider/provider.go
+++ b/pkg/simulator/dynamicresources/provider/provider.go
@@ -55,7 +55,10 @@ func (p *Provider) Snapshot() (*drasnapshot.Snapshot, error) {
 	}
 	claimMap := make(map[drasnapshot.ResourceClaimId]*resourceapi.ResourceClaim)
 	for _, claim := range claims {
-		claimMap[drasnapshot.GetClaimId(claim)] = claim
+		// The lister returns objects shared with the informer cache, which are meant to be
+		// read-only. The snapshot's base layer can be mutated in place before the first Fork(),
+		// so it needs to own its own copies rather than the informer's.
+		claimMap[drasnapshot.GetClaimId(claim)] = claim.DeepCopy()
 	}
 
 	slices, err := p.resourceSlices.ListAll()

--- a/pkg/simulator/dynamicresources/provider/provider_test.go
+++ b/pkg/simulator/dynamicresources/provider/provider_test.go
@@ -144,6 +144,33 @@ func TestProviderSnapshot(t *testing.T) {
 	}
 }
 
+// TestProviderSnapshotDoesNotMutateListerObjects verifies that mutating a Snapshot returned by Provider.Snapshot()
+// (before any Fork()) doesn't mutate the ResourceClaim objects returned by the lister, which are shared with the
+// informer cache and are meant to be read-only.
+func TestProviderSnapshotDoesNotMutateListerObjects(t *testing.T) {
+	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim-1", Namespace: "default", UID: "claim-1"}}
+	origClaim := claim.DeepCopy()
+	pod := test.BuildTestPod("pod1", 1, 1, test.WithResourceClaim("a", "claim-1", ""))
+
+	claimLister := &fakeLister[*resourceapi.ResourceClaim]{objects: []*resourceapi.ResourceClaim{claim}}
+	sliceLister := &fakeLister[*resourceapi.ResourceSlice]{}
+	classLister := &fakeLister[*resourceapi.DeviceClass]{}
+	provider := NewProvider(claimLister, sliceLister, classLister)
+
+	snapshot, err := provider.Snapshot()
+	if err != nil {
+		t.Fatalf("Provider.Snapshot(): unexpected error: %v", err)
+	}
+
+	if err := snapshot.ReservePodClaims(pod); err != nil {
+		t.Fatalf("Snapshot.ReservePodClaims(): unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(origClaim, claim); diff != "" {
+		t.Errorf("lister-returned claim was mutated by Snapshot.ReservePodClaims() on an unforked snapshot (-want +got): %s", diff)
+	}
+}
+
 // TestNewProviderFromInformers verifies that the interface translation listers created in NewProviderFromInformers correctly return
 // all objects in the cluster.
 func TestNewProviderFromInformers(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The DRA provider's `Snapshot()` stored resource claims returned directly from the lister into the snapshot's claim map, without copying them. Lister objects are shared with the informer cache and are meant to be treated as read only, but the snapshot's base layer can be mutated in place before the first `Fork()`. Storing the lister's own objects means a mutation of the snapshot claim also mutates the informer cache's copy, which every other consumer of that cache sees too. This copies each claim with `DeepCopy()` before storing it, so the snapshot owns independent objects. Added `TestProviderSnapshotDoesNotMutateListerObjects` to cover the regression directly: it mutates a claim obtained from the snapshot and asserts the object still sitting in the fake lister is unchanged.

#### Which issue(s) this PR fixes:
Fixes #37

#### Special notes for your reviewer:

Found by reading the snapshot construction path, not from an existing issue.

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where the DRA snapshot could mutate resource claims still shared with the informer cache.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

