### PR TITLE
Skip fixNodeGroupSize for ZeroOrMaxNodeScaling node groups

### DIFF
--- a/pkg/cloudprovider/test/fake_cloud_provider.go
+++ b/pkg/cloudprovider/test/fake_cloud_provider.go
@@ -241,6 +241,13 @@ func WithNodeReadinessDelay(delay time.Duration) NodeGroupOption {
 	}
 }
 
+// WithOptions sets the NodeGroupAutoscalingOptions for the node group.
+func WithOptions(opts *config.NodeGroupAutoscalingOptions) NodeGroupOption {
+	return func(n *NodeGroup) {
+		n.opts = opts
+	}
+}
+
 // AddNodeGroup is a helper for tests to add a group with its template.
 func (c *CloudProvider) AddNodeGroup(id string, opts ...NodeGroupOption) *NodeGroup {
 	c.Lock()
@@ -320,6 +327,7 @@ type NodeGroup struct {
 	// nodeReadinessDelay can be used to simulate Node objects taking some time to transition to Ready after they appear in the K8s API. If unset,
 	// the Nodes will appear as Ready immediately after registration.
 	nodeReadinessDelay time.Duration
+	opts               *config.NodeGroupAutoscalingOptions
 }
 
 // MaxSize returns the maximum size of the node group.
@@ -442,7 +450,23 @@ func (n *NodeGroup) Autoprovisioned(ctx context.Context) bool {
 
 // GetOptions returns autoscaling options specific to this node group.
 func (n *NodeGroup) GetOptions(ctx context.Context, defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, nil
+	n.RLock()
+	defer n.RUnlock()
+	return n.opts, nil
+}
+
+// SetOptions sets autoscaling options for this node group.
+func (n *NodeGroup) SetOptions(opts *config.NodeGroupAutoscalingOptions) {
+	n.Lock()
+	defer n.Unlock()
+	n.opts = opts
+}
+
+// SetTargetSize sets target size for group.
+func (n *NodeGroup) SetTargetSize(size int) {
+	n.Lock()
+	defer n.Unlock()
+	n.targetSize = size
 }
 
 // TargetSize returns the current target size of the node group.

--- a/pkg/core/static_autoscaler.go
+++ b/pkg/core/static_autoscaler.go
@@ -990,6 +990,14 @@ func fixNodeGroupSize(ctx context.Context, autoscalingCtx *ca_context.Autoscalin
 			return false, fmt.Errorf("failed to retrieve maxNodeProvisionTime for nodeGroup %s", nodeGroup.Id())
 		}
 		if incorrectSize.FirstObserved.Add(maxNodeProvisionTime).Before(currentTime) {
+			opts, err := nodeGroup.GetOptions(ctx, autoscalingCtx.NodeGroupDefaults)
+			if err != nil && err != cloudprovider.ErrNotImplemented {
+				return false, fmt.Errorf("failed to get options for nodeGroup %s: %v", nodeGroup.Id(), err)
+			}
+			if opts != nil && opts.ZeroOrMaxNodeScaling {
+				logger.V(0).Info("Skipping fixing node group size for ZeroOrMaxNodeScaling node group", "nodeGroupId", nodeGroup.Id())
+				continue
+			}
 			delta := incorrectSize.CurrentSize - incorrectSize.ExpectedSize
 			if delta < 0 {
 				logger.V(0).Info("Decreasing size", "nodeGroupId", nodeGroup.Id(), "targetSize", incorrectSize.ExpectedSize, "size", incorrectSize.CurrentSize, "delta", delta)

--- a/pkg/test/integration/inmemory/staticautoscaler_test.go
+++ b/pkg/test/integration/inmemory/staticautoscaler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider"
 	fakecloudprovider "sigs.k8s.io/cluster-autoscaler/pkg/cloudprovider/test"
+	"sigs.k8s.io/cluster-autoscaler/pkg/config"
 	"sigs.k8s.io/cluster-autoscaler/pkg/test/integration"
 	synctestutils "sigs.k8s.io/cluster-autoscaler/pkg/test/integration/synctest"
 	"sigs.k8s.io/cluster-autoscaler/pkg/utils/test"
@@ -115,5 +116,64 @@ func TestScaleUp_ResourceLimits(t *testing.T) {
 		synctestutils.MustRunOnceAfter(t, autoscaler, unneededTime)
 		newSize, _ := fakes.CloudProvider.GetNodeGroup("ng").TargetSize(context.Background())
 		assert.Equal(t, 2, newSize, "Should scale up after resource limit is increased")
+	})
+}
+
+// TestFixNodeGroupSize_ZeroOrMaxNodeScaling verifies that fixNodeGroupSize skips
+// attempting DecreaseTargetSize on ZeroOrMaxNodeScaling node groups when registered
+// nodes mismatch the target size after MaxNodeProvisionTime.
+func TestFixNodeGroupSize_ZeroOrMaxNodeScaling(t *testing.T) {
+	testConfig := integration.NewTestConfig().
+		WithOverrides(
+			integration.WithCloudProviderName("gce"),
+		)
+
+	options := testConfig.ResolveOptions()
+	infra := integration.SetupInfrastructure(t)
+	fakes := infra.Fakes
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer synctestutils.TearDown(cancel)
+
+		autoscaler, _, err := integration.DefaultAutoscalingBuilder(options, infra).Build(ctx)
+		assert.NoError(t, err)
+
+		nodeGroupOpts := &config.NodeGroupAutoscalingOptions{
+			ZeroOrMaxNodeScaling: true,
+			MaxNodeProvisionTime: 10 * time.Second,
+		}
+
+		templateNode := test.BuildTestNode("atomic-ng-node-0", 2000, 8*1024*1024*1024, test.IsReady(true))
+		ng := fakes.CloudProvider.AddNodeGroup(
+			"atomic-ng",
+			fakecloudprovider.WithNodes(templateNode, 2),
+			fakecloudprovider.WithNGSize(0, 10),
+			fakecloudprovider.WithOptions(nodeGroupOpts),
+		)
+
+		// Add non-empty pods running on each node to prevent scale-down from deleting them.
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-0", 1000, 1000, "atomic-ng-node-0"))
+		fakes.K8s.AddPod(test.BuildScheduledTestPod("pod-1", 1000, 1000, "atomic-ng-node-1"))
+
+		// First cycle: Autoscaler initializes cluster state with the 2 registered nodes.
+		synctestutils.MustRunOnceAfter(t, autoscaler, time.Second)
+
+		// Simulate discrepancy: TargetSize is 4 in cloud provider, but only 2 nodes exist.
+		ng.SetTargetSize(4)
+
+		// Second cycle: Autoscaler observes discrepancy (2 registered nodes vs target 4).
+		synctestutils.MustRunOnceAfter(t, autoscaler, time.Second)
+
+		// Third cycle: Advance time past MaxNodeProvisionTime (10s).
+		// fixNodeGroupSize triggers: for ZeroOrMaxNodeScaling, it skips decreasing target size.
+		// RunOnce succeeds without error.
+		err = synctestutils.RunOnceAfter(t, autoscaler, 15*time.Second)
+		assert.NoError(t, err)
+
+		// Verify target size was not decreased and remained 4.
+		targetSize, err := ng.TargetSize(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 4, targetSize)
 	})
 }


### PR DESCRIPTION


#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
-->

#### What this PR does / why we need it:

fixNodeGroupSize() decreases the cloud provider target size when the registered node count remains smaller than expected target size past MaxNodeProvisionTime.

For atomic node groups (ZeroOrMaxNodeScaling = true) partial resizing is invalid. Calling DecreaseTargetSize() attempts an illegal partial size causing mentioned function to fail and crashing the autoscaler loop with "Failed to fix node group sizes".

This change skips target size adjustments in fixNodeGroupSize() for atomic node groups, relying instead on atomic cleanup mechanisms (e.g. overrideNodesToDeleteForZeroOrMax) to preserve or tear down the group as a whole.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
