### PR TITLE
DRA snapshot: fix claim mutation leak when a Pod aliases a claim twice

### DIFF
--- a/pkg/simulator/dynamicresources/snapshot/snapshot.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot.go
@@ -355,7 +355,13 @@ func (s *Snapshot) findPodClaims(pod *apiv1.Pod, ignoreNotTracked bool) ([]*reso
 func (s *Snapshot) ensureClaimWritable(claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
 	claimId := GetClaimId(claim)
 	if s.resourceClaims.InCurrentPatch(claimId) {
-		return claim
+		// A Pod can reference the same claim through more than one alias, in which case
+		// the caller's claim may still be the base layer's pointer even though this claim
+		// id already has a copy in the current patch from an earlier alias. Fetch that
+		// copy instead of trusting the caller, or an in-place mutation would land on the
+		// base object and survive a Revert.
+		current, _ := s.resourceClaims.FindValue(claimId)
+		return current
 	}
 
 	return claim.DeepCopy()

--- a/pkg/simulator/dynamicresources/snapshot/snapshot_test.go
+++ b/pkg/simulator/dynamicresources/snapshot/snapshot_test.go
@@ -722,3 +722,30 @@ func TestSnapshotForkCommitRevert(t *testing.T) {
 		compareSnapshots(t, expectedState, snapshot, "After Fork, Modify, Revert, Fork, Modify")
 	})
 }
+
+func TestReservePodClaimsAliasRevert(t *testing.T) {
+	sharedClaim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "shared", UID: "shared", Namespace: "default"}}
+	pod := test.BuildTestPod("aliaspod", 1, 1,
+		test.WithResourceClaim("aliasA", "shared", ""),
+		test.WithResourceClaim("aliasB", "shared", ""),
+	)
+	pod.Namespace = "default"
+
+	snapshot := NewSnapshot(map[ResourceClaimId]*resourceapi.ResourceClaim{GetClaimId(sharedClaim): sharedClaim.DeepCopy()}, nil, nil, nil)
+
+	snapshot.Fork()
+	if err := snapshot.ReservePodClaims(pod); err != nil {
+		t.Fatalf("ReservePodClaims failed: %v", err)
+	}
+	snapshot.Revert()
+
+	allClaims, err := snapshot.ResourceClaims().List()
+	if err != nil {
+		t.Fatalf("ResourceClaims().List(): unexpected error: %v", err)
+	}
+	for _, claim := range allClaims {
+		if claim.Name == sharedClaim.Name && len(claim.Status.ReservedFor) != 0 {
+			t.Errorf("a claim referenced by a Pod through two aliases leaked %d reservation(s) into the base layer after Revert", len(claim.Status.ReservedFor))
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ensureClaimWritable` trusted the caller's own pointer once a claim id was already in the current patch, but `findPodClaims` can return the same base pointer more than once when a Pod references one claim through two aliases (`spec.resourceClaims` entries with different `name` but the same `resourceClaimName`, which the Pod API allows). The second alias then mutated the base object in place instead of the copy the first alias had already made, and `Revert` cannot undo a mutation to the base layer. `ReservePodClaims`, `UnreservePodClaims`, and the shared-claim branch of `RemovePodOwnedClaims` all share this shape. Fetches the current patched value from the patch set instead of trusting the caller when the claim id is already patched.

Added `TestReservePodClaimsAliasRevert`, confirmed it fails against the unfixed code with the exact symptom described (a leaked reservation surviving Revert) and passes with the fix.

#### Which issue(s) this PR fixes:
Fixes #33

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where reserving a Pod's resource claims could leave a leaked reservation behind after a failed scheduling attempt was reverted, when the Pod referenced the same claim through two aliases.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

