### PR TITLE
Fail closed when balanced scale-up cannot evaluate quota

### DIFF
--- a/pkg/core/scaleup/orchestrator/orchestrator.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator.go
@@ -721,12 +721,13 @@ func (o *ScaleUpOrchestrator) balanceScaleUps(
 	if aErr != nil {
 		return nil, aErr
 	}
-	return o.capScaleUpsByQuota(ctx, scaleUpInfos, nodeInfos, tracker), nil
+	return o.capScaleUpsByQuota(ctx, scaleUpInfos, nodeInfos, tracker)
 }
 
 // capScaleUpsByQuota caps each group's scale-up delta by its available quota and filters
 // out groups capped to zero. Uses ConsumeQuota to commit consumed quota so subsequent groups
-// sharing the same quota see the updated limits.
+// sharing the same quota see the updated limits. A quota that cannot be evaluated is an error
+// rather than an unlimited group, as it already is in applyLimits.
 // Note: unclaimed capacity from a capped group is not redistributed to other groups;
 // a group capped below its balanced delta may leave some pods unschedulable until the
 // next autoscaler cycle.
@@ -735,7 +736,7 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 	scaleUpInfos []nodegroupset.ScaleUpInfo,
 	nodeInfos map[string]*framework.NodeInfo,
 	tracker *resourcequotas.Tracker,
-) []nodegroupset.ScaleUpInfo {
+) ([]nodegroupset.ScaleUpInfo, errors.AutoscalerError) {
 	logger := klog.FromContext(ctx)
 	for i := range scaleUpInfos {
 		sui := &scaleUpInfos[i]
@@ -745,12 +746,11 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 		}
 		nodeInfo, found := nodeInfos[sui.Group.Id()]
 		if !found {
-			continue
+			return nil, errors.NewAutoscalerErrorf(errors.CloudProviderError, "no node info for balanced node group %s", sui.Group.Id())
 		}
 		checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, sui.Group, nodeInfo.Node(), delta)
 		if err != nil {
-			logger.Error(err, "Failed to check quota for balanced group", "nodeGroupId", sui.Group.Id())
-			continue
+			return nil, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to check resource quotas for node group %s: ", sui.Group.Id())
 		}
 		allowedDelta := checkResult.AllowedDelta
 		if allowedDelta < delta {
@@ -758,8 +758,9 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 			sui.NewSize = sui.CurrentSize + allowedDelta
 		}
 		if allowedDelta > 0 {
+			// Leaving the quota unreserved would let the groups after this one read stale headroom.
 			if _, err := tracker.ConsumeQuota(ctx, o.autoscalingCtx, sui.Group, nodeInfo.Node(), allowedDelta); err != nil {
-				logger.Error(err, "Failed to apply quota delta for balanced group", "nodeGroupId", sui.Group.Id())
+				return nil, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to reserve resource quota for node group %s: ", sui.Group.Id())
 			}
 		}
 	}
@@ -771,7 +772,7 @@ func (o *ScaleUpOrchestrator) capScaleUpsByQuota(
 			filtered = append(filtered, sui)
 		}
 	}
-	return filtered
+	return filtered, nil
 }
 
 // ComputeSimilarNodeGroups finds similar node groups which can schedule the same

--- a/pkg/core/scaleup/orchestrator/orchestrator_test.go
+++ b/pkg/core/scaleup/orchestrator/orchestrator_test.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/metrics"
 	"sigs.k8s.io/cluster-autoscaler/pkg/observers/nodegroupchange"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors"
+	"sigs.k8s.io/cluster-autoscaler/pkg/processors/customresources"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroupconfig"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroups/asyncnodegroups"
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/nodegroupset"
@@ -57,6 +58,8 @@ import (
 	"sigs.k8s.io/cluster-autoscaler/pkg/processors/status"
 	processorstest "sigs.k8s.io/cluster-autoscaler/pkg/processors/test"
 	"sigs.k8s.io/cluster-autoscaler/pkg/resourcequotas"
+	csisnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/csi/snapshot"
+	drasnapshot "sigs.k8s.io/cluster-autoscaler/pkg/simulator/dynamicresources/snapshot"
 	"sigs.k8s.io/cluster-autoscaler/pkg/simulator/framework"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/errors"
 	kube_util "sigs.k8s.io/cluster-autoscaler/pkg/utils/kubernetes"
@@ -2662,4 +2665,163 @@ func (m *mockMetrics) RegisterFailedNodeCreations(reason metrics.FailedScaleUpRe
 
 func (m *mockMetrics) RegisterScaleUp(nodesCount int, gpuResourceName string, gpuType string, draDriverNames string) {
 	m.Called(nodesCount, gpuResourceName, gpuType, draDriverNames)
+}
+
+// failingCustomResourcesProcessor makes the quota tracker's node resource lookup fail for one node
+// group, which is the only way CheckQuota can return an error. The tracker caches the lookup per
+// node group, so only a group with no nodes yet reaches it during a scale-up.
+type failingCustomResourcesProcessor struct {
+	failFor string
+	err     errors.AutoscalerError
+}
+
+func (p *failingCustomResourcesProcessor) FilterOutNodesWithUnreadyResources(_ gocontext.Context, _ *ca_context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node, _ *drasnapshot.Snapshot, _ *csisnapshot.Snapshot) ([]*apiv1.Node, []*apiv1.Node) {
+	return allNodes, readyNodes
+}
+
+func (p *failingCustomResourcesProcessor) GetNodeResourceTargets(_ gocontext.Context, _ *ca_context.AutoscalingContext, _ *apiv1.Node, nodeGroup cloudprovider.NodeGroup) ([]customresources.CustomResourceTarget, errors.AutoscalerError) {
+	if nodeGroup != nil && nodeGroup.Id() == p.failFor {
+		return nil, p.err
+	}
+	return nil, nil
+}
+
+func (p *failingCustomResourcesProcessor) CleanUp() {}
+
+// quotaCapTestEnv is the smallest environment capScaleUpsByQuota needs: node groups with and
+// without nodes, and a tracker built over whichever quotas the case wants.
+type quotaCapTestEnv struct {
+	orchestrator *ScaleUpOrchestrator
+	tracker      *resourcequotas.Tracker
+	nodeInfos    map[string]*framework.NodeInfo
+	groups       map[string]cloudprovider.NodeGroup
+}
+
+func newQuotaCapTestEnv(t *testing.T, quotas []resourcequotas.Quota, crp customresources.CustomResourcesProcessor) *quotaCapTestEnv {
+	t.Helper()
+	ctx := t.Context()
+
+	n1 := BuildTestNode("n1", 1000, 1000)
+	n2 := BuildTestNode("n2", 1000, 1000)
+	now := time.Now()
+	SetNodeReadyState(n1, true, now.Add(-2*time.Minute))
+	SetNodeReadyState(n2, true, now.Add(-2*time.Minute))
+	nodes := []*apiv1.Node{n1, n2}
+
+	provider := testprovider.NewTestCloudProviderBuilder().Build()
+	provider.AddNodeGroup("ng1", 1, 10, 1)
+	provider.AddNodeGroup("ng2", 1, 10, 1)
+	provider.AddNode("ng1", n1)
+	provider.AddNode("ng2", n2)
+	// ng3 has no nodes, so the tracker has nothing cached for it, the way a node group created
+	// during this scale-up would not.
+	provider.AddNodeGroup("ng3", 0, 10, 0)
+
+	listers := kube_util.NewListerRegistry(nil, nil, kube_util.NewTestPodLister(nil), nil, nil, nil, nil, nil, nil)
+	options := config.AutoscalingOptions{
+		EstimatorName:                  estimator.BinpackingEstimatorName,
+		MaxCoresTotal:                  config.DefaultMaxClusterCores,
+		MaxMemoryTotal:                 config.DefaultMaxClusterMemory,
+		MaxNodeGroupBinpackingDuration: time.Second,
+	}
+	processors, templateNodeInfoRegistry := processorstest.NewTestProcessors(options)
+	if crp != nil {
+		processors.CustomResourcesProcessor = crp
+	}
+	autoscalingCtx, err := NewScaleTestAutoscalingContext(options, &fake.Clientset{}, listers, provider, nil, nil, templateNodeInfoRegistry)
+	assert.NoError(t, err)
+	assert.NoError(t, autoscalingCtx.ClusterSnapshot.SetClusterState(ctx, nodes, nil, nil, nil))
+	assert.NoError(t, autoscalingCtx.TemplateNodeInfoRegistry.Recompute(ctx, &autoscalingCtx, nodes, []*appsv1.DaemonSet{}, taints.TaintConfig{}, now))
+
+	trackerFactory := resourcequotas.NewTrackerFactory(resourcequotas.TrackerOptions{
+		QuotaProvider:            resourcequotas.NewFakeProvider(quotas),
+		CustomResourcesProcessor: processors.CustomResourcesProcessor,
+	})
+	tracker, err := trackerFactory.NewMaxQuotasTracker(ctx, &autoscalingCtx, nodes)
+	if err != nil {
+		t.Fatalf("could not build quota tracker: %v", err)
+	}
+
+	orchestrator := New()
+	clusterState := clusterstate.NewClusterStateRegistry(provider, autoscalingCtx.LogRecorder, NewBackoff(), nodegroupconfig.NewDefaultNodeGroupConfigProcessor(options.NodeGroupDefaults), autoscalingCtx.TemplateNodeInfoRegistry)
+	orchestrator.Initialize(&autoscalingCtx, processors, clusterState, newEstimatorBuilder(), taints.TaintConfig{}, trackerFactory)
+
+	nodeInfos := autoscalingCtx.TemplateNodeInfoRegistry.GetNodeInfos()
+	// A node group with no nodes has no template of its own, so it borrows one, which is what
+	// processCreateNodeGroupResult does for a node group created during the scale-up.
+	nodeInfos["ng3"] = nodeInfos["ng2"]
+
+	return &quotaCapTestEnv{
+		orchestrator: orchestrator,
+		tracker:      tracker,
+		nodeInfos:    nodeInfos,
+		groups: map[string]cloudprovider.NodeGroup{
+			"ng1": provider.GetNodeGroup("ng1"),
+			"ng2": provider.GetNodeGroup("ng2"),
+			"ng3": provider.GetNodeGroup("ng3"),
+		},
+	}
+}
+
+func TestCapScaleUpsByQuotaFailsClosed(t *testing.T) {
+	quotaErr := errors.NewAutoscalerError(errors.CloudProviderError, "custom resources unavailable")
+
+	testCases := []struct {
+		name           string
+		crp            customresources.CustomResourcesProcessor
+		dropNodeInfoOf string
+	}{
+		{
+			name: "quota cannot be evaluated",
+			crp:  &failingCustomResourcesProcessor{failFor: "ng3", err: quotaErr},
+		},
+		{
+			name:           "node group has no node info",
+			dropNodeInfoOf: "ng3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newQuotaCapTestEnv(t, nil, tc.crp)
+			if tc.dropNodeInfoOf != "" {
+				delete(env.nodeInfos, tc.dropNodeInfoOf)
+			}
+			scaleUpInfos := []nodegroupset.ScaleUpInfo{
+				{Group: env.groups["ng1"], CurrentSize: 1, NewSize: 3, MaxSize: 10},
+				{Group: env.groups["ng3"], CurrentSize: 0, NewSize: 2, MaxSize: 10},
+			}
+
+			capped, aErr := env.orchestrator.capScaleUpsByQuota(t.Context(), scaleUpInfos, env.nodeInfos, env.tracker)
+
+			assert.Error(t, aErr)
+			assert.Nil(t, capped)
+		})
+	}
+}
+
+func TestCapScaleUpsByQuotaSharedQuota(t *testing.T) {
+	// One quota over both groups: what the first group reserves has to be gone from the second's
+	// headroom, and a group left with nothing has to drop out of the plan.
+	quotas := []resourcequotas.Quota{
+		&resourcequotas.FakeQuota{
+			Name:        "shared",
+			AppliesToFn: resourcequotas.MatchEveryNode,
+			LimitsVal:   map[string]int64{string(apiv1.ResourceCPU): 5},
+		},
+	}
+	env := newQuotaCapTestEnv(t, quotas, nil)
+	scaleUpInfos := []nodegroupset.ScaleUpInfo{
+		{Group: env.groups["ng1"], CurrentSize: 1, NewSize: 4, MaxSize: 10},
+		{Group: env.groups["ng2"], CurrentSize: 1, NewSize: 4, MaxSize: 10},
+	}
+
+	capped, aErr := env.orchestrator.capScaleUpsByQuota(t.Context(), scaleUpInfos, env.nodeInfos, env.tracker)
+
+	assert.NoError(t, aErr)
+	sizes := map[string]int{}
+	for _, sui := range capped {
+		sizes[sui.Group.Id()] = sui.NewSize
+	}
+	assert.Equal(t, map[string]int{"ng1": 4}, sizes)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`capScaleUpsByQuota` swallows three failures: a balanced node group with no node info is skipped silently, and errors from `CheckQuota` and `ConsumeQuota` are logged and left behind. In each case `sui.NewSize` keeps whatever delta the balancer picked, so that group is resized as though no quota applied to it. The `ConsumeQuota` one has a second effect: the quota is never reserved, so the groups after it in the slice read headroom that has already been spent.

A few lines up, `applyLimits` treats the same class of failure as fatal:

```go
checkResult, err := tracker.CheckQuota(ctx, o.autoscalingCtx, nodeGroup, nodeInfo.Node(), newNodes)
if err != nil {
    return 0, errors.ToAutoscalerError(errors.InternalError, err).AddPrefix("failed to check resource quotas: ")
}
```

So the best option stops the scale-up when its quota cannot be read, and the balanced groups scale up unlimited. This PR returns an `AutoscalerError` from `capScaleUpsByQuota` instead. `balanceScaleUps` already returns `([]nodegroupset.ScaleUpInfo, errors.AutoscalerError)` and `prepareScaleUp` already turns that into a failed scale-up status, so nothing reaches the executor and no node group is resized.

This came out of reviewing kubernetes/autoscaler#9830, where @norbertcyran agreed that letting a failed `CheckDelta` read as "not quota limited" is a bug. `capScaleUpsByQuota` is @rrangith's, from the earlier fix that made balanced scale-ups respect quotas; this only changes how it behaves when a quota cannot be evaluated, and does not touch the redistribution that #9830 adds.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

No exported signature changes. `capScaleUpsByQuota` and `balanceScaleUps` are both unexported, so this does not touch `NodeGroupSetProcessor` or anything else forks build against.

How reachable each branch is today, since it changes what the tests can show:

- The `CheckQuota` branch is reachable for a node group created during the scale-up. `applyLimits` runs before the group is created, so it warms `nodeResourcesCache` under the candidate's id, and `processCreateNodeGroupResult` then gives the group a new one. For groups that kept their id through `applyLimits` or the similar-group filter the cache already holds their resources, so `CheckQuota` cannot fail a second time.
- The missing node info branch is defensive. `processCreateNodeGroupResult` sets `nodeInfos[newId]` unconditionally across that same id change, and `balanceScaleUps` drops similar node groups with no node info before they reach here, so nothing in tree gets to it. It is still an error instead of the old `continue`, which left `sui.NewSize` at the balancer's delta and scaled the group as if no quota applied.
- The `ConsumeQuota` branch cannot be reached through the current `Tracker` at all, for that same reason: the cache is warm by the time it runs, and `ErrNegativeDelta` is ruled out by the `allowedDelta > 0` guard above it. I changed it anyway rather than leave one of the three continuing, but that is why it has no test.

The tests cover both of those branches and pin the behaviour that has to survive: `TestCapScaleUpsByQuotaSharedQuota` asserts the exact resulting sizes for two groups under one shared quota, so a regression that drops the reservation shows up as both groups taking the full headroom rather than as a vague failure.

It is separate from #103. `CheckQuota` reaches `GetNodeResourceTargets`, not `NodeGroupForNode`, so the template node error being removed there is a different path and stays benign.

#### Does this PR introduce a user-facing change?

```release-note
Fixed cluster-autoscaler scaling up balanced node groups without a quota check when the quota could not be evaluated.
```

